### PR TITLE
Fido: implement FidoAppIdExtension constructor

### DIFF
--- a/play-services-fido-api/src/main/java/com/google/android/gms/fido/fido2/api/common/FidoAppIdExtension.java
+++ b/play-services-fido-api/src/main/java/com/google/android/gms/fido/fido2/api/common/FidoAppIdExtension.java
@@ -27,6 +27,13 @@ public class FidoAppIdExtension extends AutoSafeParcelable {
     @Field(2)
     private String appId;
 
+    private FidoAppIdExtension() {
+    }
+
+    public FidoAppIdExtension(String appId) {
+        this.appId = appId;
+    }
+
     public String getAppId() {
         return appId;
     }


### PR DESCRIPTION
FidoAppIdExtension class should have a constructor[1] with the appId argument.

[1] https://developers.google.com/android/reference/com/google/android/gms/fido/fido2/api/common/FidoAppIdExtension#public-constructors