### PR TITLE
EN: fix AEM version check

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/Constants.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/Constants.kt
@@ -40,5 +40,7 @@ const val TX_POWER_LOW = -15
 const val ADVERTISER_OFFSET = 60 * 1000
 const val CLEANUP_INTERVAL = 24 * 60 * 60 * 1000L
 
+// The version is encoded in bits 7..6 (major) and 5..4 (minor); 3..0 are reserved for future use
+const val VERSION_MASK: Int = 0xF0
 const val VERSION_1_0: Byte = 0x40
 const val VERSION_1_1: Byte = 0x50

--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
@@ -458,11 +458,12 @@ class ExposureDatabase private constructor(private val context: Context) : SQLit
             it.timestamp >= targetTimestamp - ALLOWED_KEY_OFFSET_MS && it.timestamp <= targetTimestamp + ROLLING_WINDOW_LENGTH_MS + ALLOWED_KEY_OFFSET_MS
         }.mapNotNull {
             val decrypted = key.cryptAem(it.rpi, it.aem)
-            if (decrypted[0] == 0x40.toByte() || decrypted[0] == 0x50.toByte()) {
+            val aemVersion = (decrypted[0].toInt() and VERSION_MASK).toByte()
+            if (aemVersion == VERSION_1_0 || aemVersion == VERSION_1_1) {
                 val txPower = decrypted[1]
                 MeasuredExposure(it.timestamp, it.duration, it.rssi, txPower.toInt(), key)
             } else {
-                Log.w(TAG, "Unknown AEM version ${decrypted[0]}, ignoring")
+                Log.w(TAG, "Unknown AEM version ${aemVersion}, ignoring")
                 null
             }
         }


### PR DESCRIPTION
According to the [spec](https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ExposureNotification-BluetoothSpecificationv1.2.pdf), the AEM version is encoded in bits 7..4 of the first byte, so only those should be checked for validity (I've seen advertisements coming from GAEN with a first byte of e.g. 0x5C).