### PR TITLE
Fix date format being used incorrectly

### DIFF
--- a/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/DotChartView.kt
+++ b/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/DotChartView.kt
@@ -10,14 +10,12 @@ import android.annotation.TargetApi
 import android.content.Context
 import android.graphics.*
 import android.os.Build
-import android.provider.Settings
-import android.text.TextUtils
+import android.text.format.DateFormat
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import org.microg.gms.nearby.exposurenotification.ExposureScanSummary
 import org.microg.gms.ui.resolveColor
-import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -38,12 +36,7 @@ class DotChartView : View {
             val now = System.currentTimeMillis()
             val min = now - 14 * 24 * 60 * 60 * 1000L
             val date = Date(min)
-            val format = Settings.System.getString(context.contentResolver, Settings.System.DATE_FORMAT)
-            val dateFormat = if (TextUtils.isEmpty(format)) {
-                android.text.format.DateFormat.getMediumDateFormat(context)
-            } else {
-                SimpleDateFormat(format.replace('m', 'M'))
-            }
+            val dateFormat = DateFormat.getMediumDateFormat(context)
             val lowest = dateFormat.parse(dateFormat.format(date))?.time ?: date.time
             for (day in 0 until 15) {
                 date.time = now - (14 - day) * 24 * 60 * 60 * 1000L

--- a/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/DotChartView.kt
+++ b/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/DotChartView.kt
@@ -38,11 +38,11 @@ class DotChartView : View {
             val now = System.currentTimeMillis()
             val min = now - 14 * 24 * 60 * 60 * 1000L
             val date = Date(min)
-            val format = Settings.System.getString(context.contentResolver, Settings.System.DATE_FORMAT);
+            val format = Settings.System.getString(context.contentResolver, Settings.System.DATE_FORMAT)
             val dateFormat = if (TextUtils.isEmpty(format)) {
                 android.text.format.DateFormat.getMediumDateFormat(context)
             } else {
-                SimpleDateFormat(format)
+                SimpleDateFormat(format.replace('m', 'M'))
             }
             val lowest = dateFormat.parse(dateFormat.format(date))?.time ?: date.time
             for (day in 0 until 15) {


### PR DESCRIPTION
Addresses #1441. 

The issue detailed in https://github.com/microg/GmsCore/issues/1441#issuecomment-817174607 is fixed in this PR because it replaces `'m'` with `'M'`.

However I'm not sure under which circumstances the operating system actually provides a `DATE_FORMAT` value. In the emulator nothing was provided. I also think that this string does not provide a great format because it always separates the digits with `/`, which is rather American and not fitting German, for example, where usually `.` is used.