### PR TITLE
Add getConfiguration for LocationSettingsRequest

### DIFF
--- a/play-services-location-api/src/main/java/com/google/android/gms/location/LocationSettingsRequest.java
+++ b/play-services-location-api/src/main/java/com/google/android/gms/location/LocationSettingsRequest.java
@@ -37,8 +37,13 @@ public class LocationSettingsRequest extends AutoSafeParcelable {
     @PublicApi(exclude = true)
     public boolean alwaysShow;
 
+    @SafeParceled(3)
     @PublicApi(exclude = true)
     public boolean needBle;
+
+    @SafeParceled(5)
+    @PublicApi(exclude = true)
+    public int getConfiguration;
 
     private LocationSettingsRequest() {
     }


### PR DESCRIPTION
Fixes `Unknown field num 3 in com.google.android.gms.location.LocationSettingsRequest, skipping.` error

This was super  quick and dirty, I didn't test too much