### PR TITLE
Prevent an ArrayIndexOutOfBoundsException when calling extension function LongSparseArray.values() in GoogleMap.kt

### DIFF
--- a/play-services-maps-core-mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps-core-mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -58,7 +58,7 @@ import org.microg.gms.maps.mapbox.utils.MultiArchLoader
 import org.microg.gms.maps.mapbox.utils.toGms
 import org.microg.gms.maps.mapbox.utils.toMapbox
 
-private fun <T : Any> LongSparseArray<T>.values() = (0..size()).map { valueAt(it) }.mapNotNull { it }
+private fun <T : Any> LongSparseArray<T>.values() = (0 until size()).mapNotNull { valueAt(it) }
 
 fun runOnMainLooper(method: () -> Unit) {
     if (Looper.myLooper() == Looper.getMainLooper()) {


### PR DESCRIPTION
Kotlin's `..` operator includes the upper bound contrary to `until`. Including the `size()` value of `LongSparseArray` produces an `ArrayIndexOutOfBoundsException`. This reproduces in the current (5.0.41 (550)) version of the Tisséo (fr.tisseo.android) application. Here is the stacktrace:

```
06-01 14:01:00.961 E/AndroidRuntime(24926): FATAL EXCEPTION: main
06-01 14:01:00.961 E/AndroidRuntime(24926): Process: fr.tisseo.android, PID: 24926
06-01 14:01:00.961 E/AndroidRuntime(24926): java.lang.ArrayIndexOutOfBoundsException: length=126; index=126
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at androidx.collection.LongSparseArray.valueAt(LongSparseArray.java:377)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at org.microg.gms.maps.mapbox.GoogleMapKt.values(GoogleMap.kt:61)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at org.microg.gms.maps.mapbox.GoogleMapKt.access$values(GoogleMap.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at org.microg.gms.maps.mapbox.GoogleMapImpl.applyMapType(GoogleMap.kt:347)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at org.microg.gms.maps.mapbox.GoogleMapImpl.setMapType(GoogleMap.kt:340)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at com.google.android.gms.maps.internal.IGoogleMapDelegate$Stub.onTransact(IGoogleMapDelegate.java:454)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at org.microg.gms.maps.mapbox.GoogleMapImpl.onTransact(GoogleMap.kt:808)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at android.os.Binder.transact(Binder.java:1043)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at k5.a.C(com.google.android.gms:play-services-maps@@18.0.0:2)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at p5.v.N0(com.google.android.gms:play-services-maps@@18.0.0:3)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at o5.c.n(com.google.android.gms:play-services-maps@@18.0.0:2)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fr.tisseo.android.fragment.map.MapFragment.w2(MapFragment.kt:7)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fr.tisseo.android.fragment.map.MapFragment.W1(MapFragment.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fr.tisseo.android.fragment.map.MapFragment$t.p(MapFragment.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fr.tisseo.android.fragment.map.MapFragment$t.u(Unknown Source:10)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at kotlinx.coroutines.flow.t$b$a.a(Collect.kt:5)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at kotlinx.coroutines.flow.i.c(Channels.kt:11)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at kotlinx.coroutines.flow.i.a(Channels.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at kotlinx.coroutines.flow.i$a.p(Unknown Source:11)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at jb.a.h(ContinuationImpl.kt:3)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.v0.run(DispatchedTask.kt:22)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.d1.d0(EventLoop.common.kt:3)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.w0.e(DispatchedTask.kt:6)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.w0.a(DispatchedTask.kt:8)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.k.q(CancellableContinuationImpl.kt:2)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.k.E(CancellableContinuationImpl.kt:2)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fe.a$a.t(AbstractChannel.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fe.d.z(ArrayChannel.kt:14)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fe.c.o(AbstractChannel.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at fe.g.o(Unknown Source:2)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at ge.x.a(SendingCollector.kt:1)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at kotlinx.coroutines.flow.b0.d(SharedFlow.kt:11)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at kotlinx.coroutines.flow.b0$c.p(Unknown Source:12)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at jb.a.h(ContinuationImpl.kt:3)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at de.v0.run(DispatchedTask.kt:22)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at android.os.Handler.handleCallback(Handler.java:938)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at android.os.Handler.dispatchMessage(Handler.java:99)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at android.os.Looper.loop(Looper.java:223)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at android.app.ActivityThread.main(ActivityThread.java:7664)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at java.lang.reflect.Method.invoke(Native Method)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
06-01 14:01:00.961 E/AndroidRuntime(24926): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```