### PR TITLE
Auth: Remove unnecessary prompts

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
@@ -89,7 +89,7 @@ fun getServerAuthTokenManager(context: Context, packageName: String, options: Go
     val serverAuthTokenManager = AuthManager(context, account.name, packageName, "oauth2:server:client_id:${options.serverClientId}:api_scope:${options.scopeUris.joinToString(" ")}")
     serverAuthTokenManager.includeEmail = if (options.includeEmail) "1" else "0"
     serverAuthTokenManager.includeProfile = if (options.includeProfile) "1" else "0"
-    serverAuthTokenManager.setOauth2Prompt(if (options.isForceCodeForRefreshToken) "consent" else "auto")
+    serverAuthTokenManager.setOauth2Prompt("auto")
     serverAuthTokenManager.setItCaveatTypes("2")
     return serverAuthTokenManager
 }


### PR DESCRIPTION
The processing has already been done when requesting the authorized content for the first time, so there is no need to request consent here. Otherwise, login will be impossible.