### PR TITLE
Fixed the login exception issue when the scope is "oauth2:"

### DIFF
--- a/play-services-basement/src/main/java/org/microg/gms/auth/AuthConstants.java
+++ b/play-services-basement/src/main/java/org/microg/gms/auth/AuthConstants.java
@@ -31,5 +31,7 @@ public class AuthConstants {
     public static final String ERROR_CODE = "errorCode";
     public static final String SIGN_IN_CREDENTIAL = "sign_in_credential";
     public static final String STATUS = "status";
+    public static final String SCOPE_OAUTH2 = "oauth2:";
+    public static final String SCOPE_EM_OP_PRO = "oauth2:email openid profile";
 
 }

--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static android.accounts.AccountManager.*;
@@ -118,6 +119,8 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
 
         if (!AuthConstants.SCOPE_GET_ACCOUNT_ID.equals(scope))
             Log.d(TAG, "getToken: account:" + account.name + " scope:" + scope + " extras:" + extras + ", notify: " + notify);
+
+        scope = Objects.equals(AuthConstants.SCOPE_OAUTH2, scope) ? AuthConstants.SCOPE_EM_OP_PRO : scope;
 
         /*
          * TODO: This scope seems to be invalid (according to https://developers.google.com/oauthplayground/),


### PR DESCRIPTION
Fixed the login exception issue when the scope is "oauth2:" 
e.g. Chai - Chat with AI Friends