### PR TITLE
EN: Declare EN_SETTINGS intent filter also in play-services-nearby-core-ui

### DIFF
--- a/play-services-nearby-core-ui/src/main/AndroidManifest.xml
+++ b/play-services-nearby-core-ui/src/main/AndroidManifest.xml
@@ -18,6 +18,11 @@
             <intent-filter>
                 <action android:name="org.microg.gms.nearby.exposurenotification.CONFIRM" />
             </intent-filter>
+            <intent-filter android:priority="-100">
+                <action android:name="com.google.android.gms.settings.EXPOSURE_NOTIFICATION_SETTINGS" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
Still part of #1179: the DP3T-SDK checks the availability of EN on the phone by checking whether the `ACTION_EXPOSURE_NOTIFICATION_SETTINGS` intent resolves to an activity (it does not send the intent, just checks whether it resolves).

So far, I have worked around this by declaring the intent filter in the DP3T project, as it is not declared in the microG libraries I use (it's in `play-services-core`).

I was wondering if that filter could also be declared in `play-services-nearby-core-ui`, with a lower priority? As I understand the way priorities work (but I could be  wrong), it should still result in the `SettingsActivity` be called when both are available.

Does it make sense, or is it a bad idea? :)
Or should the SDK just check EN availability differently?