### PR TITLE
Correct RU and BE strings missing on weblate

### DIFF
--- a/play-services-core/microg-ui-tools/src/main/res/values-be/strings.xml
+++ b/play-services-core/microg-ui-tools/src/main/res/values-be/strings.xml
@@ -25,12 +25,12 @@
 
     <string name="prefcat_setup">Ўсталяваць</string>
 
-    <string name="self_check_title">Праверка працаздольнасці</string>
+    <string name="self_check_title">Працаздольнасць</string>
     <string name="self_check_desc">Праверце, ці правільна настроена сістэма для выкарыстання microG.</string>
 
     <string name="self_check_cat_permissions">Правы доступу прадастаўленыя</string>
     <string name="self_check_name_permission">%1$s:</string>
-    <string name="self_check_resolution_permission">Націсніце тут, каб даць дазвол. Непрадастаўленне дазволу можа прывесці да некарэктнай працы прыкладання.</string>
+    <string name="self_check_resolution_permission">Краніце, каб даць дазвол. Адсутны дазвол можа прывесці да некарэктнай працы прыкладання.</string>
 
     <string name="about_root_title">microG UI Demo</string>
     <string name="about_root_summary">Падрабязнасці</string>

--- a/play-services-core/microg-ui-tools/src/main/res/values-ru/strings.xml
+++ b/play-services-core/microg-ui-tools/src/main/res/values-ru/strings.xml
@@ -25,13 +25,13 @@
 
     <string name="prefcat_setup">Установить</string>
 
-    <string name="self_check_title">Проверка работоспособности</string>
+    <string name="self_check_title">Работоспособность</string>
     <string name="self_check_desc">Проверьте, правильно ли настроена система для использования microG.</string>
 
     <string name="self_check_cat_permissions">Права доступа предоставлены</string>
     <!-- it's better if the next line stays like this -->
     <string name="self_check_name_permission">%1$s:</string>
-    <string name="self_check_resolution_permission">Нажмите здесь, чтобы дать разрешение. Непредоставление разрешения может привести к некорректной работе приложения.</string>
+    <string name="self_check_resolution_permission">Коснитесь, чтобы предоставить разрешение. Отсутствующее разрешение может привести к некорректной работе приложения.</string>
 
     <string name="about_root_title">microG UI Demo</string>
     <string name="about_root_summary">Подробности</string>


### PR DESCRIPTION
- Respect small displays with big font (Self-check)
- Grammar correction
