### PR TITLE
Add a missing null check in GamesService

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/games/GamesService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/games/GamesService.kt
@@ -71,7 +71,7 @@ class GamesService : BaseService(TAG, GmsService.GAMES) {
 
         lifecycleScope.launchWhenStarted {
             try {
-                val account = request.account.takeIf { it.name != AuthConstants.DEFAULT_ACCOUNT }
+                val account = request.account?.takeIf { it.name != AuthConstants.DEFAULT_ACCOUNT }
                     ?: GamesConfigurationService.getDefaultAccount(this@GamesService, packageName)
                     ?: return@launchWhenStarted sendSignInRequired()
 


### PR DESCRIPTION
Fixes a warning I noticed when launching Clash Royale. It worked regardless, but it might help in other games.