### PR TITLE
EN: Fix permission granting on Android 11

### DIFF
--- a/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/ExposureNotificationsConfirmActivity.kt
+++ b/play-services-nearby-core-ui/src/main/kotlin/org/microg/gms/nearby/core/ui/ExposureNotificationsConfirmActivity.kt
@@ -118,14 +118,26 @@ class ExposureNotificationsConfirmActivity : AppCompatActivity() {
     }
 
     private fun requestPermissions() {
-        if (Build.VERSION.SDK_INT >= 23) {
-            requestPermissions(permissions, ++permissionRequestCode)
+        when {
+            Build.VERSION.SDK_INT >= 30 -> requestPermissions(
+                permissions.toSet().minus("android.permission.ACCESS_BACKGROUND_LOCATION").toTypedArray(), ++permissionRequestCode
+            )
+            Build.VERSION.SDK_INT >= 23 -> requestPermissions(permissions, ++permissionRequestCode)
         }
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == this.permissionRequestCode) checkPermissions()
+        if (requestCode == this.permissionRequestCode) {
+            when {
+                Build.VERSION.SDK_INT >= 30 && permissions.contains("android.permission.ACCESS_FINE_LOCATION") ->
+                    requestPermissions(
+                        arrayOf("android.permission.ACCESS_BACKGROUND_LOCATION"),
+                        ++permissionRequestCode
+                    )
+                else -> checkPermissions()
+            }
+        }
     }
 
     // Bluetooth


### PR DESCRIPTION
An attempted fix for #1519, inspired by the fix for https://github.com/home-assistant/android/issues/1039

It is not ideal as it requires a double operation by the user: first granting the foreground location, then the background :-/

Tested on LineageOS 17.1, LineageOS 18.1 and stock Android 11 (Samsung A40).