### PR TITLE
add deeplink to rpi information screen

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -453,6 +453,13 @@
             android:process=":ui"
             android:roundIcon="@mipmap/ic_microg_settings">
             <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data
+                    android:host="exposure-notifications-rpis"
+                    android:scheme="x-gms-settings" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>

--- a/play-services-nearby-core-ui/src/main/res/navigation/nav_nearby.xml
+++ b/play-services-nearby-core-ui/src/main/res/navigation/nav_nearby.xml
@@ -26,7 +26,11 @@
     <fragment
         android:id="@+id/exposureNotificationsRpisFragment"
         android:name="org.microg.gms.nearby.core.ui.ExposureNotificationsRpisFragment"
-        android:label="@string/pref_exposure_collected_rpis_title" />
+        android:label="@string/pref_exposure_collected_rpis_title">
+        <deepLink
+            app:action="ACTION_VIEW"
+            app:uri="x-gms-settings://exposure-notifications-rpis" />
+    </fragment>
 
     <fragment
         android:id="@+id/exposureNotificationsAppFragment"


### PR DESCRIPTION
CCTG could use this when interacting with external microG. Instead of
directly embedding the fragment through the bottomNavigationBar[1] we can
at least jump to the correct target location. Doing this through an
implicit deeplink intent seems easiest as an explicit intent adds all
the top level nav elements to the backstack
(see: https://developer.android.com/guide/navigation/navigation-deep-link).

Tested and this works pretty nicely :).



[1]
![image](https://user-images.githubusercontent.com/105185/110260092-1dbd1c00-7fab-11eb-8c80-76de1b54b772.png)
