### PR TITLE
Supplement Google Password Manager functionality

### DIFF
--- a/play-services-api/src/main/java/com/google/android/gms/credential/manager/invocationparams/CallerInfo.java
+++ b/play-services-api/src/main/java/com/google/android/gms/credential/manager/invocationparams/CallerInfo.java
@@ -10,18 +10,18 @@ import org.microg.safeparcel.AutoSafeParcelable;
 
 public class CallerInfo extends AutoSafeParcelable {
     @Field(1)
-    public String s1;
+    public String source;
     @Field(2)
-    public String s2;
+    public String medium;
     @Field(3)
-    public String s3;
+    public String campaign;
     @Field(4)
-    public String s4;
+    public String content;
 
     @NonNull
     @Override
     public String toString() {
-        return "CallerInfo(" + s1 + "," + s2 + "," + s3 + "," + s4 + ")";
+        return "CallerInfo(" + source + "," + medium + "," + campaign + "," + content + ")";
     }
 
     public static final Creator<CallerInfo> CREATOR = new AutoCreator<>(CallerInfo.class);

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -878,6 +878,13 @@
             android:excludeFromRecents="true"
             android:theme="@style/Theme.App.Translucent"/>
 
+        <activity
+            android:name="com.google.android.gms.credential.manager.PasswordManagerActivity"
+            android:exported="true"
+            android:process=":ui"
+            android:excludeFromRecents="true"
+            android:theme="@style/Theme.Translucent"/>
+
         <service android:name="org.microg.gms.clearcut.ClearcutLoggerService">
             <intent-filter>
                 <action android:name="com.google.android.gms.clearcut.service.START" />

--- a/play-services-core/src/main/kotlin/com/google/android/gms/credential/manager/PasswordManagerActivity.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/credential/manager/PasswordManagerActivity.kt
@@ -1,0 +1,99 @@
+package com.google.android.gms.credential.manager
+
+import android.accounts.AccountManager
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.webkit.WebView
+import android.widget.ProgressBar
+import android.widget.RelativeLayout
+import androidx.appcompat.app.AppCompatActivity
+import org.microg.gms.accountsettings.ui.WebViewHelper
+import org.microg.gms.auth.AuthConstants
+
+const val PASSWORD_MANAGER_CLASS_NAME = "com.google.android.gms.credential.manager.PasswordManagerActivity"
+
+const val EXTRA_KEY_ACCOUNT_NAME = "pwm.DataFieldNames.accountName"
+const val EXTRA_KEY_UTM_SOURCE = "utm_source"
+const val EXTRA_KEY_UTM_MEDIUM = "utm_medium"
+const val EXTRA_KEY_UTM_CAMPAIGN = "utm_campaign"
+const val EXTRA_KEY_UTM_CONTENT = "utm_content"
+
+private const val TAG = "PasswordManagerActivity"
+
+private const val PSW_MANAGER_PATH = "https://passwords.google.com/"
+
+class PasswordManagerActivity : AppCompatActivity() {
+
+    private lateinit var webView: WebView
+
+    private val accountName: String?
+        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_ACCOUNT_NAME) }.getOrNull()
+    private val utmSource: String?
+        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_SOURCE) }.getOrNull()
+    private val utmMedium: String?
+        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_MEDIUM) }.getOrNull()
+    private val utmCampaign: String?
+        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_CAMPAIGN) }.getOrNull()
+    private val utmContent: String?
+        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_CONTENT) }.getOrNull()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Log.d(TAG, "onCreate: start")
+
+        val accounts = AccountManager.get(this).getAccountsByType(AuthConstants.DEFAULT_ACCOUNT_TYPE)
+        val realAccountName = accounts.find { it.name.equals(accountName) }?.name
+
+        Log.d(TAG, "realAccountName: $realAccountName")
+
+        val layout = RelativeLayout(this)
+        layout.addView(ProgressBar(this).apply {
+            layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT, RelativeLayout.LayoutParams.WRAP_CONTENT).apply {
+                addRule(RelativeLayout.CENTER_HORIZONTAL)
+                addRule(RelativeLayout.CENTER_VERTICAL)
+            }
+            isIndeterminate = true
+        })
+        webView = WebView(this).apply {
+            layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
+            visibility = View.INVISIBLE
+        }
+        layout.addView(webView)
+        setContentView(layout)
+        WebViewHelper(this, webView).openWebView(constructPswPath(), realAccountName)
+    }
+
+    private fun constructPswPath(): String {
+        val psmPath = StringBuilder().apply {
+            append(PSW_MANAGER_PATH)
+            if (!utmSource.isNullOrEmpty()) {
+                if (isEmpty()) append("?") else append("&")
+                append("$EXTRA_KEY_UTM_SOURCE=$utmSource")
+            }
+            if (!utmMedium.isNullOrEmpty()) {
+                if (isEmpty()) append("?") else append("&")
+                append("$EXTRA_KEY_UTM_MEDIUM=$utmMedium")
+            }
+            if (!utmCampaign.isNullOrEmpty()) {
+                if (isEmpty()) append("?") else append("&")
+                append("$EXTRA_KEY_UTM_CAMPAIGN=$utmCampaign")
+            }
+            if (!utmContent.isNullOrEmpty()) {
+                if (isEmpty()) append("?") else append("&")
+                append("$EXTRA_KEY_UTM_CONTENT=$utmContent")
+            }
+        }.toString()
+        Log.d(TAG, "constructPswPath: $psmPath")
+        return psmPath
+    }
+
+    override fun onBackPressed() {
+        if (this::webView.isInitialized && webView.canGoBack()) {
+            webView.goBack()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+}

--- a/play-services-core/src/main/kotlin/com/google/android/gms/credential/manager/PasswordManagerActivity.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/credential/manager/PasswordManagerActivity.kt
@@ -66,7 +66,6 @@ class PasswordManagerActivity : AppCompatActivity() {
 
     private fun constructPswPath(): String {
         val psmPath = StringBuilder().apply {
-            append(PSW_MANAGER_PATH)
             if (!utmSource.isNullOrEmpty()) {
                 if (isEmpty()) append("?") else append("&")
                 append("$EXTRA_KEY_UTM_SOURCE=$utmSource")
@@ -83,6 +82,7 @@ class PasswordManagerActivity : AppCompatActivity() {
                 if (isEmpty()) append("?") else append("&")
                 append("$EXTRA_KEY_UTM_CONTENT=$utmContent")
             }
+            insert(0, PSW_MANAGER_PATH)
         }.toString()
         Log.d(TAG, "constructPswPath: $psmPath")
         return psmPath

--- a/play-services-core/src/main/kotlin/com/google/android/gms/credential/manager/PasswordManagerActivity.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/credential/manager/PasswordManagerActivity.kt
@@ -14,10 +14,6 @@ import org.microg.gms.auth.AuthConstants
 const val PASSWORD_MANAGER_CLASS_NAME = "com.google.android.gms.credential.manager.PasswordManagerActivity"
 
 const val EXTRA_KEY_ACCOUNT_NAME = "pwm.DataFieldNames.accountName"
-const val EXTRA_KEY_UTM_SOURCE = "utm_source"
-const val EXTRA_KEY_UTM_MEDIUM = "utm_medium"
-const val EXTRA_KEY_UTM_CAMPAIGN = "utm_campaign"
-const val EXTRA_KEY_UTM_CONTENT = "utm_content"
 
 private const val TAG = "PasswordManagerActivity"
 
@@ -29,14 +25,6 @@ class PasswordManagerActivity : AppCompatActivity() {
 
     private val accountName: String?
         get() = runCatching { intent?.getStringExtra(EXTRA_KEY_ACCOUNT_NAME) }.getOrNull()
-    private val utmSource: String?
-        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_SOURCE) }.getOrNull()
-    private val utmMedium: String?
-        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_MEDIUM) }.getOrNull()
-    private val utmCampaign: String?
-        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_CAMPAIGN) }.getOrNull()
-    private val utmContent: String?
-        get() = runCatching { intent?.getStringExtra(EXTRA_KEY_UTM_CONTENT) }.getOrNull()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,31 +49,7 @@ class PasswordManagerActivity : AppCompatActivity() {
         }
         layout.addView(webView)
         setContentView(layout)
