### PR TITLE
fixes unhandled NullPointerException for styleOperations

### DIFF
--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/Styles.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/Styles.kt
@@ -111,7 +111,7 @@ fun getFallbackStyleOnlineUri(mapType: Int) = when (mapType) {
 
 fun MapStyleOptions.apply(style: JSONObject) {
     try {
-        Gson().fromJson(json, Array<StyleOperation>::class.java).let { styleOperations ->
+        Gson().fromJson(json, Array<StyleOperation>::class.java)?.let { styleOperations ->
 
             val layerArray = style.getJSONArray(KEY_LAYERS)
 


### PR DESCRIPTION
If the `json` String of the `MapStyleOptions` is empty, then the result of `Gson().fromJson(json, ...)` will be null which currently leads to an unhandled NullPointerException as soon as `styleOperations` is accessed causing an application crash:

```
java.lang.NullPointerException: styleOperations must not be null
    at org.microg.gms.maps.mapbox.StylesKt.apply(Styles.kt:119)
    at org.microg.gms.maps.mapbox.StylesKt.getStyle(Styles.kt:79)
    at org.microg.gms.maps.mapbox.StylesKt.getStyle$default(Styles.kt:42)
    at org.microg.gms.maps.mapbox.GoogleMapImpl.applyMapStyle(GoogleMap.kt:385)
    at org.microg.gms.maps.mapbox.GoogleMapImpl.setMapType(GoogleMap.kt:371)
```

The crash doesn't occur on phones that use Google Play Services; therefore, the null check fixes the crash and aligns the API with the proprietary services.