### PR TITLE
EN: Trace received advertisements

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ScannerService.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ScannerService.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import org.microg.gms.common.ForegroundServiceContext
 import java.io.FileDescriptor
 import java.io.PrintWriter
+import java.nio.ByteBuffer
 import java.util.*
 
 @TargetApi(21)
@@ -88,6 +89,9 @@ class ScannerService : LifecycleService() {
         seenAdvertisements++
         lastAdvertisement = System.currentTimeMillis()
         lifecycleScope.launchWhenStarted {
+            val uuid = ByteBuffer.wrap(data).run {UUID(long, long)}
+            val metadata = data.drop(16).joinToString(separator="", transform={"%02x".format(it)})
+            Log.d(TAG, "Recording advertisement: [${result.device} ${result.rssi}dB] $uuid -- $metadata")
             ExposureDatabase.with(this@ScannerService) { database ->
                 database.noteAdvertisement(data.sliceArray(0..15), data.drop(16).toByteArray(), result.rssi)
             }


### PR DESCRIPTION
Debug traces of the received EN advertisements, which I found useful to debug/verify proper behavior in various scenarios.
Could be useful to others. :)