### PR TITLE
Update mapbox libraries

### DIFF
--- a/play-services-maps-core-mapbox/build.gradle
+++ b/play-services-maps-core-mapbox/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     implementation project(':play-services-maps')
     implementation project(':play-services-base-core')
     implementation project(':play-services-location')
-    implementation("org.maplibre.gl:android-sdk:10.0.0")
-    implementation("org.maplibre.gl:android-plugin-annotation-v9:1.0.0") {
+    implementation("org.maplibre.gl:android-sdk:10.2.0")
+    implementation("org.maplibre.gl:android-plugin-annotation-v9:2.0.0") {
         exclude group: 'com.google.android.gms'
     }
     implementation 'org.maplibre.gl:android-sdk-turf:5.9.0'

--- a/play-services-maps-core-mapbox/src/main/AndroidManifest.xml
+++ b/play-services-maps-core-mapbox/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
-    <uses-sdk tools:overrideLibrary="com.mapbox.mapboxsdk" />
+    <uses-sdk tools:overrideLibrary="com.mapbox.mapboxsdk, com.mapbox.mapboxsdk.plugins.annotation" />
 
     <application />
 


### PR DESCRIPTION
This fixes #969 but requires setting the minimum Android version to 5.0. It may need more testing since breaking changes may be present in org.maplibre.gl:android-sdk.