### PR TITLE
Fix calling parameters of Dot for PatternItem

### DIFF
--- a/play-services-maps/src/main/java/com/google/android/gms/maps/model/Dot.java
+++ b/play-services-maps/src/main/java/com/google/android/gms/maps/model/Dot.java
@@ -21,7 +21,7 @@ public final class Dot extends PatternItem {
      * Constructs a {@code Dot}.
      */
     public Dot() {
-        super(1, null);
+        super(1, 0.0f);
     }
 
     @NonNull


### PR DESCRIPTION
This is a minor change fixing #1886. The Skanetrafiken app now is able to display footpaths.
Thanks to @raminou who found the issue that the length argument must be of type Float.

Unfortunately I was not able to test the other apps affected by this issue (cf #1906)

Screenshot of the working view:

![working](https://user-images.githubusercontent.com/5196262/233808949-71c7df8e-2d5d-4aea-abfd-ab675645d3fd.png)

Zoomed in section of the footpath:

![footpath](https://user-images.githubusercontent.com/5196262/233808947-73288c79-f0e2-4b5f-88b9-fd0954588082.png)
