### PR TITLE
permission: remove <com.android.vending.CHECK_LICENSE>

### DIFF
--- a/vending-app/src/main/AndroidManifest.xml
+++ b/vending-app/src/main/AndroidManifest.xml
@@ -6,10 +6,6 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <permission
-        android:name="com.android.vending.CHECK_LICENSE"
-        android:protectionLevel="normal" />
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission
@@ -71,7 +67,6 @@
 
         <service
             android:name="com.android.vending.licensing.LicensingService"
-            android:permission="com.android.vending.CHECK_LICENSE"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.android.vending.licensing.ILicensingService" />


### PR DESCRIPTION
![image](https://github.com/microg/GmsCore/assets/150454414/4595123f-35d5-4887-a981-e5a2ad3bbb77)
![image](https://github.com/microg/GmsCore/assets/150454414/ecd7e6fb-7287-47dc-a65a-2beed04eeb36)

During the test, it was found that after uninstalling and reinstalling the fakestore, games that have been downloaded and need to be updated cannot enter the FakeLicenseService for execution because there is an exception in the <com.android.vending.CHECK_LICENSE> permission.

The general reason is that after the fakestore is uninstalled and reinstalled, the permission statement is removed and reset. It is not practical to turn fakestore into a system application that does not allow uninstallation. Is it possible to remove the permission here?