### PR TITLE
Location: handle invalid or dead old binder on location request update

### DIFF
--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LocationRequestManager.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LocationRequestManager.kt
@@ -83,7 +83,11 @@ class LocationRequestManager(private val context: Context, private val lifecycle
 
     suspend fun update(oldBinder: IBinder, binder: IBinder, clientIdentity: ClientIdentity, callback: ILocationCallback, request: LocationRequest, lastLocationCapsule: LastLocationCapsule) {
         lock.withLock {
-            oldBinder.unlinkToDeath(this, 0)
+            try {
+                oldBinder.unlinkToDeath(this, 0)
+            } catch (e: Exception) {
+                Log.w(TAG, "update: ", e)
+            }
             val holder = binderRequests.remove(oldBinder)
             try {
                 val startedHolder = holder?.update(callback, request) ?: LocationRequestHolder(context, clientIdentity, request, callback, null).start().also {


### PR DESCRIPTION
…it is opened for the first time.