### PR TITLE
Vending: Add AssetModuleService dummy

### DIFF
--- a/vending-app/src/main/AndroidManifest.xml
+++ b/vending-app/src/main/AndroidManifest.xml
@@ -166,5 +166,14 @@
             android:name="org.microg.vending.billing.ui.PlayWebViewActivity"
             android:exported="false" />
 
+        <service
+            android:name="com.google.android.finsky.assetmoduleservice.AssetModuleService"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.play.core.assetmoduleservice.BIND_ASSET_MODULE_SERVICE" />
+            </intent-filter>
+        </service>
+
     </application>
 </manifest>

--- a/vending-app/src/main/aidl/com/google/android/play/core/assetpacks/protocol/IAssetModuleService.aidl
+++ b/vending-app/src/main/aidl/com/google/android/play/core/assetpacks/protocol/IAssetModuleService.aidl
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2023 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.play.core.assetpacks.protocol;
+
+import com.google.android.play.core.assetpacks.protocol.IAssetModuleServiceCallback;
+
+interface IAssetModuleService {
+    void startDownload(String packageName, in List<Bundle> list, in Bundle bundle, in IAssetModuleServiceCallback callback) = 1;
+    void getSessionStates(String packageName, in Bundle bundle, in IAssetModuleServiceCallback callback) = 4;
+    void notifyChunkTransferred(String packageName, in Bundle bundle, in Bundle bundle2, in IAssetModuleServiceCallback callback) = 5;
+    void notifyModuleCompleted(String packageName, in Bundle bundle, in Bundle bundle2, in IAssetModuleServiceCallback callback) = 6;
+    void notifySessionFailed(String packageName, in Bundle bundle, in Bundle bundle2, in IAssetModuleServiceCallback callback) = 8;
+    void keepAlive(String packageName, in Bundle bundle, in IAssetModuleServiceCallback callback) = 9;
+    void getChunkFileDescriptor(String packageName, in Bundle bundle, in Bundle bundle2, in IAssetModuleServiceCallback callback) = 10;
+    void requestDownloadInfo(String packageName, in List<Bundle> list, in Bundle bundle, in IAssetModuleServiceCallback callback) = 11;
+    void removeModule(String packageName, in Bundle bundle, in Bundle bundle2, in IAssetModuleServiceCallback callback) = 12;
+    void cancelDownloads(String packageName, in List<Bundle> list, in Bundle bundle, in IAssetModuleServiceCallback callback) = 13;
+}

--- a/vending-app/src/main/aidl/com/google/android/play/core/assetpacks/protocol/IAssetModuleServiceCallback.aidl
+++ b/vending-app/src/main/aidl/com/google/android/play/core/assetpacks/protocol/IAssetModuleServiceCallback.aidl
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2023 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.play.core.assetpacks.protocol;
+
+interface IAssetModuleServiceCallback {
+    void onStartDownload(int status, in Bundle bundle) = 1;
+    void onCancelDownload(int status) = 2;
+    void onGetSession(int status) = 3;
+    void onGetSessionStates(in List<Bundle> list) = 4;
+    void onNotifyChunkTransferred(in Bundle bundle) = 5;
+    void onError(in Bundle bundle) = 6;
+    void onNotifyModuleCompleted(in Bundle bundle) = 7;
+    void onNotifySessionFailed(in Bundle bundle) = 9;
+    void onKeepAlive(in Bundle bundle, in Bundle bundle2) = 10;
+    void onGetChunkFileDescriptor(in Bundle bundle, in Bundle bundle2) = 11;
+    void onRequestDownloadInfo(in Bundle bundle, in Bundle bundle2) = 12;
+    void onRemoveModule() = 13;
+    void onCancelDownloads() = 14;
+}

--- a/vending-app/src/main/java/com/google/android/finsky/assetmoduleservice/AssetModuleService.java
+++ b/vending-app/src/main/java/com/google/android/finsky/assetmoduleservice/AssetModuleService.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2023 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.finsky.assetmoduleservice;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.util.Log;
+
+import com.google.android.play.core.assetpacks.protocol.IAssetModuleService;
+import com.google.android.play.core.assetpacks.protocol.IAssetModuleServiceCallback;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AssetModuleService extends Service {
+    private static final String TAG = "AssetModuleService";
+
+    private final IAssetModuleService.Stub service = new IAssetModuleService.Stub() {
+
+        @Override
+        public void startDownload(String packageName, List<Bundle> list, Bundle bundle, IAssetModuleServiceCallback callback) throws RemoteException {
+            Log.d(TAG, "Method (startDownload) called by packageName -> " + packageName);
+            Bundle result = new Bundle();
+            result.putStringArrayList("pack_names", new ArrayList<>());
+            callback.onStartDownload(-1, result);
+        }
+
+        @Override
+        public void getSessionStates(String packageName, Bundle bundle, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (getSessionStates) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void notifyChunkTransferred(String packageName, Bundle bundle, Bundle bundle2, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (notifyChunkTransferred) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void notifyModuleCompleted(String packageName, Bundle bundle, Bundle bundle2, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (notifyModuleCompleted) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void notifySessionFailed(String packageName, Bundle bundle, Bundle bundle2, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (notifySessionFailed) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void keepAlive(String packageName, Bundle bundle, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (keepAlive) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void getChunkFileDescriptor(String packageName, Bundle bundle, Bundle bundle2, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (getChunkFileDescriptor) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void requestDownloadInfo(String packageName, List<Bundle> list, Bundle bundle, IAssetModuleServiceCallback callback) throws RemoteException {
+            Log.d(TAG, "Method (requestDownloadInfo) called by packageName -> " + packageName);
+            Bundle result = new Bundle();
+            result.putStringArrayList("pack_names", new ArrayList<>());
+            callback.onRequestDownloadInfo(result, result);
+        }
+
+        @Override
+        public void removeModule(String packageName, Bundle bundle, Bundle bundle2, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (removeModule) called but not implement by packageName -> " + packageName);
+        }
+
+        @Override
+        public void cancelDownloads(String packageName, List<Bundle> list, Bundle bundle, IAssetModuleServiceCallback callback) {
+            Log.d(TAG, "Method (cancelDownloads) called but not implement by packageName -> " + packageName);
+        }
+    };
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        Log.d(TAG, "onBind");
+        return service.asBinder();
+    }
+}


### PR DESCRIPTION
Supplementary store AssetModuleService service is used to solve the problem that League of Legends: Wild Rift cannot be opened normally.