### PR TITLE
Remove an outdated and misleading log message

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
@@ -622,7 +622,6 @@ class ExposureNotificationServiceImpl(private val context: Context, private val 
     }
 
     override fun getStatus(params: GetStatusParams) {
-        Log.w(TAG, "Not yet implemented: getStatus")
         lifecycleScope.launchSafely {
             val isAuthorized = ExposureDatabase.with(context) { database ->
                 database.noteAppAction(packageName, "getStatus")


### PR DESCRIPTION
This PR removes an outdated log message that was left by mistake after commit aee45c2.