### PR TITLE
use null initial dynamic link

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/firebase/dynamiclinks/DynamicLinksServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/firebase/dynamiclinks/DynamicLinksServiceImpl.java
@@ -39,7 +39,7 @@ public class DynamicLinksServiceImpl extends IDynamicLinksService.Stub {
 
     @Override
     public void getInitialLink(IDynamicLinksCallbacks callback, String link) throws RemoteException {
-        callback.onStatusDynamicLinkData(Status.SUCCESS, new DynamicLinkData());
+        callback.onStatusDynamicLinkData(Status.SUCCESS, null);
     }
 
 


### PR DESCRIPTION
Avoid sending empty initial links to apps, use null like stock GMS. Empty links can confuse apps such as Jitsi Meet when the proper link has already been delivered as an intent.