### PR TITLE
Set max auto heartbeat interval to 15min

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/gcm/GcmPrefs.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/gcm/GcmPrefs.kt
@@ -39,7 +39,7 @@ data class GcmPrefs(
         const val PREF_NETWORK_OTHER = Gcm.NETWORK_OTHER
 
         private const val MIN_INTERVAL = 5 * 60 * 1000 // 5 minutes
-        private const val MAX_INTERVAL = 30 * 60 * 1000 // 30 minutes
+        private const val MAX_INTERVAL = 15 * 60 * 1000 // 15 minutes
 
         @JvmStatic
         fun get(context: Context): GcmPrefs {


### PR DESCRIPTION
The previous maximum of 30 minutes is too high for a worst case, potentially resulting in massive notification delays on any network but especially on certain less-reliable networks.