### PR TITLE
Introduce a new AccountsFragment to store accounts related prefs

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/ui/AccountsFragment.kt
+++ b/play-services-core/src/main/java/org/microg/gms/ui/AccountsFragment.kt
@@ -1,0 +1,53 @@
+package org.microg.gms.ui
+
+import android.accounts.AccountManager
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
+import androidx.preference.PreferenceFragmentCompat
+import com.google.android.gms.R
+import org.microg.gms.auth.AuthConstants
+
+class AccountsFragment : PreferenceFragmentCompat() {
+
+    private val TAG = AccountsFragment::class.java.simpleName
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.preferences_accounts)
+
+        val accountManager = AccountManager.get(requireContext())
+        val accounts = accountManager.getAccountsByType(AuthConstants.DEFAULT_ACCOUNT_TYPE)
+
+        findPreference<Preference>("pref_current_accounts_none")?.isVisible = accounts.isEmpty()
+        val preferenceCategory = findPreference<PreferenceCategory>("prefcat_current_accounts")
+        accounts.forEach {
+            Preference(requireContext()).apply {
+                title = it.name
+                icon = ContextCompat.getDrawable(
+                    requireContext(),
+                    R.drawable.proprietary_auth_gls_ic_google_minitab_selected
+                )
+                preferenceCategory?.addPreference(this)
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        findPreference<Preference>("pref_manage_accounts")?.setOnPreferenceClickListener {
+            try {
+                startActivity(Intent(Settings.ACTION_SYNC_SETTINGS))
+            } catch (activityNotFoundException: ActivityNotFoundException) {
+                Log.e(TAG, "Failed to launch sync settings", activityNotFoundException)
+            }
+            true
+        }
+    }
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/SettingsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/SettingsFragment.kt
@@ -27,6 +27,10 @@ class SettingsFragment : ResourceSettingsFragment() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         super.onCreatePreferences(savedInstanceState, rootKey)
 
+        findPreference<Preference>(PREF_ACCOUNTS)!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            findNavController().navigate(requireContext(), R.id.accountManagerFragment)
+            true
+        }
         findPreference<Preference>(PREF_CHECKIN)!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             findNavController().navigate(requireContext(), R.id.openCheckinSettings)
             true
@@ -131,6 +135,7 @@ class SettingsFragment : ResourceSettingsFragment() {
         const val PREF_LOCATION = "pref_location"
         const val PREF_CHECKIN = "pref_checkin"
         const val PREF_VENDING = "pref_vending"
+        const val PREF_ACCOUNTS = "pref_accounts"
     }
 
     init {

--- a/play-services-core/src/main/res/navigation/nav_settings.xml
+++ b/play-services-core/src/main/res/navigation/nav_settings.xml
@@ -44,6 +44,13 @@
         android:name="org.microg.gms.ui.SelfCheckFragment"
         android:label="@string/self_check_title" />
 
+    <!-- Account -->
+
+    <fragment
+        android:id="@+id/accountManagerFragment"
+        android:name="org.microg.gms.ui.AccountsFragment"
+        android:label="@string/pref_accounts_title" />
+
     <!-- Device registration -->
 
     <fragment

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -137,8 +137,15 @@ This can take a couple of minutes."</string>
     <string name="pref_info_status">Status</string>
     <string name="pref_more_settings">More</string>
 
+    <string name="pref_accounts_title">Accounts</string>
+    <string name="pref_accounts_summary">Add and manage Google accounts</string>
+    <string name="prefcat_accounts_settings_title">Settings</string>
+    <string name="prefcat_accounts_current_accounts_title">Currently signed-in accounts</string>
+    <string name="pref_accounts_manage_accounts_title">Manage accounts</string>
+    <string name="pref_accounts_manage_accounts_summary">Manage existing accounts settings</string>
     <string name="pref_add_account_title">Account</string>
     <string name="pref_add_account_summary">Add Google account</string>
+
     <string name="pref_gcm_enable_mcs_summary">Cloud Messaging is a push notification provider used by many third-party applications. To use it you must enable device registration.</string>
     <string name="pref_gcm_heartbeat_title">Cloud Messaging heartbeat interval</string>
     <string name="pref_gcm_heartbeat_summary">The interval in seconds for the system to heartbeat the Google servers. Increasing this number will reduce battery consumption, but might cause delays on push messages.\nDeprecated, will be replaced in future release.</string>

--- a/play-services-core/src/main/res/xml/preferences_accounts.xml
+++ b/play-services-core/src/main/res/xml/preferences_accounts.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory
+        android:key="prefcat_current_accounts"
+        android:title="@string/prefcat_accounts_current_accounts_title">
+        <Preference
+            android:enabled="false"
+            android:key="pref_current_accounts_none"
+            android:title="@string/list_no_item_none" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:key="prefcat_account_settings"
+        android:title="@string/prefcat_accounts_settings_title">
+        <Preference
+            android:summary="@string/pref_add_account_summary"
+            android:title="@string/pref_add_account_title">
+            <intent
+                android:targetClass="org.microg.gms.auth.login.LoginActivity"
+                android:targetPackage="com.google.android.gms" />
+        </Preference>
+        <Preference
+            android:key="pref_manage_accounts"
+            android:summary="@string/pref_accounts_manage_accounts_summary"
+            android:title="@string/pref_accounts_manage_accounts_title" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/play-services-core/src/main/res/xml/preferences_start.xml
+++ b/play-services-core/src/main/res/xml/preferences_start.xml
@@ -29,12 +29,9 @@
     <PreferenceCategory android:title="@string/prefcat_google_services" android:key="prefcat_google_services">
         <Preference
             android:icon="@drawable/ic_add_account"
-            android:summary="@string/pref_add_account_summary"
-            android:title="@string/pref_add_account_title">
-            <intent
-                android:targetClass="org.microg.gms.auth.login.LoginActivity"
-                android:targetPackage="com.google.android.gms" />
-        </Preference>
+            android:key="pref_accounts"
+            android:summary="@string/pref_accounts_summary"
+            android:title="@string/pref_accounts_title" />
         <Preference
             android:icon="@drawable/ic_device_login"
             android:key="pref_checkin"


### PR DESCRIPTION
## Summary

Add a new fragment to host preferences that concern accounts or data related to them.

* Show currently logged-in accounts as a simple list on the top
* Relocate add account preference below.
* Add a new preference to open account settings page to manage all accounts quickly.