### PR TITLE
Added new domain name to Google Maps Timeline

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
@@ -108,6 +108,7 @@ private val ALLOWED_WEB_PREFIXES = setOf(
     "https://payments.google.com/",
     "https://policies.google.com/",
     "https://fit.google.com/privacy/settings",
+    "https://maps.google.com/maps/timeline"
 )
 
 private val ACTION_TO_SCREEN_ID = hashMapOf(


### PR DESCRIPTION
The Google Maps Timeline function cannot be used properly because the domain name has changed.