### PR TITLE
Handle GMS intent for launching account settings

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -538,6 +538,7 @@
                 <action android:name="com.google.android.gms.accountsettings.ACCOUNT_PREFERENCES_SETTINGS" />
                 <action android:name="com.google.android.gms.accountsettings.PRIVACY_SETTINGS" />
                 <action android:name="com.google.android.gms.accountsettings.SECURITY_SETTINGS" />
+                <action android:name="com.google.android.gms.accountsettings.action.VIEW_SETTINGS" />
 
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>


### PR DESCRIPTION
This small change prevents Google apps from crashing due to an ActivityNotFoundException when the user clicks on "Manage Google account" button. The corresponding intent is now handled by AccountSettingsActivity (currently used as a placeholder for account settings).