### PR TITLE
Optimize Gradle build on GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,26 @@
-name: Build
-on: [pull_request, push]
+name: "Gradle build"
+permissions: {}
+on:
+  - push
+  - pull_request
+  - workflow_dispatch
+
 jobs:
   build:
+    name: "Gradle build"
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - name: "Checkout sources"
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
+      - name: "Setup Java"
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-      - run: ./gradlew --no-daemon build
-        env:
-          TERM: dumb
-          JAVA_OPTS: -Xmx2048m
+          distribution: "temurin"
+          java-version: "17"
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@v3
+      - name: "Execute Gradle build"
+        run: "./gradlew --no-daemon build"


### PR DESCRIPTION
I have done some changes:
- Added "workflow_dispatch", this will allow you to run the build manually if needed in addition of the automatic run;
- Remove all permissions from the actions since they aren't needed for a simple build;
- Update the versions of actions (older versions will probably break soon);
- Start using the official action to setup Gradle since it handle caching automatically in a better way compared to setup java action (the first run will be slower due to cache changes but the following runs will decrease);
- Remove useless ENV variables, the ram of Gradle is already configured inside gradle.properties and the other is probably a remnant of the past;
- Minor cosmetic improvements.