### PR TITLE
Improve Russian translation

### DIFF
--- a/play-services-core/src/main/res/values-ru/plurals.xml
+++ b/play-services-core/src/main/res/values-ru/plurals.xml
@@ -27,9 +27,9 @@
         <item quantity="other"><xliff:g example="123">%1$d</xliff:g> привязанных приложений</item>
     </plurals>
     <plurals name="cond_perm_summary">
-        <item quantity="one">Не предоставлено разрешение, которое требуется для правильного функционирования microG Service Core.</item>
-        <item quantity="few">Не предоставлены разрешения, которые требуются для правильного функционирования microG Service Core.</item>
-        <item quantity="other">Не предоставлены разрешения, которые требуются для правильного функционирования microG Service Core.</item>
+        <item quantity="one">Не предоставлено разрешение, которое требуется для правильного функционирования microG Services Core.</item>
+        <item quantity="few">Не предоставлены разрешения, которые требуются для правильного функционирования microG Services Core.</item>
+        <item quantity="other">Не предоставлены разрешения, которые требуются для правильного функционирования microG Services Core.</item>
     </plurals>
     <plurals name="cond_perm_action">
         <item quantity="one">Запросить отсутствующее разрешение</item>

--- a/play-services-core/src/main/res/values-ru/strings.xml
+++ b/play-services-core/src/main/res/values-ru/strings.xml
@@ -24,7 +24,7 @@
     <string name="ask_permission_tos">Продолжая, вы позволяете этому приложению и Google использовать свою информацию в соответствии с их соответствующими условиями предоставления услуг и политиками конфиденциальности.</string>
     <string name="ask_scope_permission_title"><xliff:g example="F-Droid">%1$s</xliff:g> хотел бы:</string>
     <string name="ask_service_permission_title"><xliff:g example="F-Droid">%1$s</xliff:g> хотел бы использовать:</string>
-    <string name="account_manager_title">Google Account Manager</string>
+    <string name="account_manager_title">Менеджер аккаунта Google</string>
     <string name="sorry">Извините…</string>
 	<string name="auth_before_connect">"Приложение на вашем устройстве пытается войти в учетную запись Google.
 
@@ -43,7 +43,7 @@
 
 Это может занять несколько минут."</string>
     <string name="allow">Разрешить</string>
-    <string name="deny">Отказано</string>
+    <string name="deny">Отказать</string>
     <string name="auth_notification_title">Требуется аутентификация</string>
     <string name="auth_notification_content"><xliff:g example="F-Droid">%1$s</xliff:g> требуется авторизация чтобы получить доступ к вашей учетной записи Google.</string>
 
@@ -56,7 +56,7 @@
     <string name="perm_provision_description">Позволить приложению настраивать сервисы microG без вмешательства пользователя</string>
 
     <string name="service_name_checkin">Регистрация устройства в Google</string>
-    <string name="service_name_mcs">Cloud Messaging</string>
+    <string name="service_name_mcs">Облачный обмен сообщениями</string>
     <string name="service_name_snet">Google SafetyNet</string>
 
     <string name="service_status_disabled">Выключено</string>
@@ -119,7 +119,7 @@
     <string name="prefcat_test">Тест</string>
 
     <string name="cond_gcm_bat_title">Активна оптимизация энергопотребления</string>
-    <string name="cond_gcm_bat_summary">Вы включили Cloud Messaging, но у вас активна оптимизация энергопотребления для microG Services Core. Чтобы получать push-уведомления вам необходимо разрешить приложению работать в фоновом режиме.</string>
+    <string name="cond_gcm_bat_summary">Вы включили облачный обмен сообщениями, но у вас активна оптимизация энергопотребления для microG Services Core. Чтобы получать push-уведомления вам необходимо разрешить приложению работать в фоновом режиме.</string>
     <string name="cond_gcm_bat_action">Разрешить работу в фоне</string>
     <string name="cond_perm_title">Отсутствуют разрешения</string>
 
@@ -144,11 +144,11 @@
 
     <string name="pref_add_account_title">Аккаунт</string>
     <string name="pref_add_account_summary">Добавить аккаунт Google</string>
-    <string name="pref_gcm_enable_mcs_summary">Cloud Messaging предоставляет push-уведомления, которые используются во многих в сторонних приложениях. Чтобы использовать их, вы должны включить регистрацию устройства.</string>
-    <string name="pref_gcm_heartbeat_title">Интервал соединения Cloud Messaging</string>
+    <string name="pref_gcm_enable_mcs_summary">Облачный обмен сообщениями предоставляет push-уведомления, которые используются во многих в сторонних приложениях. Чтобы использовать их, вы должны включить регистрацию устройства.</string>
+    <string name="pref_gcm_heartbeat_title">Интервал соединения облачных сообщений</string>
     <string name="pref_gcm_heartbeat_summary">"Интервал в секундах, для использования серверов Google. Увеличение этого числа сократит потребление батареи, но может привести к задержкам push-сообщений.\nУстарело, будет изменено в следующем релизе."</string>
