### PR TITLE
Specify targetPackage for intents from Authenticator Preferences

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -543,7 +543,6 @@
 
         <activity
             android:name="org.microg.gms.ui.AccountSettingsActivity"
-            android:exported="true"
             android:process=":ui"
             android:taskAffinity="org.microg.gms.settings">
             <intent-filter>

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -543,6 +543,7 @@
 
         <activity
             android:name="org.microg.gms.ui.AccountSettingsActivity"
+            android:exported="true"
             android:process=":ui"
             android:taskAffinity="org.microg.gms.settings">
             <intent-filter>

--- a/play-services-core/src/main/res/xml/preferences_auth.xml
+++ b/play-services-core/src/main/res/xml/preferences_auth.xml
@@ -18,16 +18,22 @@
     <PreferenceScreen
         android:key="k2"
         android:title="@string/prefs_account_security">
-        <intent android:action="com.google.android.gms.accountsettings.SECURITY_SETTINGS"/>
+        <intent
+            android:action="com.google.android.gms.accountsettings.SECURITY_SETTINGS"
+            android:targetPackage="com.google.android.gms" />
     </PreferenceScreen>
     <PreferenceScreen
         android:key="k3"
         android:title="@string/prefs_account_privacy">
-        <intent android:action="com.google.android.gms.accountsettings.PRIVACY_SETTINGS"/>
+        <intent
+            android:action="com.google.android.gms.accountsettings.PRIVACY_SETTINGS"
+            android:targetPackage="com.google.android.gms" />
     </PreferenceScreen>
     <PreferenceScreen
         android:key="k4"
         android:title="@string/prefs_account">
-        <intent android:action="com.google.android.gms.accountsettings.ACCOUNT_PREFERENCES_SETTINGS"/>
+        <intent
+            android:action="com.google.android.gms.accountsettings.ACCOUNT_PREFERENCES_SETTINGS"
+            android:targetPackage="com.google.android.gms" />
     </PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
Turns out that those intents may resolve to activities from Vanced microG, resulting a UID mismatch between resolved app (Vanced) and authenticator app (microG).

Validated by uninstalling Vanced microG, after which the AccountSettingsActivity launched as expected.

This is an attempt to eliminate the conflict.

Logcat from Settings app:
```
AccountTypePrefLoader: Refusing to launch authenticator intent becauseit exploits Settings permissions: Intent { act=com.google.android.gms.accountsettings.PRIVACY_SETTINGS flg=0x10000000 (has extras) }
```

Reference: https://cs.android.com/android/platform/superproject/+/master:packages/apps/Settings/src/com/android/settings/accounts/AccountTypePreferenceLoader.java;l=166;drc=6d97d6d7215fef247d1a90e05545cac3676f9212?q=Refusing%20to%20launch%20authenticator%20intent&ss=android