-        WebViewHelper(this, webView).openWebView(constructPswPath(), realAccountName)
-    }
-
-    private fun constructPswPath(): String {
-        val psmPath = StringBuilder().apply {
-            if (!utmSource.isNullOrEmpty()) {
-                if (isEmpty()) append("?") else append("&")
-                append("$EXTRA_KEY_UTM_SOURCE=$utmSource")
-            }
-            if (!utmMedium.isNullOrEmpty()) {
-                if (isEmpty()) append("?") else append("&")
-                append("$EXTRA_KEY_UTM_MEDIUM=$utmMedium")
-            }
-            if (!utmCampaign.isNullOrEmpty()) {
-                if (isEmpty()) append("?") else append("&")
-                append("$EXTRA_KEY_UTM_CAMPAIGN=$utmCampaign")
-            }
-            if (!utmContent.isNullOrEmpty()) {
-                if (isEmpty()) append("?") else append("&")
-                append("$EXTRA_KEY_UTM_CONTENT=$utmContent")
-            }
-            insert(0, PSW_MANAGER_PATH)
-        }.toString()
-        Log.d(TAG, "constructPswPath: $psmPath")
-        return psmPath
+        WebViewHelper(this, webView).openWebView(PSW_MANAGER_PATH, realAccountName)
     }
 
     override fun onBackPressed() {

--- a/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
@@ -5,8 +5,9 @@
 
 package org.microg.gms.credential
 
+import android.app.PendingIntent
 import android.content.Context
-import android.os.Bundle
+import android.content.Intent
 import android.os.Parcel
 import android.util.Base64
 import android.util.Log
@@ -20,11 +21,18 @@ import com.google.android.gms.common.api.internal.IStatusCallback
 import com.google.android.gms.common.internal.ConnectionInfo
 import com.google.android.gms.common.internal.GetServiceRequest
 import com.google.android.gms.common.internal.IGmsCallbacks
+import com.google.android.gms.credential.manager.EXTRA_KEY_ACCOUNT_NAME
+import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_CAMPAIGN
+import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_CONTENT
+import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_MEDIUM
+import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_SOURCE
+import com.google.android.gms.credential.manager.PASSWORD_MANAGER_CLASS_NAME
 import com.google.android.gms.credential.manager.common.IPendingIntentCallback
 import com.google.android.gms.credential.manager.common.ISettingsCallback
 import com.google.android.gms.credential.manager.firstparty.internal.ICredentialManagerService
 import com.google.android.gms.credential.manager.invocationparams.CredentialManagerInvocationParams
 import org.microg.gms.BaseService
+import org.microg.gms.common.Constants
 import org.microg.gms.common.GmsService
 import org.microg.gms.common.GooglePackagePermission
 import org.microg.gms.common.PackageUtils
@@ -53,13 +61,27 @@ class CredentialManagerService : BaseService(TAG, GmsService.CREDENTIAL_MANAGER)
 
 private class CredentialManagerServiceImpl(private val context: Context, override val lifecycle: Lifecycle) : ICredentialManagerService.Stub(), LifecycleOwner {
 
-    override fun getCredentialManagerIntent(callback: IPendingIntentCallback?, params: CredentialManagerInvocationParams?) {
-        Log.d(TAG, "Not yet implemented: getCredentialManagerIntent $params")
+    override fun getCredentialManagerIntent(callback: IPendingIntentCallback?, params: CredentialManagerInvocationParams) {
+        Log.d(TAG, "Method getCredentialManagerIntent $params called")
         lifecycleScope.launchWhenStarted {
-            try {
+            runCatching {
+                val intent = Intent().apply {
+                    setClassName(Constants.GMS_PACKAGE_NAME, PASSWORD_MANAGER_CLASS_NAME)
+                    putExtra(EXTRA_KEY_ACCOUNT_NAME, params.account.name)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    if (params.caller != null) {
+                        putExtra(EXTRA_KEY_UTM_SOURCE, params.caller.source)
+                        putExtra(EXTRA_KEY_UTM_MEDIUM, params.caller.medium)
+                        putExtra(EXTRA_KEY_UTM_CAMPAIGN, params.caller.campaign)
+                        putExtra(EXTRA_KEY_UTM_CONTENT, params.caller.content)
+                    }
+                }
+                val flags = PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_UPDATE_CURRENT
+                val pendingIntent = PendingIntent.getActivity(context, 0, intent, flags)
+                callback?.onPendingIntent(Status.SUCCESS, pendingIntent)
+            }.onFailure {
+                Log.d(TAG, "getCredentialManagerIntent error", it)
                 callback?.onPendingIntent(Status.INTERNAL_ERROR, null)
-            } catch (e: Exception) {
-                Log.w(TAG, e)
             }
         }
     }

--- a/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
@@ -22,10 +22,6 @@ import com.google.android.gms.common.internal.ConnectionInfo
 import com.google.android.gms.common.internal.GetServiceRequest
 import com.google.android.gms.common.internal.IGmsCallbacks
 import com.google.android.gms.credential.manager.EXTRA_KEY_ACCOUNT_NAME
-import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_CAMPAIGN
-import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_CONTENT
-import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_MEDIUM
-import com.google.android.gms.credential.manager.EXTRA_KEY_UTM_SOURCE
 import com.google.android.gms.credential.manager.PASSWORD_MANAGER_CLASS_NAME
 import com.google.android.gms.credential.manager.common.IPendingIntentCallback
 import com.google.android.gms.credential.manager.common.ISettingsCallback
@@ -69,15 +65,8 @@ private class CredentialManagerServiceImpl(private val context: Context, overrid
                     setClassName(Constants.GMS_PACKAGE_NAME, PASSWORD_MANAGER_CLASS_NAME)
                     putExtra(EXTRA_KEY_ACCOUNT_NAME, params.account.name)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    if (params.caller != null) {
-                        putExtra(EXTRA_KEY_UTM_SOURCE, params.caller.source)
-                        putExtra(EXTRA_KEY_UTM_MEDIUM, params.caller.medium)
-                        putExtra(EXTRA_KEY_UTM_CAMPAIGN, params.caller.campaign)
-                        putExtra(EXTRA_KEY_UTM_CONTENT, params.caller.content)
-                    }
                 }
-                val flags = PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_UPDATE_CURRENT
-                val pendingIntent = PendingIntent.getActivity(context, 0, intent, flags)
+                val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
                 callback?.onPendingIntent(Status.SUCCESS, pendingIntent)
             }.onFailure {
                 Log.d(TAG, "getCredentialManagerIntent error", it)


### PR DESCRIPTION
During the testing of the latest version of Google Chrome, clicking the password management tool in the settings did not respond. The CREDENTIAL_MANAGER service method needs to be improved. 
e.g. Google Chrome <126.0.6478.110>