### PR TITLE
Add update check for Github actions, it save a lot of manual work

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
When there is an update a pull request is created automatically, so the only manual work needed is the merge button.
It is limited to a single pull request at a time.

Please merge #2341 before this to avoid conflits with the "position" change of the action.