### PR TITLE
Fixed app crash by DynamiteLoader

### DIFF
--- a/play-services-basement/src/main/java/com/google/android/gms/dynamite/DynamiteModule.java
+++ b/play-services-basement/src/main/java/com/google/android/gms/dynamite/DynamiteModule.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Field;
 import java.util.Objects;
 
 public class DynamiteModule {
-    private static final String TAG = "DynamiteModule";
+    private static final String TAG = "GmsDynamiteModule";
 
     public static final int NONE = 0;
     public static final int LOCAL = -1;

--- a/play-services-core/src/main/java/com/google/android/gms/chimera/container/DynamiteLoaderImpl.java
+++ b/play-services-core/src/main/java/com/google/android/gms/chimera/container/DynamiteLoaderImpl.java
@@ -17,18 +17,13 @@
 package com.google.android.gms.chimera.container;
 
 import android.content.Context;
-import android.content.ContextWrapper;
-import android.content.pm.PackageManager;
 import android.os.RemoteException;
 import android.util.Log;
 
 import com.google.android.gms.dynamic.IObjectWrapper;
 import com.google.android.gms.dynamic.ObjectWrapper;
+import com.google.android.gms.dynamite.DynamiteModule;
 import com.google.android.gms.dynamite.IDynamiteLoader;
-
-import org.microg.gms.common.Constants;
-
-import java.lang.reflect.Field;
 
 public class DynamiteLoaderImpl extends IDynamiteLoader.Stub {
     private static final String TAG = "GmsDynamiteLoaderImpl";
@@ -43,7 +38,12 @@ public class DynamiteLoaderImpl extends IDynamiteLoader.Stub {
     public IObjectWrapper createModuleContextV2(IObjectWrapper wrappedContext, String moduleId, int minVersion) throws RemoteException {
         Log.d(TAG, "createModuleContext for " + moduleId + " at version " + minVersion);
         final Context originalContext = (Context) ObjectWrapper.unwrap(wrappedContext);
-        return ObjectWrapper.wrap(DynamiteContext.create(moduleId, originalContext));
+        try {
+            Context moduleContext = DynamiteModule.load(originalContext, DynamiteModule.PREFER_LOCAL, moduleId).getModuleContext();
+            return ObjectWrapper.wrap(moduleContext);
+        } catch (Exception e) {
+            return ObjectWrapper.wrap(DynamiteContext.create(moduleId, originalContext));
+        }
     }
 
     @Override


### PR DESCRIPTION
The MODULE_VERSION specified in the measurement corresponding ModuleDescriptor is too high, which causes the application to be unable to use the MeasurementService to obtain the corresponding parameter content, which will cause the application to crash.
e.g. <PropertyGuru> <iProperty Malaysia> 