### PR TITLE
EN: Add database export feature

### DIFF
--- a/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/ExposureNotificationsRpisFragment.kt
+++ b/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/ExposureNotificationsRpisFragment.kt
@@ -30,6 +30,7 @@ class ExposureNotificationsRpisFragment : PreferenceFragmentCompat() {
     private lateinit var histogramCategory: PreferenceCategory
     private lateinit var histogram: BarChartPreference
     private lateinit var deleteAll: Preference
+    private lateinit var exportDb: Preference
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences_exposure_notifications_rpis)
@@ -39,6 +40,7 @@ class ExposureNotificationsRpisFragment : PreferenceFragmentCompat() {
         histogramCategory = preferenceScreen.findPreference("prefcat_exposure_rpi_histogram") ?: histogramCategory
         histogram = preferenceScreen.findPreference("pref_exposure_rpi_histogram") ?: histogram
         deleteAll = preferenceScreen.findPreference("pref_exposure_rpi_delete_all") ?: deleteAll
+        exportDb = preferenceScreen.findPreference("pref_exposure_export_database") ?: exportDb
         deleteAll.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             AlertDialog.Builder(requireContext())
                     .setTitle(R.string.pref_exposure_rpi_delete_all_title)
@@ -52,6 +54,10 @@ class ExposureNotificationsRpisFragment : PreferenceFragmentCompat() {
                     .setNegativeButton(android.R.string.cancel) { _, _ -> }
                     .create()
                     .show()
+            true
+        }
+        exportDb.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            ExposureDatabase.export(requireContext())
             true
         }
     }

--- a/play-services-nearby-core-ui/src/main/res/values-de/strings.xml
+++ b/play-services-nearby-core-ui/src/main/res/values-de/strings.xml
@@ -23,6 +23,8 @@
     <string name="pref_exposure_rpi_delete_all_title">Alle gesammelten IDs löschen</string>
     <string name="pref_exposure_rpi_delete_all_warning">Nach dem Löschen der gesammelten IDs kannst du nicht mehr informiert werden, falls einer deiner Kontakte der letzten 14 Tage positiv getested wurde.</string>
     <string name="pref_exposure_rpi_delete_all_warning_confirm_button">Trotzdem löschen</string>
+    <string name="pref_exposure_rpi_export_title">Datenbank Export</string>
+    <string name="pref_exposure_rpi_export_summary">Exportiere die aktuelle Datenbank um sie mit einer anderen App zu analysieren.</string>
     <string name="pref_exposure_info_summary">"Die Exposure Notifications API ermöglicht es Apps, dich zu warnen, falls du Kontakt zu einer positiv getesteten Person hattest.
 
 Das Datum, die Zeitdauer und die Signalstärke, die dem Kontakt zugeordnet sind, werden mit der zugehörigen App geteilt."</string>

--- a/play-services-nearby-core-ui/src/main/res/values/strings.xml
+++ b/play-services-nearby-core-ui/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="pref_exposure_rpi_delete_all_title">Delete all collected IDs</string>
     <string name="pref_exposure_rpi_delete_all_warning">Deleting collected IDs will make it impossible to notify you in case any of your contacts of the last 14 days is diagnosed.</string>
     <string name="pref_exposure_rpi_delete_all_warning_confirm_button">Delete anyways</string>
+    <string name="pref_exposure_rpi_export_title">Export Database</string>
+    <string name="pref_exposure_rpi_export_summary">Export the current database for analysis with another app.</string>
     <string name="pref_exposure_info_summary">"Exposure Notifications API allows apps to notify you if you were exposed to someone who reported to be diagnosed positive.
 
 The date, duration, and signal strength associated with an exposure will be shared with the corresponding app."</string>

--- a/play-services-nearby-core-ui/src/main/res/xml/preferences_exposure_notifications_rpis.xml
+++ b/play-services-nearby-core-ui/src/main/res/xml/preferences_exposure_notifications_rpis.xml
@@ -19,6 +19,12 @@
             android:title="@string/pref_exposure_rpi_delete_all_title" />
     </PreferenceCategory>
     <PreferenceCategory android:layout="@layout/preference_category_no_label">
+        <Preference
+            android:key="pref_exposure_export_database"
+            android:title="@string/pref_exposure_rpi_export_title"
+            android:summary="@string/pref_exposure_rpi_export_summary" />
+    </PreferenceCategory>
+    <PreferenceCategory android:layout="@layout/preference_category_no_label">
         <org.microg.gms.ui.TextPreference
             android:icon="@drawable/ic_info_outline"
             android:selectable="false"

--- a/play-services-nearby-core/src/main/AndroidManifest.xml
+++ b/play-services-nearby-core/src/main/AndroidManifest.xml
@@ -41,5 +41,15 @@
                 <action android:name="android.intent.action.PACKAGE_RESTARTED" />
             </intent-filter>
         </receiver>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="org.microg.gms.nearby.exposurenotification.export"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/preferences_exposure_notifications_exportedfiles" />
+        </provider>
     </application>
 </manifest>

--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
@@ -943,7 +943,7 @@ class ExposureDatabase private constructor(private val context: Context) : SQLit
                     action = Intent.ACTION_SEND
                     putExtra(Intent.EXTRA_STREAM, fileUri)
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    type = "application/vnd.sqlite3"
+                    type = "application/vnd.microg.exposure+sqlite3"
                 }
 
                 val shareIntent = Intent.createChooser(sendIntent, null)

--- a/play-services-nearby-core/src/main/res/xml/preferences_exposure_notifications_exportedfiles.xml
+++ b/play-services-nearby-core/src/main/res/xml/preferences_exposure_notifications_exportedfiles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="exposureDatabase" path="exposureDatabase" />
+</paths>


### PR DESCRIPTION
This pull requests adds an database-export feature to the exposure-notification preference screen.

I am using MicroG on an unrooted device, so cannot read the database otherwise. By having this export feature, I can use the [corona warn companion app](https://github.com/mh-/corona-warn-companion-android) to create an analysis without root.

<img src="https://user-images.githubusercontent.com/58152939/100554920-96b82380-3298-11eb-9ac1-3f9b951a7da0.png" alt="Your image title" width="250"/>

The export is done using `Intent.ACTION_SEND`. Unfortunately, a `FileProvider` cannot directly share files in the `/databases` folder, so I copy it from `/databases` to `/files` first.
This method allows any file-browser app to capture the SEND intent and write the database to a user specified directory, or (with a companion pull request) open it directly in the corona companion app.