### PR TITLE
Workaround implementation for `onMapLoadedCallback`

### DIFF
--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -527,12 +527,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
         if (callback != null) {
             synchronized(mapLock) {
                 if (loaded) {
-                    Log.d(TAG, "Invoking callback instantly, as map is loaded")
-                    try {
-                        callback.onMapLoaded()
-                    } catch (e: Exception) {
-                        Log.w(TAG, e)
-                    }
+                    callback.scheduleExecute()
                 } else {
                     Log.d(TAG, "Delay callback invocation, as map is not yet loaded")
                     loadedCallback = callback
@@ -768,10 +763,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
 
                 synchronized(mapLock) {
                     loaded = true
-                    if (loadedCallback != null) {
-                        Log.d(TAG, "Invoking callback delayed, as map is loaded")
-                        loadedCallback?.onMapLoaded()
-                    }
+                    loadedCallback?.scheduleExecute()
                 }
 
                 isMyLocationEnabled = locationEnabled
@@ -854,7 +846,29 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
         tryRunUserInitializedCallbacks("getMapAsync")
     }
 
+    /**
+     * Per docs, `onMapLoaded` shall only be called when the map has finished loading,
+     * and some apps like Signal location sharing rely on this to behave accordingly.
+     * However, MapLibre does not provide proper `onMapLoaded` callbacks.
+     *
+     * Workaround: schedule map loaded callback for a certain time in the future.
+     */
+    private fun IOnMapLoadedCallback.scheduleExecute() {
+        Log.d(TAG, "Scheduling executing of OnMapLoadedCallback in ${ON_MAP_LOADED_CALLBACK_DELAY}ms, as map is now initialized.")
+        Handler(Looper.getMainLooper()).postDelayed({
+            Log.d(TAG, "Executing scheduled onMapLoaded callback")
+
+            try {
+                this.onMapLoaded()
+            } catch (e: Exception) {
+                Log.w(TAG, e)
+            }
+
+        }, ON_MAP_LOADED_CALLBACK_DELAY)
+    }
+
     private var isInvokingInitializedCallbacks = AtomicBoolean(false)
+
     fun tryRunUserInitializedCallbacks(tag: String = "") {
 
         synchronized(mapLock) {
@@ -909,6 +923,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
             }
 
     companion object {
-        private val TAG = "GmsMap"
+        private const val TAG = "GmsMap"
+        private const val ON_MAP_LOADED_CALLBACK_DELAY = 500L
     }
 }


### PR DESCRIPTION
With this implementation, a delay is added before calling back an `onMapLoadedCallback`.

Issues:

* As it is just a workaround, it does not guarantee that the map is actually loaded. Thus the snapshot Signal takes can still be empty – however, if the map was zoomed in previously, the tiles are already cached and will be rendered correctly within the 500ms delay. (Unlike a _completely_ empty snapshot, not showing even the MapLibre logo, that was the result before.)
* <del>Sometimes there is a crash in Signal that I still need to investigate where it is coming from.</del> (https://github.com/signalapp/Signal-Android/pull/13461)

Fixes https://github.com/microg/GmsCore/issues/1960. Re. https://github.com/signalapp/Signal-Android/issues/12723#issuecomment-1595810834, see also https://github.com/signalapp/Signal-Android/issues/13006.

![signal-location-sharing](https://github.com/microg/GmsCore/assets/16943720/58ae8b41-d7ec-4afa-8729-6793214b7255)