### PR TITLE
Add the app which was denied push permission to log message

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/gcm/PushRegisterService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/gcm/PushRegisterService.kt
@@ -70,10 +70,10 @@ private suspend fun ensureAppRegistrationAllowed(context: Context, database: Gcm
             context.startActivity(i)
         }
         if (!accepted) {
-            throw RuntimeException("Push permission not granted to app")
+            throw RuntimeException("Push permission not granted to $packageName")
         }
     } else if (app?.allowRegister == false) {
-        throw RuntimeException("Push permission not granted to app")
+        throw RuntimeException("Push permission not granted to $packageName")
     }
 }
 


### PR DESCRIPTION
This small change enriches the log message to see exactly which app was denied push permission.