### PR TITLE
Declare car related permissions

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -91,6 +91,36 @@
         android:label="@string/perm_provision_label"
         android:protectionLevel="privileged|signature" />
 
+    <permission
+        android:name="com.google.android.gms.permission.CAR_SPEED"
+        android:label="@string/perm_car_speed_label"
+        android:description="@string/perm_car_speed_description"
+        android:permissionGroup="android.permission-group.LOCATION"
+        android:protectionLevel="dangerous" />
+
+    <permission-group
+        android:name="com.google.android.gms.permission.CAR_INFORMATION"
+        android:label="@string/perm_car_info_label"
+        android:description="@string/perm_car_info_description" />
+    <permission
+        android:name="com.google.android.gms.permission.CAR_FUEL"
+        android:label="@string/perm_car_fuel_label"
+        android:description="@string/perm_car_fuel_description"
+        android:permissionGroup="com.google.android.gms.permission.CAR_INFORMATION"
+        android:protectionLevel="dangerous" />
+    <permission
+        android:name="com.google.android.gms.permission.CAR_MILEAGE"
+        android:label="@string/perm_car_mileage_label"
+        android:description="@string/perm_car_mileage_description"
+        android:permissionGroup="com.google.android.gms.permission.CAR_INFORMATION"
+        android:protectionLevel="dangerous" />
+    <permission
+        android:name="com.google.android.gms.permission.CAR_VENDOR_EXTENSION"
+        android:label="@string/perm_car_vendor_extension_label"
+        android:description="@string/perm_car_vendor_extension_description"
+        android:permissionGroup="com.google.android.gms.permission.CAR_INFORMATION"
+        android:protectionLevel="dangerous" />
+
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -55,6 +55,18 @@ This can take a couple of minutes."</string>
     <string name="perm_provision_label">provision microG services</string>
     <string name="perm_provision_description">Allows the app to configure microG services without user interaction</string>
 
+    <string name="perm_car_speed_label">Car speed</string>
+    <string name="perm_car_speed_description">"Access your car's speed"</string>
+
+    <string name="perm_car_info_label">Car information</string>
+    <string name="perm_car_info_description">"Access your car's information"</string>
+    <string name="perm_car_fuel_label">Car fuel level</string>
+    <string name="perm_car_fuel_description">"Access your car's fuel level information"</string>
+    <string name="perm_car_mileage_label">Car mileage</string>
+    <string name="perm_car_mileage_description">"Access your car's mileage information"</string>
+    <string name="perm_car_vendor_extension_label">Car vendor channel</string>
+    <string name="perm_car_vendor_extension_description">"Access your car's vendor channel to exchange car-specific information"</string>
+
     <string name="service_name_checkin">Google device registration</string>
     <string name="service_name_mcs">Cloud Messaging</string>
     <string name="service_name_snet">Google SafetyNet</string>


### PR DESCRIPTION
Declare CAR_SPEED permission fix the Google Maps location permission authorization pop-up window when connecting to Android Auto.
I have declared the others as well.

Derived from #2123