-    <string name="pref_gcm_apps_title">Приложения, использующие Cloud Messaging</string>
-    <string name="pref_gcm_apps_summary">Список приложений, которые привязаны к Cloud Messaging.</string>
+    <string name="pref_gcm_apps_title">Приложения, использующие облачный обмен сообщениями</string>
+    <string name="pref_gcm_apps_summary">Список приложений, которые привязаны к облачному обмену сообщениями.</string>
     <string name="pref_gcm_confirm_new_apps_title">Подтверждать новые приложения</string>
     <string name="pref_gcm_confirm_new_apps_summary">Спрашивать разрешение перед привязкой новых приложений для получения push-уведомлений</string>
     <string name="pref_gcm_ping_interval">Интервал проверки: <xliff:g example="10 минут">%1$s</xliff:g></string>
@@ -175,7 +175,7 @@
     <string name="pref_push_app_allow_register_title">Разрешить регистрацию</string>
     <string name="pref_push_app_allow_register_summary">Разрешить приложению регистрироваться для получения push-уведомлений.</string>
     <string name="pref_push_app_wake_for_delivery_title">Запускать приложение при получении сообщения</string>
-    <string name="pref_push_app_wake_for_delivery_summary">Запустите приложение в фоновом режиме, чтобы получать входящие push-уведомления.</string>
+    <string name="pref_push_app_wake_for_delivery_summary">Запускать приложение в фоновом режиме, чтобы получать входящие push-уведомления.</string>
     <string name="prefcat_push_apps_title">Приложения использующие push-уведомления</string>
     <string name="prefcat_push_apps_registered_title">Зарегистрированные приложения</string>
     <string name="prefcat_push_apps_unregistered_title">Незарегистрированные приложения</string>

--- a/play-services-nearby-core-ui/src/main/res/values-ru/strings.xml
+++ b/play-services-nearby-core-ui/src/main/res/values-ru/strings.xml
@@ -17,15 +17,21 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="service_name_exposure">Уведомления о риске инфицирования</string>
     <string name="pref_exposure_enable_info_summary">Чтобы включить уведомления о риске инфицирования запустите любое приложение, которое их поддерживает.</string>
-    <string name="pref_exposure_error_bluetooth_off_summary">Чтобы использовать уведомления о риске инфицирования включите Bluetooth в настройках системы.</string>
-    <string name="pref_exposure_error_location_off_summary">Чтобы использовать уведомления о риске инфицирования включите доступ к местоположению в настройках системы.</string>
+    <string name="pref_exposure_error_bluetooth_off_title">Включить Bluetooth</string>
+    <string name="pref_exposure_error_location_off_title">Открыть настройки местоположения</string>
     <string name="pref_exposure_error_bluetooth_unsupported_summary">К сожалению ваше устройство несовместимо с уведомлениями о риске инфицирования.</string>
     <string name="pref_exposure_error_bluetooth_no_advertise_summary">К сожалению ваше устройство лишь частично совместимо с уведомлениями о риске инфицирования. Вы можете получать уведомления об опасных контактах, но не сможете уведомлять других.</string>
     <string name="prefcat_exposure_apps_title">Приложения использующие уведомления о риске инфицирования</string>
     <string name="pref_exposure_collected_rpis_title">Собранные идентификаторы</string>
     <string name="pref_exposure_collected_rpis_summary"><xliff:g example="63">%1$d</xliff:g> Количество идентификаторов за последний час</string>
     <string name="pref_exposure_advertising_id_title">Транслируемый в настоящее время идентификатор</string>
-    <string name="pref_exposure_app_last_report_title">Последний отчёт (<xliff:g example="3 hours ago">%1$s</xliff:g>)</string>
+    <string name="prefcat_exposure_app_report_title">Сообщения о взаимодействиях</string>
+    <string name="pref_exposure_app_report_updated_title">Обновлено: <xliff:g example="Today, 14:02">%1$s</xliff:g></string>
+    <string name="pref_exposure_app_report_entry_time_short">Менее пяти минут назад</string>
+    <string name="pref_exposure_app_report_entry_time_about">Около <xliff:g example="13">%1$d</xliff:g> минут</string>
+    <string name="pref_exposure_app_report_entry_distance_close">взаимодействия рядом</string>
+    <string name="pref_exposure_app_report_entry_distance_far">вдаимодействия далеко</string>
+    <string name="pref_exposure_app_report_entry_combined"><xliff:g example="About 12 minutes">%1$s</xliff:g>, <xliff:g example="distant exposure">%2$s</xliff:g></string>
     <string name="pref_exposure_app_last_report_summary_diagnosis_keys">Обработано <xliff:g example="121031">%1$d</xliff:g> диагностических ключей.</string>
     <string name="pref_exposure_app_last_report_summary_encounters_no">Сообщения об опасных контактах отсутствуют.</string>
     <string name="pref_exposure_app_last_report_summary_encounters_prefix">Сообщено о <xliff:g example="3">%1$d</xliff:g> опасных контактах:</string>
