### PR TITLE
AD: Changing the initial configuration

### DIFF
--- a/play-services-ads-identifier/core/src/main/kotlin/org/microg/gms/ads/identifier/AdvertisingIdService.kt
+++ b/play-services-ads-identifier/core/src/main/kotlin/org/microg/gms/ads/identifier/AdvertisingIdService.kt
@@ -29,7 +29,7 @@ class AdvertisingIdService : Service() {
 
 class MemoryAdvertisingIdConfiguration(context: Context) : AdvertisingIdConfiguration(context) {
     override val adTrackingLimitedPerApp: MutableMap<Int, Boolean> = hashMapOf()
-    override var adTrackingLimitedGlobally: Boolean = true
+    override var adTrackingLimitedGlobally: Boolean = false
     override var debugLogging: Boolean = false
     override var adId: String = EMPTY_AD_ID
     override var debugAdId: String = EMPTY_AD_ID


### PR DESCRIPTION
During the test, we found that some apps rely on AD_ID to enter the app, but the default option of adTrackingLimitedGlobally is true, which returns EMPTY_AD_ID to the app. This also makes these apps unable to enter the home page normally.
e.g. HKTVmall Lite – Online Shoppin <com.hktv.android.hktvmalllite>