### PR TITLE
Add the secondary Google package signature

### DIFF
--- a/play-services-base-core/src/main/java/org/microg/gms/common/PackageUtils.java
+++ b/play-services-base-core/src/main/java/org/microg/gms/common/PackageUtils.java
@@ -39,13 +39,15 @@ import java.util.Map;
 import static android.os.Build.VERSION.SDK_INT;
 import static org.microg.gms.common.Constants.GMS_PACKAGE_NAME;
 import static org.microg.gms.common.Constants.GMS_PACKAGE_SIGNATURE_SHA1;
+import static org.microg.gms.common.Constants.GMS_SECONDARY_PACKAGE_SIGNATURE_SHA1;
 
 public class PackageUtils {
 
     private static final String GOOGLE_PLATFORM_KEY = GMS_PACKAGE_SIGNATURE_SHA1;
+    private static final String GOOGLE_PLATFORM_KEY_2 = GMS_SECONDARY_PACKAGE_SIGNATURE_SHA1;
     private static final String GOOGLE_APP_KEY = "24bb24c05e47e0aefa68a58a766179d9b613a600";
     private static final String GOOGLE_LEGACY_KEY = "58e1c4133f7441ec3d2c270270a14802da47ba0e"; // Seems to be no longer used.
-    private static final String[] GOOGLE_PRIMARY_KEYS = {GOOGLE_PLATFORM_KEY, GOOGLE_APP_KEY};
+    private static final String[] GOOGLE_PRIMARY_KEYS = {GOOGLE_PLATFORM_KEY, GOOGLE_PLATFORM_KEY_2, GOOGLE_APP_KEY};
 
     private static final Map<String, String> KNOWN_GOOGLE_PACKAGES;
 

--- a/play-services-basement/src/main/java/org/microg/gms/common/Constants.java
+++ b/play-services-basement/src/main/java/org/microg/gms/common/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
     public static final String GMS_PACKAGE_NAME = "com.google.android.gms";
     public static final String GSF_PACKAGE_NAME = "com.google.android.gsf";
     public static final String GMS_PACKAGE_SIGNATURE_SHA1 = "38918a453d07199354f8b19af05ec6562ced5788";
+    public static final String GMS_SECONDARY_PACKAGE_SIGNATURE_SHA1 = "bd32424203e0fb25f36b57e5aa356f9bdd1da998";
     @Deprecated
     public static final int MAX_REFERENCE_VERSION = GMS_VERSION_CODE;
 }


### PR DESCRIPTION
Recently a lot of versions of Google Play Services and Google Play Store include two signatures.
I don't think we need to change something yet in the signature spoofing but we can at least prepare the code to accept it.

You can see it here:
- https://www.apkmirror.com/apk/google-inc/google-play-services/google-play-services-22-30-17-release/
- https://www.apkmirror.com/apk/google-inc/google-play-store/google-play-store-32-3-14-release/