### PR TITLE
FIDO: Increase IsoDep timeout for NFC CTAP connection

### DIFF
--- a/play-services-fido-core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/CtapNfcConnection.kt
+++ b/play-services-fido-core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/CtapNfcConnection.kt
@@ -74,6 +74,7 @@ class CtapNfcConnection(
     }
 
     suspend fun open(): Boolean = withContext(Dispatchers.IO) {
+        isoDep.timeout = 5000
         isoDep.connect()
         val (statusCode, version) = select(FIDO2_AID)
         if (statusCode == 0x9000.toShort()) {


### PR DESCRIPTION
This PR increases the timeout for raw NFC transceive operations in the CTAP transport to 5 seconds.

This is needed because my phone (Galaxy S7) and my FIDO2 tag (NXP P71) are somewhat slow in terms of communication and computation (e.g. key generation). I assume many other users might run into these limitations. Without this increased timeout, the tag will be assumed lost while the applet is still computing `authenticatorMakeCredential`:

```
2022-10-25 11:26:14.457 32731-1529/com.google.android.gms D/FidoCtapNfcConnection: Selecting AID: oAAABkcvAAE=
2022-10-25 11:26:14.520 32731-1529/com.google.android.gms D/FidoCtapNfcConnection: Device sent version: FIDO_2_0
2022-10-25 11:26:14.522 32731-1529/com.google.android.gms D/FidoCtapNfcConnection: Send CTAP2 command: gBAAAAAAAQQ=
2022-10-25 11:26:14.642 32731-1529/com.google.android.gms D/FidoCtapNfcConnection: Received CTAP2 response(9000): AKQBgWhGSURPXzJfMANQ16QjrT4ZRJKSAHgTfczBNgSjYnJr9WJ1cPVidXb1BRkEsA==
2022-10-25 11:26:14.732 32731-1529/com.google.android.gms D/FidoCtapNfcConnection: Got info: AuthenticatorGetInfoResponse(versions=[], extensions=[], aaguid=[-41, -92, 35, -83, 62, 25, 68, -110, -110, 0, 120, 19, 125, -52, -63, 54], options=Options[platformDevice=false, residentKey=true, userPresence=true, userVerification=true, noMcGaPermissionsWithClientPin=false, makeCredUvNotRqd=false], maxMsgSize=1200, pinProtocols=[])
2022-10-25 11:26:14.749 32731-32731/com.google.android.gms D/FidoCtapNfcConnection: Send CTAP2 command: gBAAAAAAvgGlAVggAAvYS3skJH4OFjlik8L+2bTgNyYLK3LycToYzFrkcfQComJpZG9kZW1vLnl1Ymljby5jb21kbmFtZWpZdWJpY29EZW1vA6NiaWRYIF1gdkUkHdvwEKTodyOIQDPjBQ2buLNYqC5+RVM++e0iZG5hbWVwWXViaWNvIGRlbW8gdXNlcmtkaXNwbGF5TmFtZXBZdWJpY28gZGVtbyB1c2VyBIGiY2FsZyZkdHlwZWpwdWJsaWMta2V5B6A=
2022-10-25 11:26:15.653 32731-32731/com.google.android.gms W/FidoNfcHandler: android.nfc.TagLostException: Tag was lost.
        at android.nfc.TransceiveResult.getResponseOrThrow(TransceiveResult.java:48)
        at android.nfc.tech.BasicTagTechnology.transceive(BasicTagTechnology.java:151)
        at android.nfc.tech.IsoDep.transceive(IsoDep.java:172)
        at org.microg.gms.fido.core.transport.nfc.CtapNfcConnection.runCommand(CtapNfcConnection.kt:41)
        at org.microg.gms.fido.core.transport.TransportHandler.ctap2register(TransportHandler.kt:76)
        at org.microg.gms.fido.core.transport.TransportHandler.register$play_services_fido_core_debug(TransportHandler.kt:161)
        at org.microg.gms.fido.core.transport.nfc.NfcTransportHandler$register$2.invokeSuspend(NfcTransportHandler.kt:58)
        at org.microg.gms.fido.core.transport.nfc.NfcTransportHandler$register$2.invoke(Unknown Source:8)
        at org.microg.gms.fido.core.transport.nfc.NfcTransportHandler$register$2.invoke(Unknown Source:4)
        at org.microg.gms.fido.core.transport.nfc.CtapNfcConnection.open(CtapNfcConnection.kt:121)
        at org.microg.gms.fido.core.transport.nfc.CtapNfcConnection$open$3.invokeSuspend(Unknown Source:15)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at androidx.lifecycle.DispatchQueue.drainQueue(DispatchQueue.kt:75)
        at androidx.lifecycle.DispatchQueue.enqueue(DispatchQueue.kt:112)
        at androidx.lifecycle.DispatchQueue.dispatchAndEnqueue$lambda-2$lambda-1(DispatchQueue.kt:100)
        at androidx.lifecycle.DispatchQueue.$r8$lambda$G2ay370n_s_ksSHUJaD9zIU8eCw(Unknown Source:0)
        at androidx.lifecycle.DispatchQueue$$ExternalSyntheticLambda0.run(Unknown Source:4)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6718)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
2022-10-25 11:26:15.682 32731-32731/com.google.android.gms D/FidoUi: NFC status set to waiting-for-device (null)
```

I tested 5 seconds, and it works fine. But you can increase it if you want.

See also: https://developer.android.com/reference/android/nfc/tech/IsoDep#setTimeout(int)

