### PR TITLE
Location: Catch exception when accidentally reusing apps database

### DIFF
--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/ui/LocationPreferencesFragment.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/ui/LocationPreferencesFragment.kt
@@ -99,7 +99,7 @@ class LocationPreferencesFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        updateContent()
+        runCatching { updateContent() }.onFailure { database.close() }
     }
 
     override fun onPause() {


### PR DESCRIPTION
java.lang.IllegalStateException: attempt to re-open an already-closed object: SQLiteDatabase: /data/user/0/com.google.android.gms/databases/geoapps.db
 at android.database.sqlite.SQLiteClosable.acquireReference(SQLiteClosable.java:58)
 at android.database.sqlite.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1422)
 at android.database.sqlite.SQLiteDatabase.query(SQLiteDatabase.java:1298)
 at android.database.sqlite.SQLiteDatabase.query(SQLiteDatabase.java:1504)
 at org.microg.gms.location.manager.LocationAppsDatabase.listAppsByAccessTime(LocationAppsDatabase.kt:72)
 at org.microg.gms.location.manager.LocationAppsDatabase.listAppsByAccessTime$default(LocationAppsDatabase.kt:70)
 at org.microg.gms.location.ui.LocationPreferencesFragment$updateContent$1$1.invokeSuspend(LocationPreferencesFragment.kt:120)
 at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
 at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
 at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
 at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
 at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
 Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@e345f52, Dispatchers.Main.immediate]