### PR TITLE
Allow using FIDO2 authenticators with a PIN

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -24,6 +24,7 @@ import java.net.HttpURLConnection
 import java.security.MessageDigest
 
 class RequestHandlingException(val errorCode: ErrorCode, message: String? = null) : Exception(message)
+class MissingPinException(message: String? = null): Exception(message)
 
 enum class RequestOptionsType { REGISTER, SIGN }
 
@@ -148,14 +149,6 @@ private suspend fun isAppIdAllowed(context: Context, appId: String, facetId: Str
 }
 
 suspend fun RequestOptions.checkIsValid(context: Context, facetId: String, packageName: String?) {
-    if (type == REGISTER) {
-        if (registerOptions.authenticatorSelection?.requireResidentKey == true) {
-            throw RequestHandlingException(
-                NOT_SUPPORTED_ERR,
-                "Resident credentials or empty 'allowCredentials' lists are not supported  at this time."
-            )
-        }
-    }
     if (type == SIGN) {
         if (signOptions.allowList.isNullOrEmpty()) {
             throw RequestHandlingException(NOT_ALLOWED_ERR, "Request doesn't have a valid list of allowed credentials.")

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -25,6 +25,7 @@ import java.security.MessageDigest
 
 class RequestHandlingException(val errorCode: ErrorCode, message: String? = null) : Exception(message)
 class MissingPinException(message: String? = null): Exception(message)
+class WrongPinException(message: String? = null): Exception(message)
 
 enum class RequestOptionsType { REGISTER, SIGN }
 

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/CoseKey.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/CoseKey.kt
@@ -19,20 +19,22 @@ class CoseKey(
     constructor(algorithm: Algorithm, x: BigInteger, y: BigInteger, curveId: Int, curvePointSize: Int) :
             this(algorithm, x.toByteArray(curvePointSize), y.toByteArray(curvePointSize), curveId)
 
-    fun encode(): ByteArray = CBORObject.NewMap().apply {
+    fun encode(): ByteArray = encodeAsCbor().EncodeToBytes(CBOREncodeOptions.DefaultCtap2Canonical)
+
+    fun encodeAsCbor(): CBORObject = CBORObject.NewMap().apply {
         set(KTY, 2.encodeAsCbor())
         set(ALG, algorithm.algoValue.encodeAsCbor())
         set(CRV, curveId.encodeAsCbor())
         set(X, x.encodeAsCbor())
         set(Y, y.encodeAsCbor())
-    }.EncodeToBytes(CBOREncodeOptions.DefaultCtap2Canonical)
+    }
 
     companion object {
-        private const val KTY = 1
-        private const val ALG = 3
-        private const val CRV = -1
-        private const val X = -2
-        private const val Y = -3
+        const val KTY = 1
+        const val ALG = 3
+        const val CRV = -1
+        const val X = -2
+        const val Y = -3
 
         fun BigInteger.toByteArray(size: Int): ByteArray {
             val res = ByteArray(size)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
@@ -37,6 +37,18 @@ class AuthenticatorClientPINRequest(
                 "newPinEnc=${newPinEnc?.contentToString()}, " +
                 "pinHashEnc=${pinHashEnc?.contentToString()})"
     }
+
+    companion object {
+        // PIN protocol versions
+        const val PIN_PROTOCOL_VERSION_ONE = 0x01
+
+        // PIN subcommands
+        const val GET_RETRIES = 0x01
+        const val GET_KEY_AGREEMENT = 0x02
+        const val SET_PIN = 0x03
+        const val CHANGE_PIN = 0x04
+        const val GET_PIN_TOKEN = 0x05
+    }
 }
 
 class AuthenticatorClientPINResponse(

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
@@ -1,0 +1,54 @@
+package org.microg.gms.fido.core.protocol.msgs
+
+import com.upokecenter.cbor.CBORObject
+import org.microg.gms.fido.core.protocol.CoseKey
+import org.microg.gms.fido.core.protocol.decodeAsCoseKey
+import org.microg.gms.fido.core.protocol.encodeAsCbor
+
+class AuthenticatorClientPINCommand(request: AuthenticatorClientPINRequest) :
+    Ctap2Command<AuthenticatorClientPINRequest, AuthenticatorClientPINResponse>(request) {
+
+    override fun decodeResponse(obj: CBORObject) = AuthenticatorClientPINResponse.decodeFromCbor(obj)
+
+    override val timeout: Long
+        get() = 60000
+
+}
+
+class AuthenticatorClientPINRequest(
+    val pinProtocol: Int,
+    val subCommand: Int,
+    val keyAgreement: CoseKey? = null,
+    val pinAuth: ByteArray? = null,
+    val newPinEnc: ByteArray? = null,
+    val pinHashEnc: ByteArray? = null
+) : Ctap2Request(0x06, CBORObject.NewMap().apply {
+    set(0x01, pinProtocol.encodeAsCbor())
+    set(0x02, subCommand.encodeAsCbor())
+    if (keyAgreement != null) set(0x03, keyAgreement.encodeAsCbor())
+    if (pinAuth != null) set(0x04, pinAuth.encodeAsCbor())
+    if (newPinEnc != null) set(0x05, newPinEnc.encodeAsCbor())
+    if (pinHashEnc != null) set(0x06, pinHashEnc.encodeAsCbor())
+}) {
+    override fun toString(): String {
+        return "AuthenticatorClientPINRequest(pinProtocol=$pinProtocol, " +
+                "subCommand=$subCommand, keyAgreement=$keyAgreement, " +
+                "pinAuth=${pinAuth?.contentToString()}, " +
+                "newPinEnc=${newPinEnc?.contentToString()}, " +
+                "pinHashEnc=${pinHashEnc?.contentToString()})"
+    }
+}
+
+class AuthenticatorClientPINResponse(
+    val keyAgreement: CoseKey?,
+    val pinToken: ByteArray?,
+    val retries: Int?
+) : Ctap2Response {
+    companion object {
+        fun decodeFromCbor(obj: CBORObject) = AuthenticatorClientPINResponse(
+            obj.get(0x01)?.decodeAsCoseKey(),
+            obj.get(0x02)?.GetByteString(),
+            obj.get(0x03)?.AsInt32Value()
+        )
+    }
+}

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
@@ -452,6 +452,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                             !pinRequested &&
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                             (
+                                    options.signOptions.requireUserVerification == null ||
                                     options.signOptions.requireUserVerification == REQUIRED ||
                                     options.signOptions.requireUserVerification == PREFERRED
                             )

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/CtapNfcConnection.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/CtapNfcConnection.kt
@@ -41,12 +41,16 @@ class CtapNfcConnection(
         Log.d(TAG, "Send CTAP2 command: ${request.toBase64(Base64.NO_WRAP)}")
         var (statusCode, payload) = decodeResponseApdu(isoDep.transceive(request))
         Log.d(TAG, "Received CTAP2 response(${(statusCode.toInt() and 0xffff).toString(16)}): ${payload.toBase64(Base64.NO_WRAP)}")
-        while (statusCode == 0x9100.toShort()) {
+        while (statusCode == 0x9100.toShort() || (statusCode > 0x6100.toShort() && statusCode < 0x6200.toShort())) {
             Log.d(TAG, "Sending GETRESPONSE")
             val res = decodeResponseApdu(isoDep.transceive(encodeCommandApdu(0x00, 0xC0.toByte(), 0x00,0x00)))
             Log.d(TAG, "Received CTAP2 response(${(statusCode.toInt() and 0xffff).toString(16)}): ${payload.toBase64(Base64.NO_WRAP)}")
+            if (statusCode < 0x6200.toShort()) {
+                payload = payload.plus(res.second)
+            } else {
+                payload = res.second
+            }
             statusCode = res.first
-            payload = res.second
         }
         if (statusCode != 0x9000.toShort()) {
             throw CtapNfcMessageStatusException(statusCode.toInt() and 0xffff)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import org.microg.gms.fido.core.MissingPinException
 import org.microg.gms.fido.core.RequestOptionsType
+import org.microg.gms.fido.core.WrongPinException
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
 import org.microg.gms.fido.core.transport.TransportHandlerCallback
@@ -106,6 +107,8 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: MissingPinException) {
+                    throw e
+                } catch (e: WrongPinException) {
                     throw e
                 } catch (e: Exception) {
                     Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
@@ -22,6 +22,7 @@ import com.google.android.gms.fido.fido2.api.common.AuthenticatorResponse
 import com.google.android.gms.fido.fido2.api.common.RequestOptions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import org.microg.gms.fido.core.MissingPinException
 import org.microg.gms.fido.core.RequestOptionsType
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
@@ -53,20 +54,24 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
     suspend fun register(
         options: RequestOptions,
         callerPackage: String,
-        tag: Tag
+        tag: Tag,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAttestationResponse {
         return CtapNfcConnection(activity, tag).open {
-            register(it, activity, options, callerPackage)
+            register(it, activity, options, callerPackage, pinRequested, pin)
         }
     }
 
     suspend fun sign(
         options: RequestOptions,
         callerPackage: String,
-        tag: Tag
+        tag: Tag,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAssertionResponse {
         return CtapNfcConnection(activity, tag).open {
-            sign(it, activity, options, callerPackage)
+            sign(it, activity, options, callerPackage, pinRequested, pin)
         }
     }
 
@@ -74,16 +79,18 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
     suspend fun handle(
         options: RequestOptions,
         callerPackage: String,
-        tag: Tag
+        tag: Tag,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorResponse {
         return when (options.type) {
-            RequestOptionsType.REGISTER -> register(options, callerPackage, tag)
-            RequestOptionsType.SIGN -> sign(options, callerPackage, tag)
+            RequestOptionsType.REGISTER -> register(options, callerPackage, tag, pinRequested, pin)
+            RequestOptionsType.SIGN -> sign(options, callerPackage, tag, pinRequested, pin)
         }
     }
 
 
-    override suspend fun start(options: RequestOptions, callerPackage: String): AuthenticatorResponse {
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse {
         val adapter = NfcAdapter.getDefaultAdapter(activity)
         val newIntentListener = Consumer<Intent> {
             if (it?.action != NfcAdapter.ACTION_TECH_DISCOVERED) return@Consumer
@@ -95,8 +102,10 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
             while (true) {
                 val tag = waitForNewNfcTag(adapter)
                 try {
-                    return handle(options, callerPackage, tag)
+                    return handle(options, callerPackage, tag, pinRequested, pin)
                 } catch (e: CancellationException) {
+                    throw e
+                } catch (e: MissingPinException) {
                     throw e
                 } catch (e: Exception) {
                     Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
@@ -230,7 +230,7 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
     }
 
     @RequiresApi(24)
-    override suspend fun start(options: RequestOptions, callerPackage: String): AuthenticatorResponse =
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse =
         when (options.type) {
             RequestOptionsType.REGISTER -> register(options, callerPackage)
             RequestOptionsType.SIGN -> sign(options, callerPackage)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -150,7 +150,9 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
                 throw e
             } catch (e: MissingPinException) {
                 throw e
-            } catch (e: Exception) {
+            } catch (e: WrongPinException) {
+                throw e
+            }  catch (e: Exception) {
                 Log.w(TAG, e)
             }
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -81,10 +81,12 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
         options: RequestOptions,
         callerPackage: String,
         device: UsbDevice,
-        iface: UsbInterface
+        iface: UsbInterface,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAttestationResponse {
         return CtapHidConnection(context, device, iface).open {
-            register(it, context, options, callerPackage)
+            register(it, context, options, callerPackage, pinRequested, pin)
         }
     }
 
@@ -92,10 +94,12 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
         options: RequestOptions,
         callerPackage: String,
         device: UsbDevice,
-        iface: UsbInterface
+        iface: UsbInterface,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAssertionResponse {
         return CtapHidConnection(context, device, iface).open {
-            sign(it, context, options, callerPackage)
+            sign(it, context, options, callerPackage, pinRequested, pin)
         }
     }
 
@@ -119,7 +123,9 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
         options: RequestOptions,
         callerPackage: String,
         device: UsbDevice,
-        iface: UsbInterface
+        iface: UsbInterface,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorResponse {
         Log.d(TAG, "Trying to use ${device.productName} for ${options.type}")
         invokeStatusChanged(
@@ -127,20 +133,22 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
             Bundle().apply { putParcelable(UsbManager.EXTRA_DEVICE, device) })
         try {
             return when (options.type) {
-                RequestOptionsType.REGISTER -> register(options, callerPackage, device, iface)
-                RequestOptionsType.SIGN -> sign(options, callerPackage, device, iface)
+                RequestOptionsType.REGISTER -> register(options, callerPackage, device, iface, pinRequested, pin)
+                RequestOptionsType.SIGN -> sign(options, callerPackage, device, iface, pinRequested, pin)
             }
         } finally {
             this.device = null
         }
     }
 
-    override suspend fun start(options: RequestOptions, callerPackage: String): AuthenticatorResponse {
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse {
         for (device in context.usbManager?.deviceList?.values.orEmpty()) {
             val iface = getCtapHidInterface(device) ?: continue
             try {
-                return handle(options, callerPackage, device, iface)
+                return handle(options, callerPackage, device, iface, pinRequested, pin)
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: MissingPinException) {
                 throw e
             } catch (e: Exception) {
                 Log.w(TAG, e)
@@ -151,7 +159,7 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
             val device = waitForNewUsbDevice()
             val iface = getCtapHidInterface(device) ?: continue
             try {
-                return handle(options, callerPackage, device, iface)
+                return handle(options, callerPackage, device, iface, pinRequested, pin)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -257,10 +257,10 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
     }
 
     @RequiresApi(24)
-    fun startTransportHandling(transport: Transport, instant: Boolean = false): Job = lifecycleScope.launchWhenResumed {
+    fun startTransportHandling(transport: Transport, instant: Boolean = false, pinRequested: Boolean = false, authenticatorPin: String? = null): Job = lifecycleScope.launchWhenResumed {
         val options = options ?: return@launchWhenResumed
         try {
-            finishWithSuccessResponse(getTransportHandler(transport)!!.start(options, callerPackage), transport)
+            finishWithSuccessResponse(getTransportHandler(transport)!!.start(options, callerPackage, pinRequested, authenticatorPin), transport)
         } catch (e: SecurityException) {
             Log.w(TAG, e)
             if (instant) {
@@ -274,6 +274,9 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
         } catch (e: RequestHandlingException) {
             Log.w(TAG, e)
             finishWithError(e.errorCode, e.message ?: e.errorCode.name)
+        } catch (e: MissingPinException) {
+            // Redirect the user to ask for a PIN code
+            navHostFragment.navController.navigate(R.id.openPinFragment)
         } catch (e: Exception) {
             Log.w(TAG, e)
             finishWithError(UNKNOWN_ERR, e.message ?: e.javaClass.simpleName)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -12,6 +12,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
@@ -276,6 +277,10 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
             finishWithError(e.errorCode, e.message ?: e.errorCode.name)
         } catch (e: MissingPinException) {
             // Redirect the user to ask for a PIN code
+            navHostFragment.navController.navigate(R.id.openPinFragment)
+        } catch (e: WrongPinException) {
+            // Redirect the user, and inform them that the pin was wrong
+            Toast.makeText(baseContext, R.string.fido_wrong_pin, Toast.LENGTH_LONG).show()
             navHostFragment.navController.navigate(R.id.openPinFragment)
         } catch (e: Exception) {
             Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivityFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivityFragment.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.fido.fido2.api.common.ErrorCode
 import com.google.android.gms.fido.fido2.api.common.RequestOptions
@@ -21,6 +22,7 @@ import org.microg.gms.fido.core.transport.Transport
 
 @TargetApi(24)
 abstract class AuthenticatorActivityFragment : Fragment() {
+    private val pinViewModel: AuthenticatorPinViewModel by activityViewModels()
     val data: AuthenticatorActivityFragmentData
         get() = AuthenticatorActivityFragmentData(arguments ?: Bundle.EMPTY)
     val authenticatorActivity: AuthenticatorActivity?
@@ -28,7 +30,7 @@ abstract class AuthenticatorActivityFragment : Fragment() {
     val options: RequestOptions?
         get() = authenticatorActivity?.options
 
-    fun startTransportHandling(transport: Transport) = authenticatorActivity?.startTransportHandling(transport)
+    fun startTransportHandling(transport: Transport) = authenticatorActivity?.startTransportHandling(transport, pinRequested = pinViewModel.pinRequest, authenticatorPin = pinViewModel.pin)
     fun shouldStartTransportInstantly(transport: Transport) = authenticatorActivity?.shouldStartTransportInstantly(transport) == true
 
     abstract override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/PinFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/PinFragment.kt
@@ -1,0 +1,57 @@
+package org.microg.gms.fido.core.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModel
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.navOptions
+import org.microg.gms.fido.core.R
+import org.microg.gms.fido.core.databinding.FidoPinFragmentBinding
+
+class AuthenticatorPinViewModel : ViewModel() {
+    var pinRequest: Boolean = false
+    var pin: String? = null
+}
+
+class PinFragment: AuthenticatorActivityFragment() {
+    private lateinit var binding: FidoPinFragmentBinding
+    private val pinViewModel: AuthenticatorPinViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FidoPinFragmentBinding.inflate(inflater, container, false)
+        binding.onCancel = View.OnClickListener {
+            leaveFragment()
+        }
+        binding.onEnterPin = View.OnClickListener {
+            enterPin()
+        }
+
+        return binding.root
+    }
+
+    fun enterPin () {
+        val textEditor = view?.findViewById<EditText>(R.id.pin_editor)
+        if (textEditor != null) {
+            pinViewModel.pin = textEditor.text.toString()
+        }
+        leaveFragment()
+    }
+
+    fun leaveFragment() {
+        pinViewModel.pinRequest = true
+        if (!findNavController().navigateUp()) {
+            findNavController().navigate(
+                R.id.transportSelectionFragment,
+                arguments,
+                navOptions { popUpTo(R.id.usbFragment) { inclusive = true } })
+        }
+    }
+}

--- a/play-services-fido/core/src/main/res/layout/fido_pin_fragment.xml
+++ b/play-services-fido/core/src/main/res/layout/fido_pin_fragment.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable
+            name="onEnterPin"
+            type="android.view.View.OnClickListener" />
+        <variable
+            name="onCancel"
+            type="android.view.View.OnClickListener" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/pin_fragment_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/fido_pin_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/pin_editor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:ems="10"
+            android:hint="@string/fido_pin_hint"
+            android:inputType="textPassword"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pin_fragment_title"
+            android:autofillHints="password" />
+
+        <Button
+            android:id="@+id/pin_fragment_ok"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/fido_pin_ok"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pin_editor"
+            android:onClick="@{onEnterPin}"/>
+
+        <Button
+            android:id="@+id/pin_fragment_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/fido_pin_cancel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pin_fragment_ok"
+            android:onClick="@{onCancel}"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/play-services-fido/core/src/main/res/navigation/nav_fido_authenticator.xml
+++ b/play-services-fido/core/src/main/res/navigation/nav_fido_authenticator.xml
@@ -58,10 +58,23 @@
     <fragment
         android:id="@+id/nfcFragment"
         android:name="org.microg.gms.fido.core.ui.NfcTransportFragment"
-        tools:layout="@layout/fido_nfc_transport_fragment" />
+        tools:layout="@layout/fido_nfc_transport_fragment">
+        <action
+            android:id="@+id/openPinFragment"
+            app:destination="@id/pinFragment" />
+    </fragment>
     <fragment
         android:id="@+id/usbFragment"
         android:name="org.microg.gms.fido.core.ui.UsbTransportFragment"
-        tools:layout="@layout/fido_usb_transport_fragment" />
+        tools:layout="@layout/fido_usb_transport_fragment">
+        <action
+            android:id="@+id/openPinFragment"
+            app:destination="@id/pinFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/pinFragment"
+        android:name="org.microg.gms.fido.core.ui.PinFragment"
+        tools:layout="@layout/fido_pin_fragment" />
 
 </navigation>

--- a/play-services-fido/core/src/main/res/values/strings.xml
+++ b/play-services-fido/core/src/main/res/values/strings.xml
@@ -24,4 +24,8 @@
     <string name="fido_transport_selection_biometric">Use this device with screen lock</string>
     <string name="fido_transport_usb_wait_connect_body">Please connect your USB security key.</string>
     <string name="fido_transport_usb_wait_confirm_body">Please tap the golden ring or disc on %1$s.</string>
+    <string name="fido_pin_title">Please enter the PIN for your authenticator</string>
+    <string name="fido_pin_hint">4 to 63 characters</string>
+    <string name="fido_pin_ok">OK</string>
+    <string name="fido_pin_cancel">Cancel</string>
 </resources>

--- a/play-services-fido/core/src/main/res/values/strings.xml
+++ b/play-services-fido/core/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="fido_pin_hint">4 to 63 characters</string>
     <string name="fido_pin_ok">OK</string>
     <string name="fido_pin_cancel">Cancel</string>
+    <string name="fido_wrong_pin">Wrong PIN entered!</string>
 </resources>


### PR DESCRIPTION
Added PIN verification for FIDO2 authenticators. I am not a great Kotlin or Android programmer, so this could probably have been done in a more elegant way.

When the AuthenticatorActivityFragment is started, a ModelView is created which contains two variables: a boolean that says whether the user has input a PIN, and a nullable string containing the PIN. These variables are then passed to the TransportHandler. If the authenticator wants a client PIN and the user has not yet been asked for a PIN (ie. the boolean is false), a MissingPin exception is thrown up to the AuthenticatorActivity. This makes the activity redirect the user to a PinFragment, where the user can enter a pin that is stored in the ModelView. If the user has previously cancelled entering the pin, the code tries to authenticate without a PIN (since some authenticators still seem to return something when no PIN is entered). If the authenticator returns the status code for wrong pin, the user is redirected to the PIN fragment with a message saying wrong pin.

This code has only been tested on a Yubikey over NFC, but seems to work reasonably well for both signing and registering. It is not tested for USB
To be implemented:
- Telling the user how many PIN retries are left
- Telling the user when the PIN has been wrongly entered too many times, and the authenticator reset
- Probably a whole lot of error handling