### PR TITLE
Improve the signOut method of AuthSignInService

### DIFF
--- a/play-services-base/src/main/java/com/google/android/gms/auth/api/signin/GoogleSignInOptions.java
+++ b/play-services-base/src/main/java/com/google/android/gms/auth/api/signin/GoogleSignInOptions.java
@@ -72,6 +72,7 @@ public class GoogleSignInOptions extends AutoSafeParcelable {
     private String logSessionId;
 
     private GoogleSignInOptions() {
+        this.scopes = new ArrayList<>();
     }
 
     /**

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AuthSignInService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AuthSignInService.kt
@@ -104,8 +104,12 @@ class AuthSignInServiceImpl(
         lifecycleScope.launchWhenStarted {
             try {
                 val account = account ?: options?.account ?: SignInConfigurationService.getDefaultAccount(context, packageName)
-                if (account != null) performSignOut(context, packageName, options, account)
-                SignInConfigurationService.setDefaultAccount(context, packageName, null)
+                if (account != null) {
+                    val defaultOptions = SignInConfigurationService.getDefaultOptions(context, packageName)
+                    Log.d(TAG, "$packageName:signOut defaultOptions:($defaultOptions)")
+                    performSignOut(context, packageName, defaultOptions ?: options, account)
+                }
+                SignInConfigurationService.setDefaultSignInInfo(context, packageName, null, null)
                 runCatching { callbacks.onSignOut(Status.SUCCESS) }
             } catch (e: Exception) {
                 Log.w(TAG, e)
@@ -138,7 +142,7 @@ class AuthSignInServiceImpl(
                         authManager.invalidateAuthToken(token)
                         authManager.isPermitted = false
                     }
-                    SignInConfigurationService.setDefaultAccount(context, packageName, account)
+                    SignInConfigurationService.setDefaultSignInInfo(context, packageName, account, options?.toJson())
                     runCatching { callbacks.onRevokeAccess(Status.SUCCESS) }
                 } catch (e: Exception) {
                     Log.w(TAG, e)

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
@@ -151,7 +151,7 @@ suspend fun performSignIn(context: Context, packageName: String, options: Google
             databaseHelper.close()
         }
     } else listOf(null, null, null, null)
-    SignInConfigurationService.setDefaultAccount(context, packageName, account)
+    SignInConfigurationService.setDefaultSignInInfo(context, packageName, account, options?.toJson())
     return GoogleSignInAccount(
         id,
         tokenId,


### PR DESCRIPTION
Fixed the issue that authToken was not reset when logging out, which caused the next login failure.
The reason was that the options when logging in were inconsistent with the options when logging out.
e.g. Subway Surfers<com.kiloo.subwaysurf>