### PR TITLE
Increase memory to fix build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2048m -XX:+UseParallelGC --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+org.gradle.jvmargs=-Xmx2560m -XX:+UseParallelGC --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED


### PR DESCRIPTION
@mar-v-in
I have increased only to 2,5GB to avoid increasing it to much.

It works for now but we should discover why we use so much memory, maybe our gradle files are doing something wrong.