@@ -60,6 +66,9 @@
 
 Ваша личность или результат теста не будут переданы другим людям."</string>
     <string name="exposure_confirm_keys_button">Поделиться</string>
-    <string name="exposure_confirm_permission_description">Вам нужно предоставить разрешение для <xliff:g example="microG Services Core">%1$s</xliff:g> чтобы уведомления о риске инфицирования работали корректно.</string>
+    <string name="exposure_confirm_permission_description">Для <xliff:g example="microG Services Core">%1$s</xliff:g> требуются дополнительные разрешения.</string>
     <string name="exposure_confirm_permission_button">Предоставить</string>
+    <string name="exposure_confirm_bluetooth_description">Bluetooth должен быть включён.</string>
+    <string name="exposure_confirm_location_description">требуется доступ к местоположению.</string>
+    <string name="exposure_confirm_button">Включить</string>
 </resources>

--- a/play-services-nearby-core-ui/src/main/res/values-ru/strings.xml
+++ b/play-services-nearby-core-ui/src/main/res/values-ru/strings.xml
@@ -15,13 +15,13 @@
   -->
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="service_name_exposure">Exposure Notifications</string>
-    <string name="pref_exposure_enable_info_summary">Чтобы включить Exposure Notifications запустите любое приложение, которое их поддерживает.</string>
-    <string name="pref_exposure_error_bluetooth_off_summary">Чтобы использовать Exposure Notifications включите Bluetooth в настройках системы.</string>
-    <string name="pref_exposure_error_location_off_summary">Чтобы использовать Exposure Notifications включите доступ к местоположению в настройках системы.</string>
-    <string name="pref_exposure_error_bluetooth_unsupported_summary">К сожалению ваше устройство несовместимо с Exposure Notifications.</string>
-    <string name="pref_exposure_error_bluetooth_no_advertise_summary">К сожалению ваше устройство лишь частично совместимо с Exposure Notifications. Вы можете получать уведомления об опасных контактах, но не сможете уведомлять других.</string>
-    <string name="prefcat_exposure_apps_title">Приложения использующие Exposure Notifications</string>
+    <string name="service_name_exposure">Уведомления о риске инфицирования</string>
+    <string name="pref_exposure_enable_info_summary">Чтобы включить уведомления о риске инфицирования запустите любое приложение, которое их поддерживает.</string>
+    <string name="pref_exposure_error_bluetooth_off_summary">Чтобы использовать уведомления о риске инфицирования включите Bluetooth в настройках системы.</string>
+    <string name="pref_exposure_error_location_off_summary">Чтобы использовать уведомления о риске инфицирования включите доступ к местоположению в настройках системы.</string>
+    <string name="pref_exposure_error_bluetooth_unsupported_summary">К сожалению ваше устройство несовместимо с уведомлениями о риске инфицирования.</string>
+    <string name="pref_exposure_error_bluetooth_no_advertise_summary">К сожалению ваше устройство лишь частично совместимо с уведомлениями о риске инфицирования. Вы можете получать уведомления об опасных контактах, но не сможете уведомлять других.</string>
+    <string name="prefcat_exposure_apps_title">Приложения использующие уведомления о риске инфицирования</string>
     <string name="pref_exposure_collected_rpis_title">Собранные идентификаторы</string>
     <string name="pref_exposure_collected_rpis_summary"><xliff:g example="63">%1$d</xliff:g> Количество идентификаторов за последний час</string>
     <string name="pref_exposure_advertising_id_title">Транслируемый в настоящее время идентификатор</string>
@@ -37,22 +37,22 @@
     <string name="pref_exposure_rpi_delete_all_title">Удалить все собранные идентификаторы</string>
     <string name="pref_exposure_rpi_delete_all_warning">Удаление собранных идентификаторов приведёт к невозможности информирования, в случае если у одного из ваших контактов за последние 14 дней окажется положительный диагноз.</string>
     <string name="pref_exposure_rpi_delete_all_warning_confirm_button">Всё равно удалить</string>
