### PR TITLE
add CWA and CCTG exposure file public signing keys

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureNotificationServiceImpl.kt
@@ -56,6 +56,15 @@ class ExposureNotificationServiceImpl(private val context: Context, private val 
                     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsFcEnOPY4AOAKkpv9HSdW2BrhUCWwL15Hpqu5zHaWy1Wno2KR8G6dYJ8QO0uZu1M6j8z6NGXFVZcpw7tYeXAqQ==",
             "ch.admin.bag.dp3t" to
                     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEK2k9nZ8guo7JP2ELPQXnUkqDyjjJmYmpt9Zy0HPsiGXCdI3SFmLr204KNzkuITppNV5P7+bXRxiiY04NMrEITg==",
+            // CWA, see https://github.com/corona-warn-app/cwa-documentation/issues/740#issuecomment-963223074
+            "de.rki.coronawarnapp" to
+                    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc7DEstcUIRcyk35OYDJ95/hTg3UVhsaDXKT0zK7NhHPXoyzipEnOp3GyNXDVpaPi3cAfQmxeuFMZAIX2+6A5Xg==",
+            // CCTG uses CWA infrastucture
+            "de.corona.tracing" to
+                    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc7DEstcUIRcyk35OYDJ95/hTg3UVhsaDXKT0zK7NhHPXoyzipEnOp3GyNXDVpaPi3cAfQmxeuFMZAIX2+6A5Xg==",
+            // CCTG-Test builds don't have access any staging infrastructure, so again CWA key
+            "de.corona.tracing.test" to
+                    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc7DEstcUIRcyk35OYDJ95/hTg3UVhsaDXKT0zK7NhHPXoyzipEnOp3GyNXDVpaPi3cAfQmxeuFMZAIX2+6A5Xg==",
         )
 
     // Back-end public key for this package


### PR DESCRIPTION
From: https://github.com/corona-warn-app/cwa-documentation/issues/740#issuecomment-963223074

Tested and working via CCTG-TEST:

```
11-09 15:23:45.154 32640 32746 W ExposureNotification: provideDiagnosisKeys() with de.corona.tracing.test/TYZWQ32170AXEUVCDW7A
11-09 15:23:45.182 32640 32713 D ExposureNotification: Using key file supplier
11-09 15:23:45.320 32640 32713 D ExposureNotification: de.corona.tracing.test/TYZWQ32170AXEUVCDW7A processed 592715 keys (1 files pending) in 0.137s -> 2147483.647 keys/s
11-09 15:23:45.331 32640 32713 D ExposureNotification: Verifying signature 1/1
11-09 15:23:45.331 32640 32713 D ExposureNotification: Signature info: algo=1.2.840.10045.4.3.2 key={id=262, version=v1}
11-09 15:23:45.336 32640 32713 I ExposureNotification: Key file verification successful
11-09 15:23:45.393 32640 32713 D ExposureNotification: First key with risk 7: 0008eef837ed5c082cece1a6970e0945 starts 2726928
11-09 15:23:45.393 32640 32713 D ExposureNotification: First key with risk 8: 0016e3229ca6d07cf86ec5d45aa6de68 starts 2726352
11-09 15:23:45.393 32640 32713 D ExposureNotification: First key with risk 5: 001776f49b9754e054475b46f326235c starts 2727216
11-09 15:23:45.393 32640 32713 D ExposureNotification: First key with risk 8: 002d368b0dc1acbe374645032ee7b6c9 starts 2726208
11-09 15:23:45.394 32640 32713 D ExposureNotification: First key with risk 8: 00303f9f86c32bcd27c6a643dc221658 starts 2726928
11-09 15:23:45.394 32640 32713 D ExposureNotification: First key with risk 2: 00401a78dbadafa1b3fc10a51261fd40 starts 2727360
11-09 15:23:45.394 32640 32713 D ExposureNotification: First key with risk 5: 0049032958fa67b5e0a2a795c217b778 starts 2726496
11-09 15:23:45.394 32640 32713 D ExposureNotification: First key with risk 6: 00545cbe65cf5f140794ababedfb6d81 starts 2726640
11-09 15:23:45.394 32640 32713 D ExposureNotification: First key with risk 8: 006b7d8b56976bc88f0df9d7fde1e19e starts 2726640
11-09 15:23:45.394 32640 32713 D ExposureNotification: First key with risk 8: 0085d4f3b229a9fd9b2a7413d5939138 starts 2727360
11-09 15:23:45.443 32640 32713 D ExposureNotification: Processed 9 keys, found 0 matches, ignored 4808 keys that are older than our scanning efforts (1636466250579)
11-09 15:23:45.449 32640 32713 D ExposureNotification: de.corona.tracing.test/TYZWQ32170AXEUVCDW7A processed 597532 keys (4817 new) in 0.267s -> 2147483.647 keys/s
```