### PR TITLE
EN: ensure token is non-null in provideDiagnosisKeys()

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
@@ -215,6 +215,7 @@ class ExposureNotificationServiceImpl(private val context: Context, private val 
     }
 
     override fun provideDiagnosisKeys(params: ProvideDiagnosisKeysParams) {
+        params.token = params.token ?: TOKEN_A
         Log.w(TAG, "provideDiagnosisKeys() with $packageName/${params.token}")
         lifecycleScope.launchWhenStarted {
             val tid = ExposureDatabase.with(context) { database ->


### PR DESCRIPTION
This is a suggested fix for #1300. There might be better ways. :)