### PR TITLE
Disable some optimizations on debug builds

### DIFF
--- a/vending-app/build.gradle
+++ b/vending-app/build.gradle
@@ -23,9 +23,9 @@ android {
         debug {
             postprocessing {
                 removeUnusedCode true
-                removeUnusedResources true
+                removeUnusedResources false
                 obfuscate false
-                optimizeCode true
+                optimizeCode false
             }
         }
         release {


### PR DESCRIPTION
Optimizations are mainly for releases, in debug builds they are less needed; this will reduce the pressure.