### PR TITLE
Omit RPIs in log

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/AdvertiserService.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/AdvertiserService.kt
@@ -138,8 +138,7 @@ class AdvertiserService : LifecycleService() {
                 database.generateCurrentPayload(aemBytes)
             }
             val data = AdvertiseData.Builder().addServiceUuid(SERVICE_UUID).addServiceData(SERVICE_UUID, payload).build()
-            val (uuid, _) = ByteBuffer.wrap(payload).let { UUID(it.long, it.long) to it.int }
-            Log.i(TAG, "Starting advertiser for RPI $uuid")
+            Log.i(TAG, "Starting advertiser")
             if (Build.VERSION.SDK_INT >= 26) {
                 setCallback = SetCallback()
                 val params = AdvertisingSetParameters.Builder()

--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/AdvertiserService.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/AdvertiserService.kt
@@ -200,8 +200,7 @@ class AdvertiserService : LifecycleService() {
     @Synchronized
     private fun stopOrRestartAdvertising() {
         if (!advertising) return
-        val (uuid, _) = ByteBuffer.wrap(sendingBytes).let { UUID(it.long, it.long) to it.int }
-        Log.i(TAG, "Stopping advertiser for RPI $uuid")
+        Log.i(TAG, "Stopping advertiser")
         advertising = false
         if (Build.VERSION.SDK_INT >= 26) {
             wantStartAdvertising = true


### PR DESCRIPTION
As discussed, we shouldn't log current RPIs to the system log. In case they are needed, they can still be accessed through the user interface.