### PR TITLE
Add Chat to known Google packages

### DIFF
--- a/play-services-base-core/src/main/java/org/microg/gms/common/PackageUtils.java
+++ b/play-services-base-core/src/main/java/org/microg/gms/common/PackageUtils.java
@@ -67,6 +67,7 @@ public class PackageUtils {
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.subscriptions.red", "de8304ace744ae4c4e05887a27a790815e610ff0");
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.meetings", "47a6936b733dbdb45d71997fbe1d610eca36b8bf");
         KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.nbu.paisa.user", "80df78bb700f9172bc671779b017ddefefcbf552");
+        KNOWN_GOOGLE_PACKAGES.put("com.google.android.apps.dynamite", "519c5a17a60596e6fe5933b9cb4285e7b0e5eb7b");
     }
 
     public static boolean isGooglePackage(Context context, String packageName) {


### PR DESCRIPTION
Currently, it crashes on startup. After it's whitelisted, everything seems to work.