### PR TITLE
Vending: Add PurchaseActivity dummy

### DIFF
--- a/vending-app/src/main/AndroidManifest.xml
+++ b/vending-app/src/main/AndroidManifest.xml
@@ -127,5 +127,15 @@
             android:name="com.android.vending.licensing.LicenseServiceNotificationRunnable$SignInReceiver"
             android:exported="false" />
 
+        <activity android:name="com.google.android.finsky.billing.lightpurchase.LightPurchaseFlowActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Translucent"
+            android:process=":ui">
+            <intent-filter>
+                <action android:name="com.android.vending.billing.PURCHASE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
     </application>
 </manifest>

--- a/vending-app/src/main/AndroidManifest.xml
+++ b/vending-app/src/main/AndroidManifest.xml
@@ -127,7 +127,7 @@
             android:name="com.android.vending.licensing.LicenseServiceNotificationRunnable$SignInReceiver"
             android:exported="false" />
 
-        <activity android:name="com.google.android.finsky.billing.lightpurchase.LightPurchaseFlowActivity"
+        <activity android:name="org.microg.vending.billing.LightPurchaseFlowActivity"
             android:exported="true"
             android:theme="@style/Theme.Translucent"
             android:process=":ui">

--- a/vending-app/src/main/java/com/google/android/finsky/billing/lightpurchase/LightPurchaseFlowActivity.java
+++ b/vending-app/src/main/java/com/google/android/finsky/billing/lightpurchase/LightPurchaseFlowActivity.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2023 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.finsky.billing.lightpurchase;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+
+import com.android.vending.R;
+
+public class LightPurchaseFlowActivity extends Activity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Toast.makeText(this, getString(R.string.pay_disabled), Toast.LENGTH_SHORT).show();
+        finish();
+    }
+}

--- a/vending-app/src/main/java/org/microg/vending/billing/LightPurchaseFlowActivity.java
+++ b/vending-app/src/main/java/org/microg/vending/billing/LightPurchaseFlowActivity.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.google.android.finsky.billing.lightpurchase;
+package org.microg.vending.billing;
 
 import android.app.Activity;
 import android.os.Bundle;

--- a/vending-app/src/main/res/values-zh-rCN/strings.xml
+++ b/vending-app/src/main/res/values-zh-rCN/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="toast_installed">microG Companion 不可单独使用。已转而打开 microG 服务设置。</string>
     <string name="toast_not_installed">microG Companion 不可单独使用。请安装 microG 服务以使用 microG。</string>
+
+    <string name="pay_disabled">支付功能不可用</string>
 </resources>

--- a/vending-app/src/main/res/values/strings.xml
+++ b/vending-app/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
 
     <string name="license_notification_sign_in">Sign In</string>
     <string name="license_notification_ignore">Ignore</string>
+
+    <string name="pay_disabled">Pay currently not possible</string>
 </resources>


### PR DESCRIPTION
Solve the problem of crash caused by some in-app purchases jumping to the LightPurchaseFlowActivity page through action:com.android.vending.billing.PURCHASE.
e.g. Google Play Books