### PR TITLE
Increase build memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
+org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx3072m -Xmx3072m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
-org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx2048m -Xmx2048m -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
-org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx3072m -Xmx3072m -XX:+UseParallelGC
+org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx2048m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
-org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx2048m -XX:+UseParallelGC
+org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx2048m -Xmx2048m -XX:+UseParallelGC


### PR DESCRIPTION
Fixes build issue with JVM OOM, when user's build environment is not already setting these values to an increased memory amount in `~/.gradle/gradle.properties`