### PR TITLE
Implement IDynamicLinksService -> getInitialLink for compatibility with react native firebase email link auth

### DIFF
--- a/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/DynamicLinkData.java
+++ b/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/DynamicLinkData.java
@@ -40,6 +40,14 @@ public class DynamicLinkData extends AutoSafeParcelable {
         extensionBundle = new Bundle();
         redirectUrl = Uri.EMPTY;
     }
+    public DynamicLinkData(String dynamicLink, String deepLink, int minVersion, long clickTimestamp, Bundle extensionBundle, Uri redirectUrl) {
+        this.dynamicLink = dynamicLink;
+        this.deepLink = deepLink;
+        this.minVersion = minVersion;
+        this.clickTimestamp = clickTimestamp;
+        this.extensionBundle = extensionBundle;
+        this.redirectUrl = redirectUrl;
+    }
 
     public static final Creator<DynamicLinkData> CREATOR = new AutoCreator<DynamicLinkData>(DynamicLinkData.class);
 }


### PR DESCRIPTION
Currently the implementation of getInitialLink just returns null to the client which breaks the authentication method of react native firebase using an email link only.  
In their documentation there is no example code for this, but some apps implement authentication like this:
https://stackoverflow.com/questions/61564203/how-to-setup-sendsigninlinktoemail-from-firebase-in-react-native

This pull request implements https://github.com/microg/GmsCore/blob/9e2337a4edeb908921251b400e34796d85f3740c/play-services-core/src/main/java/org/microg/gms/firebase/dynamiclinks/DynamicLinksServiceImpl.java#L41-L43
by parsing the link and returning the correct payload to the client. There are a few security related checks if the package name of the link does not match the receiving package name or if it is missing. I was able to get some logins to work. It might also fix https://github.com/microg/GmsCore/issues/1547 as this is related to the dynamic links service, but I haven't tested apps reported there.

best :-)

