### PR TITLE
Add equals() and hashCode() to Status

### DIFF
--- a/play-services-basement/src/main/java/com/google/android/gms/common/api/Status.java
+++ b/play-services-basement/src/main/java/com/google/android/gms/common/api/Status.java
@@ -88,6 +88,21 @@ public final class Status extends AutoSafeParcelable implements Result {
         this.resolution = resolution;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Status)) return false;
+
+        Status that = (Status) o;
+
+        return statusCode == that.statusCode;
+    }
+
+    @Override
+    public int hashCode() {
+        return statusCode;
+    }
+
     /**
      * A pending intent to resolve the failure. This intent can be started with
      * {@link Activity#startIntentSenderForResult(IntentSender, int, Intent, int, int, int)} to

--- a/play-services-nearby/src/main/java/org/microg/gms/nearby/ExposureNotificationClientImpl.java
+++ b/play-services-nearby/src/main/java/org/microg/gms/nearby/ExposureNotificationClientImpl.java
@@ -114,7 +114,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             StartParams params = new StartParams(new IStatusCallback.Stub() {
                 @Override
                 public void onResult(Status status) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(null);
                     } else {
                         completionSource.setException(new ApiException(status));
@@ -135,7 +135,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             StopParams params = new StopParams(new IStatusCallback.Stub() {
                 @Override
                 public void onResult(Status status) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(null);
                     } else {
                         completionSource.setException(new ApiException(status));
@@ -156,7 +156,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             IsEnabledParams params = new IsEnabledParams(new IBooleanCallback.Stub() {
                 @Override
                 public void onResult(Status status, boolean result) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(result);
                     } else {
                         completionSource.setException(new ApiException(status));
@@ -177,7 +177,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             GetTemporaryExposureKeyHistoryParams params = new GetTemporaryExposureKeyHistoryParams(new ITemporaryExposureKeyListCallback.Stub() {
                 @Override
                 public void onResult(Status status, List<TemporaryExposureKey> result) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(result);
                     } else {
                         completionSource.setException(new ApiException(status));
@@ -217,7 +217,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             ProvideDiagnosisKeysParams params = new ProvideDiagnosisKeysParams(new IStatusCallback.Stub() {
                 @Override
                 public void onResult(Status status) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(null);
                     } else {
                         completionSource.setException(new ApiException(status));
@@ -249,7 +249,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             GetExposureSummaryParams params = new GetExposureSummaryParams(new IExposureSummaryCallback.Stub() {
                 @Override
                 public void onResult(Status status, ExposureSummary result) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(result);
                     } else {
                         completionSource.setException(new ApiException(status));
@@ -270,7 +270,7 @@ public class ExposureNotificationClientImpl extends GoogleApi<Api.ApiOptions.NoO
             GetExposureInformationParams params = new GetExposureInformationParams(new IExposureInformationListCallback.Stub() {
                 @Override
                 public void onResult(Status status, List<ExposureInformation> result) {
-                    if (status == Status.SUCCESS) {
+                    if (status.equals(Status.SUCCESS)) {
                         completionSource.setResult(result);
                     } else {
                         completionSource.setException(new ApiException(status));


### PR DESCRIPTION
While integrating some microG UI modules bundled with an app, I ran into a situation where sometimes (possibly due to particular sequences of intents/activities), there were various instances of `Status.SUCCESS` around, resulting in failed calls even though they were successful.

This adds a proper `equals()` to remove this possibility.