### PR TITLE
Re-add daily RPI histogram database query

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt
@@ -673,6 +673,17 @@ class ExposureDatabase private constructor(private val context: Context) : SQLit
         }
     }
 
+    val rpiDayHistogram: Map<Long, Long>
+        get() = readableDatabase.run {
+            rawQuery("SELECT round(timestamp/(24*60*60*1000)), COUNT(*) FROM $TABLE_ADVERTISEMENTS WHERE timestamp > ? GROUP BY round(timestamp/(24*60*60*1000)) ORDER BY timestamp ASC;", arrayOf((Date().time - (14 * 24 * 60 * 60 * 1000)).toString())).use { cursor ->
+                val map = linkedMapOf<Long, Long>()
+                while (cursor.moveToNext()) {
+                    map[cursor.getLong(0)] = cursor.getLong(1)
+                }
+                map
+            }
+        }
+
     val rpiHourHistogram: Set<ExposureScanSummary>
         get() = readableDatabase.run {
             rawQuery("SELECT round(timestamp/(60*60*1000))*60*60*1000, COUNT(*), COUNT(*) FROM $TABLE_ADVERTISEMENTS WHERE timestamp > ? GROUP BY round(timestamp/(60*60*1000)) ORDER BY timestamp ASC;", arrayOf((System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000L)).toString())).use { cursor ->


### PR DESCRIPTION
With the database call from https://github.com/microg/GmsCore/blob/6e176cceed88214d9c797e74af8e30e98fd0e87a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/ExposureDatabase.kt#L676-L685 readded, we can (more easily) add the old bar chart back as a card inside CCTG:

![image](https://user-images.githubusercontent.com/16943720/142192577-b3a6a281-2fd8-41a8-848b-9139a47e9358.png)
