### PR TITLE
Keep Conscrypt and Dynamite Loader in the primary dex file otherwise it will error out on legacy Android versions, fix #2023

### DIFF
--- a/play-services-core/multidex-keep.pro
+++ b/play-services-core/multidex-keep.pro
@@ -1,5 +1,9 @@
-# Make sure maps is in primary dex file
+# Make sure maps is in the primary dex file
 -keep class com.google.android.gms.maps.** { *; }
 -keep class org.microg.gms.maps.** { *; }
 -keep class com.mapbox.** { *; }
 -keep class org.oscim.** { *; }
+
+# Make sure these classes are in the primary dex file otherwise Conscrypt will error out on legacy Android versions
+-keep class com.google.android.gms.common.security.ProviderInstallerImpl { *; }
+-keep class com.google.android.gms.org.conscrypt.** { *; }

--- a/play-services-core/multidex-keep.pro
+++ b/play-services-core/multidex-keep.pro
@@ -4,6 +4,9 @@
 -keep class com.mapbox.** { *; }
 -keep class org.oscim.** { *; }
 
-# Make sure these classes are in the primary dex file otherwise Conscrypt will error out on legacy Android versions
+# Keep Dynamite Loader in the primary dex file otherwise it will error out on legacy Android versions
+-keep class com.google.android.gms.chimera.container.DynamiteLoaderImpl { *; }
+
+# Keep Conscrypt in the primary dex file otherwise it will error out on legacy Android versions
 -keep class com.google.android.gms.common.security.ProviderInstallerImpl { *; }
 -keep class com.google.android.gms.org.conscrypt.** { *; }


### PR DESCRIPTION
@mar-v-in
It doesn't fix all the problems in the logcat but it at least allow to reach the phase of:
`D/GmsProviderInstaller( 1270): Installed default security provider GmsCore_OpenSSL`
and so the sync adapter can sync correctly.