### PR TITLE
Exclude ua.privatbank.ap24 from provider installer

### DIFF
--- a/play-services-core/src/main/java/com/google/android/gms/common/security/ProviderInstallerImpl.java
+++ b/play-services-core/src/main/java/com/google/android/gms/common/security/ProviderInstallerImpl.java
@@ -46,7 +46,7 @@ import javax.net.ssl.SSLContext;
 
 public class ProviderInstallerImpl {
     private static final String TAG = "GmsProviderInstaller";
-    private static final List<String> DISABLED = Collections.unmodifiableList(Arrays.asList("com.discord", "com.bankid.bus"));
+    private static final List<String> DISABLED = Collections.unmodifiableList(Arrays.asList("com.discord", "com.bankid.bus", "ua.privatbank.ap24"));
 
     public static void insertProvider(Context context) {
         String packageName = PackageUtils.packageFromProcessId(context, Process.myPid());


### PR DESCRIPTION
This patch fix issue:
```
time: 1603218703396
msg: java.lang.IllegalStateException: Unable to extract the trust manager on okhttp3.d0.h.a@106dae4, sslSocketFactory is class org.conscrypt.OpenSSLSocketFactoryImpl
stacktrace: java.lang.RuntimeException: Unable to start activity ComponentInfo{ua.privatbank.ap24/ua.privatbank.ap24v6.MainActivity}: java.lang.IllegalStateException: Unable to extract the trust manager on okhttp3.d0.h.a@106dae4, sslSocketFactory is class org.conscrypt.OpenSSLSocketFactoryImpl
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3270)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loop(Looper.java:214)
	at android.app.ActivityThread.main(ActivityThread.java:7356)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
Caused by: java.lang.IllegalStateException: Unable to extract the trust manager on okhttp3.d0.h.a@106dae4, sslSocketFactory is class org.conscrypt.OpenSSLSocketFactoryImpl
	at okhttp3.d0.h.f.a(Unknown Source:46)
	at okhttp3.w$b.a(Unknown Source:8)
	at ua.privatbank.core.network.OkhttpNetworkConfiguration.a(Unknown Source:91)
	at ua.privatbank.core.network.OkhttpNetworkConfiguration.a(Unknown Source:22)
	at ua.privatbank.core.network.OkhttpNetworkConfiguration.a(Unknown Source:15)
	at ua.privatbank.ap24v6.repositories.UserInfoRepositoryImpl.e(Unknown Source:39)
	at ua.privatbank.ap24v6.MainViewModel.checkAppVersion(Unknown Source:14)
	at ua.privatbank.ap24v6.MainViewModel.<init>(Unknown Source:119)
	at ua.privatbank.ap24v6.MainViewModel.<init>(Unknown Source:61)
	at ua.privatbank.ap24v6.MainViewModel.<init>(Unknown Source:10)
	at java.lang.Class.newInstance(Native Method)
	at androidx.lifecycle.ViewModelProvider$NewInstanceFactory.create(Unknown Source:2)
	at androidx.lifecycle.ViewModelProvider$AndroidViewModelFactory.create(Unknown Source:123)
	at androidx.lifecycle.ViewModelProvider.get(Unknown Source:26)
	at androidx.lifecycle.ViewModelProvider.get(Unknown Source:23)
	at ua.privatbank.core.base.b.J(Unknown Source:19)
	at ua.privatbank.core.base.b.a(Unknown Source:7)
	at ua.privatbank.core.base.b.onCreate(Unknown Source:3)
	at ua.privatbank.p24core.activity.a.onCreate(Unknown Source:0)
	at ua.privatbank.ap24v6.MainActivity.onCreate(Unknown Source:5)
	at android.app.Activity.performCreate(Activity.java:7824)
	at android.app.Activity.performCreate(Activity.java:7813)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1307)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3245)
	... 11 more
```