### PR TITLE
Fix user profile behavior

### DIFF
--- a/play-services-base/core/src/main/kotlin/org/microg/gms/profile/ProfileManager.kt
+++ b/play-services-base/core/src/main/kotlin/org/microg/gms/profile/ProfileManager.kt
@@ -96,8 +96,7 @@ object ProfileManager {
     private fun getProfileData(context: Context, profile: String, realData: Map<String, String>): Map<String, String> {
         try {
             if (profile in listOf(PROFILE_REAL, PROFILE_NATIVE)) return realData
-            val profileResId = getProfileResId(context, profile)
-            if (profileResId == 0) return realData
+            if (profile != PROFILE_USER && getProfileResId(context, profile) == 0) return realData
             val resultData = mutableMapOf<String, String>()
             resultData.putAll(realData)
             val parser = getProfileXml(context, profile)


### PR DESCRIPTION
User profile was not read at the time the SafetyNet request is done because getProfileResId() was returning 0 in that case.

We need to check profile resources id only when user profile is not selected.