### PR TITLE
Add google.sent_time extra to C2DM receive intent, fixes Telegram notifications

### DIFF
--- a/play-services-basement/src/main/java/org/microg/gms/gcm/GcmConstants.java
+++ b/play-services-basement/src/main/java/org/microg/gms/gcm/GcmConstants.java
@@ -61,6 +61,7 @@ public final class GcmConstants {
     public static final String EXTRA_SENDER_LEGACY = "legacy.sender";
     public static final String EXTRA_SEND_TO = "google.to";
     public static final String EXTRA_SEND_FROM = "google.from";
+    public static final String EXTRA_SENT_TIME = "google.sent_time";
     public static final String EXTRA_SIGNATURE = "sig";
     public static final String EXTRA_SUBSCIPTION = "subscription";
     public static final String EXTRA_SUBTYPE = "subtype";

--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -548,7 +548,8 @@ public class McsService extends Service implements Handler.Callback {
         intent.setAction(ACTION_C2DM_RECEIVE);
         intent.putExtra(EXTRA_FROM, msg.from);
         intent.putExtra(EXTRA_MESSAGE_ID, msg.id);
-        intent.putExtra(EXTRA_SENT_TIME, msg.sent);
+        if (msg.sent != null && msg.sent != 0) intent.putExtra(EXTRA_SENT_TIME, msg.sent);
+        if (msg.ttl != null && msg.ttl != 0) intent.putExtra(EXTRA_TTL, msg.ttl);
         if (msg.persistent_id != null) intent.putExtra(EXTRA_MESSAGE_ID, msg.persistent_id);
         if (msg.token != null) intent.putExtra(EXTRA_COLLAPSE_KEY, msg.token);
         if (msg.raw_data != null) {

--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -548,6 +548,7 @@ public class McsService extends Service implements Handler.Callback {
         intent.setAction(ACTION_C2DM_RECEIVE);
         intent.putExtra(EXTRA_FROM, msg.from);
         intent.putExtra(EXTRA_MESSAGE_ID, msg.id);
+        intent.putExtra(EXTRA_SENT_TIME, msg.sent);
         if (msg.persistent_id != null) intent.putExtra(EXTRA_MESSAGE_ID, msg.persistent_id);
         if (msg.token != null) intent.putExtra(EXTRA_COLLAPSE_KEY, msg.token);
         if (msg.raw_data != null) {

--- a/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/McsService.java
@@ -69,6 +69,7 @@ import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLContext;
@@ -562,6 +563,10 @@ public class McsService extends Service implements Handler.Callback {
             intent.addFlags(Intent.FLAG_EXCLUDE_STOPPED_PACKAGES);
         }
         for (AppData appData : msg.app_data) {
+            if (appData.key == null) continue;
+            String key = appData.key.toLowerCase(Locale.US);
+            // Some keys are exclusively set by the client and not the app.
+            if (key.equals(EXTRA_FROM) || (key.startsWith("google.") && !key.startsWith("google.c."))) continue;
             intent.putExtra(appData.key, appData.value_);
         }
 


### PR DESCRIPTION
This PR fixes broken notifications on apps that rely on `google.sent_time` such as Telegram.

Fixes #1986
Fixes #2298