-    <string name="pref_exposure_info_summary">"Exposure Notifications API позволяет приложениям уведомлять вас, если вы столкнулись с кем-то, у кого был положительный диагноз.
+    <string name="pref_exposure_info_summary">"API Уведомлений о риске инфицирования (Exposure Notifications API) позволяет приложениям уведомлять вас, если вы столкнулись с кем-то, у кого был положительный диагноз.
 
 Дата, продолжительность и мощность сигнала, связанные с воздействием, будут переданы соответствующему приложению."</string>
-    <string name="pref_exposure_rpis_details_summary">"Пока xposure Notifications API включен, ваше устройство пассивно собирает идентификаторы (называемые скользящими идентификаторами сближения или RPI) с соседних устройств.
+    <string name="pref_exposure_rpis_details_summary">"Пока API уведомлений о риске инфицирования включен, ваше устройство пассивно собирает идентификаторы (называемые скользящими идентификаторами сближения или RPI) с соседних устройств.
 
 Когда владельцы устройств сообщают о положительном диагнозе, их идентификаторы могут быть распространены. Ваше устройство проверяет, соответствует ли какой-либо из известных идентификаторов с подтверждённым диагнозом любому из собранных вами идентификаторов, и рассчитывает риск заражения."</string>
 
-    <string name="exposure_enable_switch">Использовать Exposure Notifications</string>
-    <string name="exposure_confirm_start_title">Включить Exposure Notifications?</string>
+    <string name="exposure_enable_switch">Использовать уведомления о риске инфицирования</string>
+    <string name="exposure_confirm_start_title">Включить уведомлений о риске инфицирования?</string>
     <string name="exposure_confirm_start_summary">"Ваш телефон должен использовать Bluetooth для безопасного сбора и распространения идентификаторов другим телефонам, находящимся поблизости.
 
-<xliff:g example="Corona-Warn">%1$s</xliff:g> может уведомить вас, если вы пересекались с кем-то, у кого был обнаружен положительный диагноз.
+<xliff:g example="Corona-Warn">%1$s</xliff:g> может уведомить вас, если вы пересекались с кем-то, у кого был подтверждён положительный диагноз.
 
 Дата, продолжительность и мощность сигнала, связанные с контактом, будут переданы приложению."</string>
     <string name="exposure_confirm_start_button">Включить</string>
-    <string name="exposure_confirm_stop_title">Выключить Exposure Notifications?</string>
+    <string name="exposure_confirm_stop_title">Выключить уведомления о риске инфицирования?</string>
     <string name="exposure_confirm_stop_summary">После отключения уведомлений вы больше не будете получать уведомления о контактах с кем-то, у кого был положительный диагноз.</string>
     <string name="exposure_confirm_stop_button">Выключить</string>
     <string name="exposure_confirm_keys_title">Делиться вашими идентификаторами с <xliff:g example="Corona-Warn">%1$s</xliff:g>?</string>
@@ -60,6 +60,6 @@
 
 Ваша личность или результат теста не будут переданы другим людям."</string>
     <string name="exposure_confirm_keys_button">Поделиться</string>
-    <string name="exposure_confirm_permission_description">Вам нужно предоставить разрешение для <xliff:g example="microG Services Core">%1$s</xliff:g> for Exposure Notifications to function correctly.</string>
+    <string name="exposure_confirm_permission_description">Вам нужно предоставить разрешение для <xliff:g example="microG Services Core">%1$s</xliff:g> чтобы уведомления о риске инфицирования работали корректно.</string>
     <string name="exposure_confirm_permission_button">Предоставить</string>
 </resources>

--- a/play-services-nearby-core/src/main/res/values-ru/strings.xml
+++ b/play-services-nearby-core/src/main/res/values-ru/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ SPDX-FileCopyrightText: 2020, microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="exposure_notify_off_title">Уведомления о риске инфицирования не активны</string>
+    <string name="exposure_notify_off_bluetooth">Bluetooth должен быть включён, чтобы принимать уведомления о риске инфицирования.</string>
+    <string name="exposure_notify_off_location">Доступ к местоположению обязателен, чтобы принимать уведомления о риске инфицирования.</string>
+    <string name="exposure_notify_off_bluetooth_location">Bluetooth и определение местоположения должны быть включены, чтобы принимать уведомления о риске инфицирования</string>
+</resources>


### PR DESCRIPTION
- Translate some string as **Cloud Messaging** and **Exposure Notifications** without using brand names and same way it translated by Google to make it easier to understand and find information on the Internet.
https://firebase.google.com/docs/cloud-messaging?hl=ru
https://support.google.com/android/announcements/9929436?hl=ru
- A couple of minor improvement