### PR TITLE
Map: Remove styles that cannot be set

### DIFF
--- a/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
+++ b/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
@@ -246,11 +246,10 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
 
     fun applyMapType() {
         // TODO: Serve map styles locally
+        Log.d(TAG, "Method: applyMapType -> $storedMapType")
         when (storedMapType) {
-            MAP_TYPE_SATELLITE -> map?.mapType = HuaweiMap.MAP_TYPE_SATELLITE
             MAP_TYPE_TERRAIN -> map?.mapType = HuaweiMap.MAP_TYPE_TERRAIN
-            MAP_TYPE_HYBRID -> map?.mapType = HuaweiMap.MAP_TYPE_HYBRID
-            //MAP_TYPE_NONE, MAP_TYPE_NORMAL,
+            // MAP_TYPE_SATELLITE, MAP_TYPE_HYBRID, MAP_TYPE_NONE, MAP_TYPE_NORMAL,
             else -> map?.mapType = HuaweiMap.MAP_TYPE_NORMAL
         }
         // map?.let { BitmapDescriptorFactoryImpl.registerMap(it) }


### PR DESCRIPTION
![image](https://github.com/microg/GmsCore/assets/150454414/982c2fba-c855-43b3-921d-64480bea636d)

It was found that some applications cannot display map content because they are set to use satellite maps, but the SDK does not support them.