### PR TITLE
Use ENF version 1.1 to send confidence values

### DIFF
--- a/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/AdvertiserService.kt
+++ b/play-services-nearby-core/src/main/kotlin/org/microg/gms/nearby/exposurenotification/AdvertiserService.kt
@@ -36,7 +36,7 @@ import java.util.*
 @TargetApi(21)
 @ForegroundServiceInfo("Exposure Notification")
 class AdvertiserService : LifecycleService() {
-    private val version = VERSION_1_0
+    private val version = VERSION_1_1
     private var advertising = false
     private var wantStartAdvertising = false
     private val advertiser: BluetoothLeAdvertiser?


### PR DESCRIPTION
I have noticed that, while there is support for advertising with version 1.1 of the protocol to also advertise the confidence value of the device, this is not used as the version is fixed to 1.0