### PR TITLE
DroidGuard：Fix class repeated loading exception

### DIFF
--- a/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/HandleProxyFactory.kt
+++ b/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/HandleProxyFactory.kt
@@ -28,7 +28,6 @@ import com.android.volley.Request as VolleyRequest
 import com.android.volley.Response as VolleyResponse
 
 class HandleProxyFactory(private val context: Context) {
-    private val classMap = hashMapOf<String, Class<*>>()
     private val dgDb: DgDatabaseHelper = DgDatabaseHelper(context)
     private val version = VersionUtil(context)
     private val queue = singleInstanceOf { Volley.newRequestQueue(context.applicationContext) }
@@ -218,6 +217,7 @@ class HandleProxyFactory(private val context: Context) {
     }
 
     companion object {
+        private val classMap = hashMapOf<String, Class<*>>()
         const val CLASS_NAME = "com.google.ccc.abuse.droidguard.DroidGuard"
         const val SERVER_URL = "https://www.googleapis.com/androidantiabuse/v1/x/create?alt=PROTO&key=AIzaSyBofcZsgLSS7BOnBjZPEkk4rYwzOIz-lTI"
         const val CACHE_FOLDER_NAME = "cache_dg"


### PR DESCRIPTION
Fixed the issue where the entry class in the same the.apk is loaded multiple times, resulting in multiple loading of so, and an exception of repeated loading of so is thrown.