### PR TITLE
Correctly draw RPIs fragment under system status bar

### DIFF
--- a/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/ExposureNotificationsRpisFragment.kt
+++ b/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/ExposureNotificationsRpisFragment.kt
@@ -7,11 +7,14 @@ package org.microg.gms.nearby.core.ui
 
 import android.annotation.TargetApi
 import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.recyclerview.widget.RecyclerView
 import org.microg.gms.nearby.exposurenotification.ExposureDatabase
 
 @TargetApi(21)
@@ -20,6 +23,18 @@ class ExposureNotificationsRpisFragment : PreferenceFragmentCompat() {
     private lateinit var histogram: DotChartPreference
     private lateinit var deleteAll: Preference
     private lateinit var exportDb: Preference
+
+    override fun onCreateRecyclerView(
+        inflater: LayoutInflater?,
+        parent: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): RecyclerView {
+        return super.onCreateRecyclerView(inflater, parent, savedInstanceState).apply {
+            // Allow drawing under system navbar / status bar
+            fitsSystemWindows = true
+            clipToPadding = false
+        }
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.preferences_exposure_notifications_rpis)


### PR DESCRIPTION
Mainly for CCTG – with this change, we can allow the layout to draw under the translucent system status bar and it will behave exactly as expected:

* Scrollbar does not go through status bar
* Scrolling up scrolls content fully out of the area of the status bar
* Scrolling down scrolls content through the status bar:

Before | After
---|---
![Screenshot_1620150386](https://user-images.githubusercontent.com/16943720/117046846-75f56d80-ad11-11eb-9413-ce92936a4cd4.png) | ![Screenshot_1620148938](https://user-images.githubusercontent.com/16943720/117044308-940d9e80-ad0e-11eb-8e40-6590dabbdabe.png)

There is no change in the microG settings app.

CCTG PR: https://codeberg.org/corona-contact-tracing-germany/cwa-android/pulls/126
