### PR TITLE
Add missing method to GoogleApiAvailability

### DIFF
--- a/play-services-base/src/main/java/com/google/android/gms/common/GoogleApiAvailability.java
+++ b/play-services-base/src/main/java/com/google/android/gms/common/GoogleApiAvailability.java
@@ -164,6 +164,19 @@ public class GoogleApiAvailability {
     }
 
     /**
+     * Verifies that Google Play services is installed and enabled on this device, and that the version installed on
+     * this device is no older than the one required by this client or the version is not older than the one specified
+     * in <code>minApkVersion</code>.
+     *
+     * @return status code indicating whether there was an error. Can be one of following in
+     * {@link ConnectionResult}: SUCCESS, SERVICE_MISSING, SERVICE_UPDATING,
+     * SERVICE_VERSION_UPDATE_REQUIRED, SERVICE_DISABLED, SERVICE_INVALID
+     */
+    public int isGooglePlayServicesAvailable(Context context, int minApkVersion) {
+        return isGooglePlayServicesAvailable(context);
+    }
+
+    /**
      * Determines whether an error can be resolved via user action. If true, proceed by calling
      * {@link #getErrorDialog(Activity, int, int)} and showing the dialog.
      *


### PR DESCRIPTION
The class `GoogleApiAvailability` does not have the method [`isGooglePlayServicesAvailable(Context, int)`][1], it only has `isGooglePlayServicesAvailable(Context)`. [CWA tries to access][0] this method, so I think it would be best to provide it here.

[0]: https://github.com/corona-warn-app/cwa-app-android/blob/4431ce3d767b4181281a84cd16639edafc03c07f/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/gplay/GoogleApiVersion.kt#L18
[1]: https://developers.google.com/android/reference/com/google/android/gms/common/GoogleApiAvailability#isGooglePlayServicesAvailable(android.content.Context,%20int)