### PR TITLE
Add Turkish (TR) strings

### DIFF
--- a/play-services-ads-identifier/core/src/main/res/values-tr/strings.xml
+++ b/play-services-ads-identifier/core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ SPDX-FileCopyrightText: 2023 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources>
+    <string name="perm_ad_id_label">Reklam kimliği izni</string>
+    <string name="perm_ad_id_description">Bir yayıncı uygulamasının geçerli bir reklam kimliğine doğrudan veya dolaylı olarak erişmesine izin verir.</string>
+    <string name="perm_ad_id_notification_label">Reklam kimliği bildirimi</string>
+    <string name="perm_ad_id_notification_description">Bir uygulamanın, kullanıcının reklam kimliği veya reklam izleme tercihi güncellendiğinde bir bildirim almasını sağlar.</string>
+</resources>

--- a/play-services-auth-api-phone/core/src/main/res/values-tr/strings.xml
+++ b/play-services-auth-api-phone/core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ SPDX-FileCopyrightText: 2023 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources>
+    <string name="sms_user_consent_title"><b>%s</b> uygulamasının aşağıdaki mesajı okumasına ve kodu girmesine izin veriyor musunuz?</string>
+    <string name="sms_user_consent_allow">İzin ver</string>
+    <string name="sms_user_consent_deny">Reddet</string>
+</resources>

--- a/play-services-base/core/src/main/res/values-tr/strings.xml
+++ b/play-services-base/core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2020, microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="foreground_service_notification_title">Arkaplanda aktif</string>
+    <string name="foreground_service_notification_text"><xliff:g example="Exposure Notification">%1$s</xliff:g> arkaplanda çalışıyor.</string>
+    <string name="foreground_service_notification_big_text"><xliff:g example="microG Services">%1$s</xliff:g> uygulamasının pil optimizasyonlarını devre dışı bırakın veya bildirim ayarlarını değiştirerek bu bildirimi gizleyin.</string>
+
+    <string name="menu_advanced">Gelişmiş</string>
+
+    <string name="list_no_item_none">Boş</string>
+    <string name="list_item_see_all">Tümünü gör</string>
+
+    <string name="open_app">Aç</string>
+
+    <string name="service_status_disabled">Devre dışı</string>
+    <string name="service_status_enabled">Etkin</string>
+    <string name="service_status_automatic">Otomatik</string>
+    <string name="service_status_manual">Manuel</string>
+    <string name="service_status_enabled_short">Açık</string>
+    <string name="service_status_disabled_short">Kapalı</string>
+</resources>

--- a/play-services-core/microg-ui-tools/src/main/res/values-tr/strings.xml
+++ b/play-services-core/microg-ui-tools/src/main/res/values-tr/strings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2013-2017 microG Project Team
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="lib_name">microG UI Araçları</string>
+    <string name="lib_license">Apache Lisansı 2.0, microG Ekibi</string>
+
+    <string name="about_version_str">Sürüm %1$s</string>
+    <string name="about_name_version_str">%1$s %2$s</string>
+    <string name="about_default_license">Tüm hakları saklıdır.</string>
+
+    <string name="prefcat_setup">Kurulum</string>
+
+    <string name="self_check_title">Çalışma durumu</string>
+    <string name="self_check_desc">microG\'yi kullanmak için sistemin doğru şekilde ayarlanıp ayarlanmadığını kontrol edin.</string>
+
+    <string name="self_check_cat_permissions">Verilen izinler</string>
+    <string name="self_check_name_permission">%1$s izni:</string>
+    <string name="self_check_resolution_permission">Buraya dokunarak izin verin. İznin verilmemesi uygulamaların hatalı davranmasına neden olabilir.</string>
+
+    <string name="about_root_title">microG UI Demosu</string>
+    <string name="about_root_summary">Özet</string>
+    <string name="about_root_version">Sürüm v0.1.0</string>
+    <string name="about_root_libraries">Dahil olan kütüphaneler</string>
+
+    <string name="about_android_support_v4">v4 Support Library</string>
+    <string name="about_android_support_v7_appcompat">v7 appcompat Support Library</string>
+    <string name="about_android_support_v7_preference">v7 preference Support Library</string>
+    <string name="about_android_support_license">Apache Lisansı 2.0, Android Open Source Project</string>
+</resources>

--- a/play-services-core/src/main/res/values-tr/permissions.xml
+++ b/play-services-core/src/main/res/values-tr/permissions.xml
@@ -50,7 +50,7 @@
     <string name="permission_service_knol_label">Knol</string>
     <string name="permission_service_knol_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Knol\'a erişmesine izin verir.</string>
     <string name="permission_service_lh2_label">Picasa Web Albümleri</string>
-    <string name="permission_service_lh2_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Picasa Web Albümleri'ne erişmesine izin verir.</string>
+    <string name="permission_service_lh2_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Picasa Web Albümleri\'ne erişmesine izin verir.</string>
     <string name="permission_service_local_label">Google Haritalar</string>
     <string name="permission_service_local_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Haritalar\'a erişmesine izin verir.</string>
     <string name="permission_service_mail_label">Google Mail</string>
@@ -128,12 +128,12 @@
     <string name="permission_scope_www.googleapis.com_auth_drive.metadata.readonly">Google Drive\'ınızdaki dosyalar ve belgeler için meta verileri görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_drive.readonly">Google Drive\'ınızdaki dosya ve belgeleri görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_drive.scripts">Google Apps Script komut dosyalarınızın davranışını değiştirme</string>
-    <string name="permission_scope_www.googleapis.com_auth_drive">Google Drive'ınızdaki dosya ve belgeleri görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive">Google Drive\'ınızdaki dosya ve belgeleri görüntüleme ve yönetme</string>
     <string name="permission_scope_www.googleapis.com_auth_freebase.readonly">Freebase hesabınızı görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_freebase">Hesabınızla Freebase\'de oturum açma</string>
     <string name="permission_scope_www.googleapis.com_auth_fusiontables">Fusion Tablolarınızı yönetme</string>
     <string name="permission_scope_www.googleapis.com_auth_fusiontables.readonly">Fusion Tablolarınızı görüntüleme</string>
-    <string name="permission_scope_www.googleapis.com_auth_games">Google Play Games'teki verilere erişmek için kapsam.</string>
+    <string name="permission_scope_www.googleapis.com_auth_games">Google Play Games\'teki verilere erişmek için kapsam.</string>
     <string name="permission_scope_www.googleapis.com_auth_gan">GAN verinizi yönetme</string>
     <string name="permission_scope_www.googleapis.com_auth_gan.readonly">GAN verinizi görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_gcm_for_chrome">Chrome için CloudMessaging</string>
@@ -166,7 +166,7 @@
     <string name="permission_scope_www.googleapis.com_auth_userinfo.email">E-posta adresinizi görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_userinfo.profile">Hesabınızla ilgili temel bilgileri görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_youtube">YouTube hesabınızı yönetme</string>
-    <string name="permission_scope_www.googleapis.com_auth_youtubepartner">YouTube'daki varlıklarınızı ve ilişkili içeriklerinizi görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_youtubepartner">YouTube\'daki varlıklarınızı ve ilişkili içeriklerinizi görüntüleme ve yönetme</string>
     <string name="permission_scope_www.googleapis.com_auth_youtube.readonly">YouTube hesabınızı görüntüleme</string>
     <string name="permission_scope_www.googleapis.com_auth_youtube.upload">YouTube videolarınızı yönetme</string>
     <string name="permission_scope_www.googleapis.com_auth_yt_analytics_monetary.readonly">YouTube içeriğiniz için YouTube Analytics parasal raporlarını görüntüleme</string>

--- a/play-services-core/src/main/res/values-tr/permissions.xml
+++ b/play-services-core/src/main/res/values-tr/permissions.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2013-2017 microG Project Team
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+    <string name="permission_service_all_label">Bütün Google hizmetleri</string>
+    <string name="permission_service_all_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile bütün Google hizmetlerine erişmesine izin verir.</string>
+    <string name="permission_service_android_label">Android hizmetleri</string>
+    <string name="permission_service_android_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Android hizmetlerine erişmesine izin verir.</string>
+    <string name="permission_service_adsense_label">AdSense</string>
+    <string name="permission_service_adsense_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile AdSense\'e erişmesine izin verir.</string>
+    <string name="permission_service_adwords_label">AdWords</string>
+    <string name="permission_service_adwords_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile AdWords\'e erişmesine izin verir.</string>
+    <string name="permission_service_ah_label">Google App Engine</string>
+    <string name="permission_service_ah_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google App Engine\'e erişmesine izin verir.</string>
+    <string name="permission_service_blogger_label">Blogger</string>
+    <string name="permission_service_blogger_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Blogger\'a erişmesine izin verir.</string>
+    <string name="permission_service_cl_label">Google Takvim</string>
+    <string name="permission_service_cl_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Takvim\'e erişmesine izin verir.</string>
+    <string name="permission_service_cp_label">Kişiler</string>
+    <string name="permission_service_cp_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Kişiler\'e erişmesine izin verir.</string>
+    <string name="permission_service_dodgeball_label">Dodgeball</string>
+    <string name="permission_service_dodgeball_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Dodgeball\'a erişmesine izin verir.</string>
+    <string name="permission_service_finance_label">Google Finans</string>
+    <string name="permission_service_finance_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Finans\'a erişmesine izin verir.</string>
+    <string name="permission_service_gbase_label">Google Base</string>
+    <string name="permission_service_gbase_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Base\'e erişmesine izin verir.</string>
+    <string name="permission_service_grandcentral_label">Google Voice</string>
+    <string name="permission_service_grandcentral_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Voice\'e erişmesine izin verir.</string>
+    <string name="permission_service_groups2_label">Google Gruplar</string>
+    <string name="permission_service_groups2_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Gruplar\'a erişmesine izin verir.</string>
+    <string name="permission_service_health_label">Google Sağlık</string>
+    <string name="permission_service_health_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Sağlık\'a erişmesine izin verir.</string>
+    <string name="permission_service_ig_label">iGoogle</string>
+    <string name="permission_service_ig_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile iGoogle\'a erişmesine izin verir.</string>
+    <string name="permission_service_jotspot_label">JotSpot</string>
+    <string name="permission_service_jotspot_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile JotSpot\'a erişmesine izin verir.</string>
+    <string name="permission_service_knol_label">Knol</string>
+    <string name="permission_service_knol_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Knol\'a erişmesine izin verir.</string>
+    <string name="permission_service_lh2_label">Picasa Web Albümleri</string>
+    <string name="permission_service_lh2_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Picasa Web Albümleri'ne erişmesine izin verir.</string>
+    <string name="permission_service_local_label">Google Haritalar</string>
+    <string name="permission_service_local_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Haritalar\'a erişmesine izin verir.</string>
+    <string name="permission_service_mail_label">Google Mail</string>
+    <string name="permission_service_mail_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Mail\'e erişmesine izin verir.</string>
+    <string name="permission_service_news_label">Google Haberler</string>
+    <string name="permission_service_news_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Haberler\'e erişmesine izin verir.</string>
+    <string name="permission_service_notebook_label">Google Notebook</string>
+    <string name="permission_service_notebook_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Notebook\'a erişmesine izin verir.</string>
+    <string name="permission_service_orkut_label">Orkut</string>
+    <string name="permission_service_orkut_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Orkut\'a erişmesine izin verir.</string>
+    <string name="permission_service_print_label">Google Kitap Arama</string>
+    <string name="permission_service_print_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Kitap Arama\'ya erişmesine izin verir.</string>
+    <string name="permission_service_sierra_label">Google Checkout hesapları</string>
+    <string name="permission_service_sierra_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Checkout hesaplarına erişmesine izin verir.</string>
+    <string name="permission_service_sierraqa_label">Google Checkout QA hesapları</string>
+    <string name="permission_service_sierraqa_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Checkout QA hesaplarına erişmesine izin verir.</string>
+    <string name="permission_service_sierrasandbox_label">Google Checkout Sandbox hesapları</string>
+    <string name="permission_service_sierrasandbox_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Checkout Sandbox hesaplarına erişmesine izin verir.</string>
+    <string name="permission_service_sitemaps_label">Google Webmaster Araçları</string>
+    <string name="permission_service_sitemaps_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Webmaster Araçları\'na erişmesine izin verir.</string>
+    <string name="permission_service_speech_label">Sesli Arama</string>
+    <string name="permission_service_speech_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Sesli Arama\'ya erişmesine izin verir.</string>
+    <string name="permission_service_speechpersonalization_label">Kişiselleştirilmiş Ses Tanıma</string>
+    <string name="permission_service_speechpersonalization_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Kişiselleştirilmiş Ses Tanıma\'ya erişmesine izin verir.</string>
+    <string name="permission_service_talk_label">Google Talk</string>
+    <string name="permission_service_talk_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Talk\'a erişmesine izin verir.</string>
+    <string name="permission_service_wifi_label">Google Wi-Fi</string>
+    <string name="permission_service_wifi_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Wi-Fi\'ye erişmesine izin verir.</string>
+    <string name="permission_service_wise_label">Google Tablolar</string>
+    <string name="permission_service_wise_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Tablolar\'a erişmesine izin verir.</string>
+    <string name="permission_service_writely_label">Google Dökümanlar</string>
+    <string name="permission_service_writely_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile Google Dökümanlar\'a erişmesine izin verir.</string>
+    <string name="permission_service_youtube_label">YouTube</string>
+    <string name="permission_service_youtube_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile YouTube\'a erişmesine izin verir.</string>
+    <string name="permission_service_YouTubeUser_label">YouTube kullanıcı adları</string>
+    <string name="permission_service_YouTubeUser_description">Uygulamanın, bağlı herhangi bir Google hesabıyla ile YouTube kullanıcı adlarına erişmesine izin verir.</string>
+    <string name="permission_scope_www.googleapis.com_auth_activity">Google uygulamalarınızın kullanım geçmişini görme</string>
+    <string name="permission_scope_www.googleapis.com_auth_adexchange.buyer">Ad Exchange alıcı hesap ayarlarını yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_adexchange.seller.readonly">Ad Exchange verinizi görme</string>
+    <string name="permission_scope_www.googleapis.com_auth_adexchange.seller">Ad Exchange verinizi görme ve değiştirme</string>
+    <string name="permission_scope_www.googleapis.com_auth_adsensehost">AdSense sağlayıcı verinizi görme, yönetme ve ilgili hesapları görme</string>
+    <string name="permission_scope_www.googleapis.com_auth_adsense.readonly">AdSense verinizi görme</string>
+    <string name="permission_scope_www.googleapis.com_auth_adsense">AdSense verinizi görme ve değiştirme</string>
+    <string name="permission_scope_www.googleapis.com_auth_analytics.readonly">Google Analytics verinizi görme</string>
+    <string name="permission_scope_www.googleapis.com_auth_analytics">Google Analytics verinizi görme ve değiştirme</string>
+    <string name="permission_scope_www.googleapis.com_auth_androidpublisher">Google Play Android Geliştiricisi\'ne erişme</string>
+    <string name="permission_scope_www.googleapis.com_auth_appengine.admin">App engine yönetici izni.</string>
+    <string name="permission_scope_www.googleapis.com_auth_apps.groups.migration">Gruplar Taşıma API için okuma ve yazma erişimi.</string>
+    <string name="permission_scope_www.googleapis.com_auth_apps.groups.settings">Bir Google Apps Grubunun ayarlarını görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_apps.licensing">Lisans Yönetici API\'na okuma/yazma erişimi.</string>
+    <string name="permission_scope_www.googleapis.com_auth_apps.order">Bayi yöneticileri ve kullanıcıları için API\'nın sanal alanında test yaparken okuma/yazma erişimi veya bir API işlemini doğrudan çağırırken okuma/yazma erişimi.</string>
+    <string name="permission_scope_www.googleapis.com_auth_apps.order.readonly">Genel okuma/yazma OAuth kapsamına ek olarak, müşterinin verilerini alırken salt okunur OAuth kapsamını kullanma.</string>
+    <string name="permission_scope_www.googleapis.com_auth_apps_reporting_audit.readonly">Yönetici Denetim API\'sine salt okunur erişme</string>
+    <string name="permission_scope_www.googleapis.com_auth_appstate">App State hizmetini kullanma kapsamı.</string>
+    <string name="permission_scope_www.googleapis.com_auth_bigquery.readonly">Verilerinizi Google BigQuery\'de görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_bigquery">Verilerinizi Google BigQuery\'de görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_blogger">Blogger hesabınızı yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_blogger.readonly">Blogger hesabınızı görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_books">Kitaplarınızı yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_calendar">Takvimlerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_calendar.readonly">Takvimlerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_cloudprint">Google Cloud Print verilerinizi görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_compute.readonly">Google Compute Engine kaynaklarınızı görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_compute">Google Compute Engine kaynaklarınızı görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_coordinate.readonly">Google Coordinate işlerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_coordinate">Google Haritalar Coordinate işlerinizi görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_devstorage.full_control">Google Cloud Storage\'daki verilerinizi ve izinlerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_devstorage.read_only">Google Cloud Storage\'daki verilerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_devstorage.read_write">Google Cloud Storage\'daki verilerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_dfareporting">Reklamverenler için DoubleClick raporlarınızı görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.appdata">Uygulama Verileri klasörüne erişim sağlama</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.apps.readonly">Google Drive uygulamalarınızı görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.file">Bu uygulama ile açtığınız veya oluşturduğunuz Google Drive dosyalarını görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.install">Kullanıcıların bir uygulamanın yüklenmesini onaylamasına izin vermek için kullanılan özel kapsam</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.metadata.readonly">Google Drive\'ınızdaki dosyalar ve belgeler için meta verileri görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.readonly">Google Drive\'ınızdaki dosya ve belgeleri görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive.scripts">Google Apps Script komut dosyalarınızın davranışını değiştirme</string>
+    <string name="permission_scope_www.googleapis.com_auth_drive">Google Drive'ınızdaki dosya ve belgeleri görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_freebase.readonly">Freebase hesabınızı görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_freebase">Hesabınızla Freebase\'de oturum açma</string>
+    <string name="permission_scope_www.googleapis.com_auth_fusiontables">Fusion Tablolarınızı yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_fusiontables.readonly">Fusion Tablolarınızı görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_games">Google Play Games'teki verilere erişmek için kapsam.</string>
+    <string name="permission_scope_www.googleapis.com_auth_gan">GAN verinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_gan.readonly">GAN verinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_gcm_for_chrome">Chrome için CloudMessaging</string>
+    <string name="permission_scope_www.googleapis.com_auth_glass.timeline">Glass timeline kapsamı</string>
+    <string name="permission_scope_www.googleapis.com_auth_gmail.compose">Taslaklar oluşturma, okuma, güncelleme ve silme. Mesaj ve taslak gönderme.</string>
+    <string name="permission_scope_www.googleapis.com_auth_gmail.modify">Konuların ve mesajların anında, kalıcı olarak silinmesi dışında tüm okuma/yazma işlemleri, Çöp Kutusunu atlayarak.</string>
+    <string name="permission_scope_www.googleapis.com_auth_gmail.readonly">Tüm kaynakları ve meta verilerini okuma - yazma işlemi yok.</string>
+    <string name="permission_scope_www.googleapis.com_auth_latitude.all.best">Kullanılabilir en iyi konumunuzu ve konum geçmişinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_latitude.all.city">Şehir düzeyinde konumunuzu ve konum geçmişinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_latitude.current.best">Kullanılabilir en iyi konumunuzu yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_latitude.current.city">Şehir düzeyinde konumunuzu yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_mapsengine">Google Maps Engine verilerinizi görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_mapsengine.readonly">Google Maps Engine verilerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_mobilemaps.firstparty">Mobil deneyim için Google Haritalar\'ınızı görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_orkut">Orkut etkinliğinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_orkut.readonly">Orkut verilerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_plus.login">Adınızı, temel bilgilerinizi ve Google+\'da bağlı olduğunuz kişilerin listesini bilme</string>
+    <string name="permission_scope_www.googleapis.com_auth_plus.me">Google\'da kim olduğunuzu bilme</string>
+    <string name="permission_scope_www.googleapis.com_auth_prediction">Google Prediction API\'de verilerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_shoppingapi">Ürün verilerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_siteverification">Kontrol ettiğiniz sitelerin ve alan adlarının listesini yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_siteverification.verify_only">Google ile yeni site doğrulamalarınızı yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_structuredcontent">Alışveriş İçeriği API\'sine okuma/yazma erişimi.</string>
+    <string name="permission_scope_www.googleapis.com_auth_taskqueue.consumer">Taskqueue\'larınızdaki görevleri tüketme</string>
+    <string name="permission_scope_www.googleapis.com_auth_taskqueue">Görevlerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_tasks">Görevlerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_tasks.readonly">Görevlerinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_tracks">Google Maps Tracks API, Bu kapsam projenizin verilerine okuma ve yazma erişimi sağlar.</string>
+    <string name="permission_scope_www.googleapis.com_auth_urlshortener">goo.gl kısa URL\'lerinizi yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_userinfo.email">E-posta adresinizi görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_userinfo.profile">Hesabınızla ilgili temel bilgileri görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_youtube">YouTube hesabınızı yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_youtubepartner">YouTube'daki varlıklarınızı ve ilişkili içeriklerinizi görüntüleme ve yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_youtube.readonly">YouTube hesabınızı görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_youtube.upload">YouTube videolarınızı yönetme</string>
+    <string name="permission_scope_www.googleapis.com_auth_yt_analytics_monetary.readonly">YouTube içeriğiniz için YouTube Analytics parasal raporlarını görüntüleme</string>
+    <string name="permission_scope_www.googleapis.com_auth_yt_analytics.readonly">YouTube içeriğiniz için YouTube Analytics raporlarını görüntüleme</string>
+</resources>

--- a/play-services-core/src/main/res/values-tr/plurals.xml
+++ b/play-services-core/src/main/res/values-tr/plurals.xml
@@ -23,8 +23,8 @@
         <item quantity="other"><xliff:g example="123">%1$d</xliff:g> kayıtlı uygulama</item>
     </plurals>
     <plurals name="cond_perm_summary">
-        <item quantity="one">microG Servisleri'nin düzgün çalışması için gerekli olan bir izin verilmedi.</item>
-        <item quantity="other">microG Servisleri'nin düzgün çalışması için gerekli olan izinler verilmedi.</item>
+        <item quantity="one">microG Servisleri\'nin düzgün çalışması için gerekli olan bir izin verilmedi.</item>
+        <item quantity="other">microG Servisleri\'nin düzgün çalışması için gerekli olan izinler verilmedi.</item>
     </plurals>
     <plurals name="cond_perm_action">
         <item quantity="one">Eksik izni iste</item>

--- a/play-services-core/src/main/res/values-tr/plurals.xml
+++ b/play-services-core/src/main/res/values-tr/plurals.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 microG Project Team
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <plurals name="pref_unifiednlp_summary">
+        <item quantity="other"><xliff:g example="3">%1$d</xliff:g> sağlayıcı ayarlandı</item>
+    </plurals>
+    <plurals name="gcm_registered_apps_counter">
+        <item quantity="other"><xliff:g example="123">%1$d</xliff:g> kayıtlı uygulama</item>
+    </plurals>
+    <plurals name="cond_perm_summary">
+        <item quantity="one">microG Servisleri'nin düzgün çalışması için gerekli olan bir izin verilmedi.</item>
+        <item quantity="other">microG Servisleri'nin düzgün çalışması için gerekli olan izinler verilmedi.</item>
+    </plurals>
+    <plurals name="cond_perm_action">
+        <item quantity="one">Eksik izni iste</item>
+        <item quantity="other">Eksik izinleri iste</item>
+    </plurals>
+</resources>

--- a/play-services-core/src/main/res/values-tr/strings.xml
+++ b/play-services-core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2017 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="gms_app_name">microG Servisleri</string>
+    <string name="gms_settings_name">microG Ayarları</string>
+    <string name="gms_settings_summary">microG servislerini ayarlar.</string>
+
+    <string name="just_a_sec">Bir saniye…</string>
+    <string name="google_account_label">Google</string>
+    <string name="ask_permission_tos">Devam ederek, bu uygulamanın ve Google\'ın bilgilerinizi kendi hizmet şartları ve gizlilik politikalarına uygun olarak kullanmasına izin vermiş olursunuz.</string>
+    <string name="ask_scope_permission_title"><xliff:g example="F-Droid">%1$s</xliff:g> şunu istiyor:</string>
+    <string name="ask_service_permission_title"><xliff:g example="F-Droid">%1$s</xliff:g> şunu kullanmak istiyor:</string>
+    <string name="account_manager_title">Google Hesap Yöneticisi</string>
+    <string name="sorry">Hay aksi…</string>
+    <string name="auth_before_connect">Cihazınızdaki bir uygulama, Google hesabına giriş yapmaya çalışıyor.\n\nEğer bu istediğiniz bir şey ise, <b>Oturum aç</b> tuşunu kullanarak Google\'ın oturum açma sayfasına bağlanın, eğer değilse, <b>İptal</b> tuşuna basarak bu menünün çıkmasına neden olan uygulamaya geri dönün.</string>
+    <string name="auth_sign_in">Oturum aç</string>
+    <string name="auth_connecting">Cihazınız, oturum açmanız için Google sunucuları ile iletişim kuruyor.\n\nBu birkaç saniye sürebilir.</string>
+    <string name="no_network_error_desc">İnternet bağlantınız yok.\n\nBu geçici bir sorun olabilir veya Android cihazınızın veri hizmetleri sağlanmamış olabilir. Bir mobil ağa veya Wi-Fi ağına bağlandığınızda tekrar deneyin.</string>
+    <string name="auth_general_error_desc">Google sunucuları ile iletişime geçerken bir sorun oluştu.\n\nDaha sonra tekrar deneyin.</string>
+    <string name="auth_finalize">Cihazınız, bilgileri hesabınıza kaydetmek için Google ile iletişime geçiyor.\n\nBu birkaç dakika sürebilir.</string>
+    <string name="allow">İzin ver</string>
+    <string name="deny">Reddet</string>
+    <string name="auth_notification_title">Yetkilendirme gerekiyor</string>
+    <string name="auth_notification_content"><xliff:g example="F-Droid">%1$s</xliff:g>, Google hesabınıza erişmek için yetkinize ihtiyaç duyuyor.</string>
+    <string name="auth_package_override_request_title"><b><xliff:g example="F-Droid">%1$s</xliff:g></b> uygulamasına <xliff:g example="account@example.com">%2$s</xliff:g> hesabının erişimine izin vermek istiyor musunuz?</string>
+    <string name="auth_package_override_request_message"><b><xliff:g example="F-Droid">%1$s</xliff:g></b> uygulaması, sanki <b><xliff:g example="F-Droid">%2$s</xliff:g> (yapımcısı <xliff:g example="F-Droid Inc.">%3$s</xliff:g> olan)</b> uygulamasıymış gibi hesabınıza erişmek istiyor. Bu, hesabınıza özel erişim sağlayabilir.</string>
+
+    <string name="signin_picker_title">Bir hesap seç</string>
+    <string name="signin_picker_subtitle">ve <xliff:g example="F-Droid">%1$s</xliff:g> uygulamasına devam et</string>
+    <string name="signin_picker_add_account_label">Başka bir hesap ekle</string>
+    <string name="signin_confirm_title"><xliff:g example="F-Droid">%1$s</xliff:g> uygulamasına giriş yapmak istediğinizi onaylayın</string>
+    <string name="signin_confirm_button_text">Kabul et ve paylaş</string>
+    <string name="signin_subtext_sharing">Devam etmek için, microG, Google hesabınızın ismini, e-posta adresini ve profil resmini <xliff:g example="F-Droid">%1$s</xliff:g> ile paylaşacak.</string>
+    <string name="signin_subtext_policy">Bu uygulamayı kullanmadan önce, uygulamanın %1$s ve %2$s inceleyin.</string>
+    <string name="signin_subtext_policy_privacy">gizlilik politikasını</string>
+    <string name="signin_subtext_policy_terms">kullanım şartlarını</string>
+
+    <string name="perm_status_broadcast_label">özel durum yayınlarını alma</string>
+    <string name="perm_gsf_read_gservices_label">Google servis bilgisini okuma</string>
+    <string name="perm_c2dm_receive_label">C2DM mesajlarını okuma</string>
+    <string name="perm_c2dm_send_label">diğer uygulamalara C2DM mesajları gönderme</string>
+    <string name="perm_gtalk_svc_label">Google sunucularına mesaj gönderme ve senkronize etme bildirimlerini alma</string>
+    <string name="perm_extended_access_label">Google servislerine ek erişim</string>
+    <string name="perm_provision_label">microG servislerine erişim</string>
+    <string name="perm_provision_description">Uygulamanın, kullanıcıya sorulmadan microG servislerinin ayarlarını değiştirmesine izin verir</string>
+
+    <string name="perm_car_speed_label">Araç hızı</string>
+    <string name="perm_car_speed_description">Aracınızın hızına erişme</string>
+
+    <string name="perm_car_info_label">Araç bilgisi</string>
+    <string name="perm_car_info_description">Aracınızın bilgisine erişme</string>
+    <string name="perm_car_fuel_label">Araç yakıt bilgisi</string>
+    <string name="perm_car_fuel_description">Aracınızın yakıt seviyesinin bilgisine erişme</string>
+    <string name="perm_car_mileage_label">Araç mesafesi</string>
+    <string name="perm_car_mileage_description">Aracınızın mesafe bilgisine erişme</string>
+    <string name="perm_car_vendor_extension_label">Araç üreticisi kanalı</string>
+    <string name="perm_car_vendor_extension_description">Araca özel bilgi alışverişi yapmak için aracınızın üretici kanalına erişme</string>
+
+    <string name="service_name_checkin">Google cihaz kaydı</string>
+    <string name="service_name_mcs">Cloud Messaging</string>
+    <string name="service_name_snet">Google SafetyNet</string>
+    <string name="service_name_vending">Play Store servisleri</string>
+
+    <string name="games_title">Google Play Oyunlar</string>
+    <string name="games_info_title"><xliff:g example="F-Droid">%1$s</xliff:g> uygulaması Play Games\'e erişmek istiyor</string>
+    <string name="games_info_content">Play Games\'i kullanmak için Google Play Games uygulamasını yüklemeniz gerekir. Uygulama Play Games olmadan çalışmaya devam edebilir, ancak beklenmedik şekilde davranabilir.</string>
+
+    <string name="pick_place_title">Bir yer seç</string>
+    <string name="pick_place_desc">Yer seçici henüz mevcut değil.</string>
+    <string name="place_picker_select_title">Bu konumu seç</string>
+    <string name="place_picker_nearby_places">Yakındaki yerler</string>
+    <string name="place_picker_location_lat_lng">(%1$.7f, %2$.7f)</string>
+
+    <string name="lacking_permission_toast">microG Servisleri: Gerekli olan <xliff:g example="have full network acccess">%1$s</xliff:g> izni sağlanmadı</string>
+
+    <string name="network_type_mobile">Mobil ağ</string>
+    <string name="network_type_wifi">Wi-Fi</string>
+    <string name="network_type_roaming">Dolaşım</string>
+    <string name="network_type_other">Diğer ağlar</string>
+
+    <!-- Self check -->
+
+    <string name="self_check_cat_fake_sig">İmza sahteciliği desteği</string>
+    <string name="self_check_cat_gms_packages">Yüklü paketler</string>
+    <string name="self_check_cat_system">Sistem</string>
+
+    <string name="self_check_name_fake_sig_perm">Sistemde imza sahteciliği desteği var mı: </string>
+    <string name="self_check_resolution_fake_sig_perm">ROM\'unuzun imza sahteciliği için yerel desteği yoktur. Yine de imza sahteciliği için Xposed veya diğer sistemleri kullanabilirsiniz. Lütfen hangi ROM\'ların imza sahteciliğini desteklediğine ve desteklemeyen ROM\'larda microG\'nin nasıl kullanılacağına ilişkin rehbere göz atın.</string>
+    <string name="self_check_name_perm_granted">Sistem imza sahteciliği desteği izni sağlandı mı: </string>
+    <string name="self_check_resolution_perm_granted">Bu, ROM\'un imza sahteciliğini desteklediğinin güçlü bir göstergesidir, ancak etkinleştirmek için daha fazla işlem yapılması gerekir. Lütfen hangi adımların gerekli olabileceğine dair rehbere göz atın.</string>
+    <string name="self_check_name_system_spoofs">Sistem imza sahteciliği yapıyor mu: </string>
+    <string name="self_check_resolution_system_spoofs">Lütfen hangi adımların gerekli olabileceğine dair rehberi kontrol edin.</string>
+
+    <string name="self_check_pkg_gms">Play Servisleri (GmsCore)</string>
+    <string name="self_check_pkg_vending">Play Store (Phonesky)</string>
+    <string name="self_check_pkg_gsf">Servis Çerçevesi (GSF)</string>
+    <string name="self_check_name_app_installed"><xliff:g example="F-Droid">%1$s</xliff:g> yüklü mü: </string>
+    <string name="self_check_resolution_app_installed"><xliff:g example="F-Droid">%1$s</xliff:g> uygulamasını veya uyumlu olanını yükleyin. Lütfen hangi uygulamaların uyumlu olduğuna dair rehbere göz atın.</string>
+    <string name="self_check_name_correct_sig"><xliff:g example="F-Droid">%1$s</xliff:g> doğru imzaya sahip mi: </string>
+    <string name="self_check_resolution_correct_sig"><xliff:g example="F-Droid">%1$s</xliff:g> uygulaması uyumlu değil veya doğru imzaya sahip değil. Lütfen hangi uygulamaların ve ROM\'ların uyumlu olduğuna dair rehbere göz atın.</string>
+
+    <string name="self_check_name_battery_optimizations">Pil optimizasyonları devre dışı bırakıldı mı:</string>
+    <string name="self_check_resolution_battery_optimizations">Pil optimizasyonlarını devre dışı bırakmak için buraya dokunun. Bunu yapmamak uygulamaların hatalı çalışmasına neden olabilir.</string>
+
+    <!-- Settings strings -->
+
+    <string name="prefcat_about">Hakkında</string>
+    <string name="prefcat_components">Bileşenler</string>
+    <string name="prefcat_configuration">Seçenekler</string>
+    <string name="prefcat_google_services">Google Servisleri</string>
+    <string name="prefcat_location_service">Konum servisi</string>
+    <string name="prefcat_services">Services</string>
+    <string name="prefcat_test">Test</string>
+
+    <string name="cond_gcm_bat_title">Pil optimizasyonları açık</string>
+    <string name="cond_gcm_bat_summary">Cloud Messaging\'i etkinleştirdiniz ancak microG Servisleri için pil optimizasyonları etkin. Anlık bildirimlerin gelmesi için pil optimizasyonlarını devre dışı bırakmalısınız.</string>
+    <string name="cond_gcm_bat_action">Optimizasyonları kapat</string>
+    <string name="cond_perm_title">İzin eksik</string>
+
+    <string name="prefs_account">Hesap tercihleri</string>
+    <string name="prefs_account_privacy">Kişisel bilgiler &amp; gizlilik</string>
+    <string name="prefs_account_security">Oturum açma &amp; güvenlik</string>
+
+    <string name="pref_auth_trust_google_title">Uygulama izinleri için Google\'a güven</string>
+    <string name="pref_auth_trust_google_summary">Devre dışı bırakıldığında, bir uygulamanın yetkilendirme isteği Google\'a gönderilmeden önce kullanıcıya sorulur. Bu devre dışı bırakılırsa bazı uygulamalar Google hesabını kullanamaz.</string>
+    <string name="pref_auth_visible_title">Uygulamaların hesapları bulmasına izin ver</string>
+    <string name="pref_auth_visible_summary">Etkinleştirildiğinde, bu cihazdaki bütün uygulamalar size sormadan Google hesaplarınızın e-posta adresini görebilecektir.</string>
+    <string name="pref_auth_include_android_id_title">Cihaz kaydı ile kimlik doğrulama</string>
+    <string name="pref_auth_include_android_id_summary">Devre dışı bırakıldığında, kimlik doğrulama istekleri cihaz kaydıyla ilişkilendirilmez, bu da yetkisiz cihazların oturum açmasına izin verebilir, ancak öngörülemeyen sonuçları olabilir.</string>
+    <string name="pref_auth_strip_device_name_title">Kimlik doğrulama yaparken cihaz adını dahil etme</string>
+    <string name="pref_auth_strip_device_name_summary">Etkinleştirildiğinde, kimlik doğrulama istekleri cihazın adını içermez, bu da yetkisiz cihazların oturum açmasına izin verebilir, ancak öngörülemeyen sonuçları olabilir.</string>
+
+    <string name="pref_checkin_enable_summary">Cihazınızı Google servislerine kaydettirir ve benzersiz bir cihaz kimliği oluşturur. microG, kayıt verilerinden Google hesap adınız dışındaki diğer tanımlayıcı bilgileri çıkarır.</string>
+    <string name="pref_device_registration_android_id">Android kimliği</string>
+
+    <string name="checkin_not_registered">Kayıtlı değil</string>
+    <string name="checkin_last_registration">Son kayıt: <xliff:g example="Yesterday, 02:20 PM">%1$s</xliff:g></string>
+    <string name="checkin_enable_switch">Cihazı kaydettir</string>
+
+    <string name="pref_info_status">Durum</string>
+    <string name="pref_more_settings">Daha fazla</string>
+
+    <string name="pref_accounts_title">Google hesapları</string>
+    <string name="pref_accounts_summary">Google hesaplarını bağla veya yönet</string>
+    <string name="prefcat_accounts_settings_title">Ayarlar</string>
+    <string name="prefcat_accounts_current_accounts_title">Hesaplar</string>
+    <string name="pref_add_account_title">Hesap</string>
+    <string name="pref_add_account_summary">Google hesabı ekle</string>
+
+    <string name="pref_gcm_enable_mcs_summary">Cloud Messaging, birçok üçüncü parti uygulama tarafından kullanılan bir anlık bildirim sağlayıcısıdır. Bunu kullanabilmek için cihaz kaydını etkinleştirmeniz gerekir.</string>
+    <string name="pref_gcm_heartbeat_title">Cloud Messaging kontrol periyodu</string>
+    <string name="pref_gcm_heartbeat_summary">Sistemin Google sunucularını kontrol etmesi için saniye cinsinden aralık. Bu sayının artırılması pil tüketimini azaltır, ancak anlık bildirimlerde gecikmelere neden olabilir.\nKullanımdan kaldırılmak üzere, gelecek sürümde değiştirilecek.</string>
+    <string name="pref_gcm_apps_title">Cloud Messaging kullanan uygulamalar</string>
+    <string name="pref_gcm_apps_summary">Cloud Messaging servisine kayıtlı uygulamaların listesi.</string>
+    <string name="pref_gcm_confirm_new_apps_title">Yeni uygulamaları sor</string>
+    <string name="pref_gcm_confirm_new_apps_summary">Anlık bildirimleri almak üzere yeni bir uygulamayı kaydetmeden önce sorun</string>
+    <string name="pref_gcm_ping_interval">Ping aralığı: <xliff:g example="10 minutes">%1$s</xliff:g></string>
+
+    <string name="pref_about_title">microG Servisleri hakkında</string>
+    <string name="pref_about_summary">Sürüm bilgisi ve kullanılan kütüphaneler</string>
+
+    <string name="gcm_app_error_unregistering">Kaydı silerken hata</string>
+    <string name="gcm_app_not_installed_anymore">Artık yüklü değil</string>
+    <string name="gcm_unregister_app">Kaydı sil</string>
+    <string name="gcm_not_registered">Kayıtlı değil</string>
+    <string name="gcm_no_message_yet">Henüz mesaj gelmedi</string>
+    <string name="gcm_last_message_at">Son mesaj: <xliff:g example="Yesterday, 02:20 PM">%1$s</xliff:g></string>
+    <string name="gcm_registered">Kayıtlı</string>
+    <string name="gcm_registered_since"><xliff:g example="Yesterday, 02:20 PM">%1$s</xliff:g> zamanından beri kayıtlı</string>
+    <string name="gcm_unregister_confirm_title"><xliff:g example="F-Droid">%1$s</xliff:g> uygulamanın kaydını sil?</string>
+    <string name="gcm_unregister_confirm_message">Bazı uygulamalar otomatik olarak yeniden kaydolmaya çalışmaz ve/veya bunu manuel olarak yapmak için bir seçenek sunmaz. Bu uygulamalar kaydı kaldırıldıktan sonra düzgün çalışmayabilir.\nEmin misiniz?</string>
+    <string name="gcm_unregister_after_deny_message">Zaten kayıtlı olan bir uygulamanın anlık bildirimlere kaydolmasını reddettiniz.\nGelecekte de anlık bildirimleri almaması için şimdiki kaydını kaldırmak istiyor musunuz?</string>
+    <string name="gcm_messages_counter">Mesaj sayısı: <xliff:g example="123">%1$d</xliff:g> (<xliff:g example="12345">%2$d</xliff:g> bayt)</string>
+    <string name="gcm_network_state_disconnected">Bağlı değil</string>
+    <string name="gcm_network_state_connected"><xliff:g example="2 hours ago">%1$s</xliff:g> zamanından beri bağlı</string>
+    <string name="gcm_enable_switch">Anlık bildirimleri al</string>
+    <string name="gcm_allow_app_popup"><xliff:g example="F-Droid">%1$s</xliff:g> uygulamasının anlık bildirimlere kaydedilmesine izin vermek istiyor musunuz?</string>
+
+    <string name="pref_push_app_allow_register_title">Kaydetmeye izin ver</string>
+    <string name="pref_push_app_allow_register_summary">Uygulamanın anlık bildirimler için kaydedilmesine izin ver.</string>
+    <string name="pref_push_app_wake_for_delivery_title">Anlık bildirimde uygulamayı başlat</string>
+    <string name="pref_push_app_wake_for_delivery_summary">Gelen anlık bildirimleri almak için uygulamayı arka plandayken başlatın.</string>
+    <string name="prefcat_push_apps_title">Anlık bildirim kullanan uygulamalar</string>
+    <string name="prefcat_push_apps_registered_title">Kayıtlı uygulamalar</string>
+    <string name="prefcat_push_apps_unregistered_title">Kayıtlı olmayan uygulamalar</string>
+    <string name="prefcat_push_networks_title">Anlık bildirimler için kullanılacak ağlar</string>
+
+    <string name="safetynet_intro">Google SafetyNet, cihazın yeterince güvenli ve Android CTS ile uyumlu olduğunu doğrulayan bir cihaz sertifikasyon sistemidir. Bazı uygulamalar SafetyNet\'i güvenlik nedeniyle veya uygulamanın kurcalanmasına karşı korumak için kullanır.\n\nmicroG Servisleri, SafetyNet\'in özgür bir versiyonuna sahiptir, ancak resmi sunucu, SafetyNet isteklerinin sahipli DroidGuard sistemiyle imzalanmasını gerektirir.</string>
+    <string name="safetynet_enable_switch">Cihazın doğrulanmasına izin ver</string>
+
+    <string name="pref_safetynet_test_title">SafetyNet kontrolü yap</string>
+    <string name="pref_recaptcha_test_title">ReCAPTCHA\'yı test et</string>
+    <string name="pref_recaptcha_enterprise_test_title">ReCAPTCHA Enterprise\'ı test et</string>
+    <string name="pref_test_summary_passed">Tüm testleri geçti</string>
+    <string name="pref_test_summary_failed">Başarısız: %s</string>
+    <string name="pref_test_summary_warn">Uyarı: %s</string>
+    <string name="pref_test_summary_running">Çalışıyor…</string>
+    <string name="pref_droidguard_operation_mode">Çalışma modu</string>
+    <string name="pref_droidguard_unsupported_summary">DroidGuard çalıştırılması bu cihazda desteklenmiyor. SafetyNet hizmetleri yanlış davranabilir.</string>
+    <string name="prefcat_safetynet_apps_title">SafetyNet kullanan uygulamalar</string>
+    <string name="menu_clear_recent_requests">Önceki istekleri temizle</string>
+    <string name="safetynet_last_run_at">Son kullanım: <xliff:g example="Yesterday, 02:20 PM">%1$s</xliff:g></string>
+
+    <string name="profile_name_native">Dahili</string>
+    <string name="profile_name_real">Gerçek</string>
+    <string name="profile_name_user">Özel: %s</string>
+    <string name="profile_name_auto">Otomatik: %s</string>
+    <string name="profile_name_system">Sistem: %s</string>
+    <string name="pref_device_registration_import_custom_profile_title">Özel profili içe aktar</string>
+    <string name="pref_device_registration_serial_title">Seri numarası</string>
+    <string name="pref_device_registration_import_custom_profile_summary">Dosyadan cihaz profili içe aktar</string>
+    <string name="pref_device_registration_select_profile_title">Profil seç</string>
+    <string name="pref_device_registration_device_profile_category">Cihaz profili</string>
+
+    <string name="pref_safetynet_recent_uses">Son kullanımlar</string>
+    <string name="pref_safetynet_recent_attestation_summary">Kontrol: %s</string>
+    <string name="pref_safetynet_recent_recaptcha_summary">ReCaptcha: %s</string>
+    <string name="pref_safetynet_recent_recaptcha_enterprise_summary">ReCaptcha Enterprise: %s</string>
+    <string name="pref_safetynet_recent_copy_json">JSON olarak JWS verisini kopyala</string>
+    <string name="pref_safetynet_recent_advice">Tavsiye</string>
+    <string name="pref_safetynet_recent_eval_type">Çalıştırma türü</string>
+    <string name="pref_safetynet_recent_response_status">Yanıt kodu</string>
+    <string name="pref_safetynet_recent_cat_response">Yanıt verisi</string>
+    <string name="pref_safetynet_recent_cat_request">İstek verisi</string>
+    <string name="pref_safetynet_recent_nonce">Sağlama (Hex)</string>
+    <string name="pref_safetynet_recent_request_time">İstek zamanı</string>
+    <string name="pref_safetynet_recent_request_type">İstek türü</string>
+    <string name="pref_safetynet_recent_cat_basic">Basit veri</string>
+    <string name="pref_safetynet_recent_token">Jeton</string>
+    <string name="pref_safetynet_recent_copied">Panoya kopyalandı!</string>
+    <string name="pref_safetynet_test_integrity_cts_passed">Bütünlük and CTS geçti</string>
+    <string name="pref_safetynet_test_cts_failed">CTS başarısız</string>
+    <string name="pref_safetynet_test_integrity_failed">Bütünlük başarısız</string>
+    <string name="pref_safetynet_test_not_completed">Henüz tamamlanmadı</string>
+    <string name="pref_safetynet_test_no_result">Sonuç yok</string>
+    <string name="pref_safetynet_test_invalid_json">Geçersiz JSON</string>
+
+    <string name="push_notifications_summary_off">KAPALI</string>
+    <string name="push_notifications_summary_automatic">AÇIK / Otomatik: %s</string>
+    <string name="push_notifications_summary_manual">AÇIK / Manuel: %s</string>
+    <string name="push_notifications_summary_values_seconds">%s saniye</string>
+    <string name="push_notifications_summary_values_minutes">%s dakika</string>
+
+    <string name="pref_vending_summary_licensing_off">Lisanslama kapalı</string>
+    <string name="pref_vending_summary_licensing_on">Lisanslama açık</string>
+    <string name="pref_vending_licensing_category">Google Play Lisanslama</string>
+    <string name="pref_vending_licensing_enable_switch">Lisans doğrulama isteklerine cevap ver</string>
+    <string name="pref_vending_license_enable_summary">Bazı uygulamalar, kendilerinin gerçekten de Google Play\'den satın alındığının doğrulanmasını talep eder. Bir uygulama tarafından talep edilirse, microG, Google\'dan bir satın alma kanıtı indirebilir. Devre dışı bırakılırsa veya Google hesabı eklenmezse, lisans doğrulama istekleri görmezden gelinir.</string>
+
+    <string name="feedback_disabled">Geri bildirim henüz mevcut değil</string>
+    <string name="backup_disabled">Yedekleme henüz mevcut değil</string>
+
+    <string name="pref_vending_billing_category">Google Play Satın Alımları</string>
+    <string name="pref_vending_billing_enable_switch">Satın alım isteklerini gerçekleştir</string>
+    <string name="pref_vending_billing_enable_summary">Etkinleştirildikten sonra, bazı uygulamalar Google\'ın Play Satın Alım hizmeti aracılığıyla satın alma işlemlerini tamamlayabilir veya abonelik başlatabilir.</string>
+    <string name="pref_vending_billing_note_experimental">Uyarı, bu özellik deneyseldir ve paranızın kaybedilmesine yol açabilir.</string>
+    <string name="pref_vending_billing_note_licensing">Bazı uygulamalar, satın alma işlemlerinizi doğrulamak için lisans doğrulamayı da etkinleştirmenizi gerektirebilir.</string>
+
+    <string name="credentials_assisted_cancel">İptal</string>
+    <string name="credentials_assisted_continue">Devam et</string>
+    <string name="credentials_assisted_confirmation_header">Oturumunuz açılıyor</string>
+    <string name="credentials_assisted_continue_as_user_button_label">%1$s olarak devam et</string>
+    <string name="credentials_assisted_sign_back_title">Google ile %1$s uygulamasında tekrar oturum aç</string>
+    <string name="credentials_assisted_signin_consent_header">%1$s olarak oturum açılıyor</string>
+    <string name="credentials_assisted_signin_consent">Devam ettiğinizde Google, adınızı, e-posta adresinizi ve profil resminizi %1$s ile paylaşacaktır. %1$s uygulamasının gizlilik politikasına ve hizmet şartlarına göz atın.</string>
+    <string name="credentials_assisted_signin_description">Google ile oturum aç özelliğini Google hesaplarınızdan yönetebilirsiniz.</string>
+    <string name="credentials_assisted_choose_account_label">Hesap seç</string>
+    <string name="credentials_assisted_choose_account_subtitle">%1$s uygulamasına devam etmek için</string>
+    <string name="credentials_assisted_signin_button_text_long">Google ile oturum aç</string>
+
+</resources>

--- a/play-services-droidguard/core/src/main/res/values-tr/strings.xml
+++ b/play-services-droidguard/core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2021 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<resources>
+    <string name="prefcat_droidguard_mode">DroidGuard çalışma modu</string>
+    <string name="pref_droidguard_mode_embedded_title">Gömülü</string>
+    <string name="pref_droidguard_mode_embedded_summary">Yerel DroidGuard çalıştırıcısını kullan</string>
+    <string name="pref_droidguard_mode_network_title">Uzaktan</string>
+    <string name="pref_droidguard_mode_network_summary">Ağ üzerinden uzak bir DroidGuard çalıştırıcısına bağlan</string>
+</resources>

--- a/play-services-fido/core/src/main/res/values-tr/strings.xml
+++ b/play-services-fido/core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2022 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources>
+    <string name="fido_welcome_title">Güvenlik anahtarınızı %1$s ile kullanın</string>
+    <string name="fido_welcome_body">Güvenlik anahtarınızı %1$s ile kullanmak, özel verilerinizin korunmasına yardımcı olur.</string>
+    <string name="fido_welcome_button_get_started">Başla</string>
+    <string name="fido_welcome_privileged_info">%1$s, güvenlik anahtarınızı %2$s ile kullanmak için güvenilir bir tarayıcı görevi görür.</string>
+    <string name="fido_welcome_privileged_check">Evet, %1$s benim güvenilir tarayıcımdır ve üçüncü taraf web sitelerinde güvenlik anahtarlarını kullanmasına izin verilmelidir.</string>
+    <string name="fido_transport_selection_title">Güvenlik anahtarınızı nasıl kullanacağınızı seçin</string>
+    <string name="fido_transport_selection_body">Güvenlik anahtarları Bluetooth, NFC ve USB ile çalışır. Anahtarınızı nasıl kullanmak istediğinizi seçin.</string>
+    <string name="fido_biometric_prompt_title">Kimliğinizi doğrulayın</string>
+    <string name="fido_biometric_prompt_body">%1$s, siz olduğunuzu doğrulamak istiyor.</string>
+    <string name="fido_usb_title">USB güvenlik anahtarınızı bağlayın</string>
+    <string name="fido_usb_prompt_body">Güvenlik anahtarınızı USB bağlantı noktasına veya bir USB kablosuyla bağlayın. Güvenlik anahtarınızda bir düğme veya altın bir disk varsa, şimdi ona dokunun.</string>
+    <string name="fido_nfc_title">NFC güvenlik anahtarınızı bağlayın</string>
+    <string name="fido_nfc_prompt_body">Titreşim durana kadar anahtarınızı cihazınızın arkasına doğru düz bir şekilde tutun</string>
+    <string name="fido_transport_selection_bluetooth">Güvenlik anahtarınızı Bluetooth ile kullanın</string>
+    <string name="fido_transport_selection_nfc">Güvenlik anahtarınızı NFC ile kullanın</string>
+    <string name="fido_transport_selection_usb">Güvenlik anahtarınızı USB ile kullanın</string>
+    <string name="fido_transport_selection_biometric">Bu cihazı ekran kilidi ile kullanın</string>
+    <string name="fido_transport_usb_wait_connect_body">Lütfen USB güvenlik anahtarınızı bağlayın.</string>
+    <string name="fido_transport_usb_wait_confirm_body">Lütfen %1$s üzerindeki altın halkaya veya diske dokunun.</string>
+</resources>

--- a/play-services-location/core/src/main/res/values-tr/strings.xml
+++ b/play-services-location/core/src/main/res/values-tr/strings.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ SPDX-FileCopyrightText: 2023 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="service_name_location">Konum</string>
+    <string name="prefcat_location_apps_title">Son erişim</string>
+    <string name="prefcat_location_wifi_title">Wi-Fi konumu</string>
+    <string name="prefcat_location_cell_title">Mobil ağ konumu</string>
+    <string name="prefcat_geocoder_title">Adres çözümleyici</string>
+    <string name="pref_location_wifi_mls_enabled_title">Mozilla\'dan iste</string>
+    <string name="pref_location_wifi_mls_enabled_summary">Mozilla Konum Servisi\'nden Wi-Fi-tabanlı konum bilgisini çek.</string>
+    <string name="pref_location_wifi_moving_enabled_title">Hotspot\'tan iste</string>
+    <string name="pref_location_wifi_moving_enabled_summary">Bağlı olunduğunda, Wi-Fi konumunu direkt olarak desteklenen hotspot ağlarından al.</string>
+    <string name="pref_location_wifi_learning_enabled_title">GPS\'den hatırla</string>
+    <string name="pref_location_wifi_learning_enabled_summary">GPS kullanılıyorken Wi-Fi konumlarını yerel olarak sakla.</string>
+    <string name="pref_location_cell_mls_enabled_title">Mozilla\'dan iste</string>
+    <string name="pref_location_cell_mls_enabled_summary">Mozilla Konum Servisi\'nden mobil ağ baz istasyonlarının bilgisini çek.</string>
+    <string name="pref_location_cell_learning_enabled_title">GPS\'den hatırla</string>
+    <string name="pref_location_cell_learning_enabled_summary">GPS kullanılıyorken mobil ağ konumlarını yerel olarak sakla.</string>
+    <string name="pref_geocoder_nominatim_enabled_title">Nominatim kullan</string>
+    <string name="pref_geocoder_nominatim_enabled_summary">Adresleri çözmek için OpenStreetMap Nominatim kullan.</string>
+
+    <string name="fragment_location_apps_title">Konum iznine sahip uygulamalar</string>
+    <string name="location_app_last_access_at">Son erişim: <xliff:g example="Yesterday, 02:20 PM">%1$s</xliff:g></string>
+
+    <string name="pref_location_app_force_coarse_title">Zorla yaklaşık konum sağla</string>
+    <string name="pref_location_app_force_coarse_summary">Uygulamaya verilen izinleri görmezden gelerek, bu uygulamaya yaklaşık konum bilgisi ver.</string>
+
+    <string name="location_settings_dialog_message_title_for_better_experience">Daha iyi bir deneyim için, microG\'nin konum hizmetini kullanan cihaz konumunu açın</string>
+    <string name="location_settings_dialog_message_title_to_continue">Devam etmek için, microG\'nin konum hizmetini kullanan cihaz konumunu açın</string>
+    <string name="location_settings_dialog_message_details_start_paragraph">Cihazınızın şunlara ihtiyacı var:</string>
+    <string name="location_settings_dialog_message_location_services_gps_and_nlp">GPS, Wi‑Fi, şebekeler ve sensörleri kullanma</string>
+    <string name="location_settings_dialog_message_grant_permissions">microG Servisler\'ine konum izinleri verme</string>
+    <string name="location_settings_dialog_message_gls_consent">microG konum hizmetini kullanma; bu hizmetin bir parçası olarak, microG, konum verilerini periyodik olarak toplayabilir ve bu verileri konum doğruluğunu ve konum tabanlı hizmetleri geliştirmek için anonim bir şekilde kullanabilir.</string>
+
+    <string name="location_settings_dialog_message_details_end_paragraph">Detaylar için, konum ayarlarına gidin.</string>
+    <string name="location_settings_dialog_btn_cancel">Hayır, teşekkürler</string>
+    <string name="location_settings_dialog_btn_sure">Tamam</string>
+
+    <string name="pref_location_custom_url_title">Hizmet bağlantısını ayarla</string>
+    <string name="pref_location_custom_url_reset">Sıfırla</string>
+    <string name="pref_location_custom_url_summary">Bu, özel bir hizmet URL\'si ayarlamaya izin verir. Geçersiz değerler, konum hizmetlerinin yanıt vermemesine veya tamamen kullanılamamasına neden olabilir.</string>
+    <string name="pref_location_custom_url_details">/v1/geolocate yolu otomatik olarak eklenir. Eğer konum sağlayıcısı bir anahtar gerektiriyorsa, bu anahtar URL köküne bir sorgu parametresi olarak eklenebilir.</string>
+    <string name="pref_location_custom_url_input_hint">Özel hizmet bağlantısı</string>
+</resources>

--- a/play-services-oss-licenses/src/main/res/values-tr/strings.xml
+++ b/play-services-oss-licenses/src/main/res/values-tr/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2022 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<resources>
+    <string name="license_content_error">Lisans alınırken bir hata oluştu.</string>
+    <string name="no_licenses_available">Bu uygulamanın herhangi bir açık kaynak kod lisansı yok.</string>
+    <string name="oss_license_title">Açık kaynak kod lisansları</string>
+    <!-- The following strings are not used by the library code but must be kept for compatibility,
+         since they may be used by apps that depend on it. -->
+    <string name="license_is_loading">Lisans bilgisi yükleniyor.</string>
+    <string name="license_list_is_loading">Lisans listesi yükleniyor.</string>
+    <string name="preferences_license_summary">Açık kaynak kodlu yazılım için lisans detayları</string>
+</resources>

--- a/vending-app/src/main/res/values-tr/strings.xml
+++ b/vending-app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2014 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources>
+    <string name="app_name">microG Eşlikçisi</string>
+    <string name="toast_installed">microG Eşlikçisi yalnız başına kullanılamaz. Onun yerine microG Servisleri ayarları açıldı.</string>
+    <string name="toast_not_installed">microG Eşlikçisi yalnız başına kullanılamaz. microG\'yi kullanmak için lütfen microG Servisleri\'ni yükleyin.</string>
+
+    <string name="license_notification_channel_name">Lisans bildirimleri</string>
+    <string name="license_notification_channel_description">Bir uygulama, lisansını doğrulamaya çalıştığında ancak siz herhangi bir Google hesabında oturum açmadığınızda haber verir.</string>
+    <string name="license_notification_title">%1$s lisansını doğrulayamıyor</string>
+    <string name="license_notification_body">Uygulama hatalı davranıyorsa, uygulamayı satın aldığınız bir Google hesabında oturum açın.</string>
+
+    <string name="license_notification_sign_in">Oturum Aç</string>
+    <string name="license_notification_ignore">Yoksay</string>
+
+    <string name="pay_disabled">Ödeme henüz mevcut değil</string>
+
+    <string name="confirm_purchase">Ödemeyi Onayla</string>
+    <string name="error_network">İnternet bağlı değil. Lütfen Wi-Fi veya mobil verinin açık olduğundan emin olun ve tekrar deneyin.</string>
+    <string name="error_passwd">Girdiğiniz şifre yanlış.</string>
+    <string name="error_unknown">Bilinmeyen hata, lütfen çıkın ve tekrar deneyin.</string>
+    <string name="tips_input_passwd">Şifrenizi girin</string>
+    <string name="tips_remember_login_info">Oturumumu bu cihazda hatırla</string>
+    <string name="tips_forget_passwd">Şifrenizi mi unuttunuz?</string>
+    <string name="tips_more_details">Daha fazla bilgi</string>
+    <string name="text_verify_button">Onayla</string>
+</resources>


### PR DESCRIPTION
This PR adds Turkish (language code is `tr`) strings for all packages from what I could find, except `play-services-nearby` (I had no time to also translate that but plan to do that later.)

* `play-services-ads-identifier`
* `play-services-auth-api-phone`
* `play-services-base`
* `play-services-core`
* `play-services-droidguard`
* `play-services-fido`
* `play-services-location`
* `play-services-oss-licenses`
* `vending-app`

I've kept copyright notices as-is, and I noticed few of strings a wrapped with `"` (quotation) character, I assume it is written to escape `'` (apostrophe), so I added backslash in front of each `'` to avoid wrapping the whole string with `"` instead to make it consistent with other strings. I'm not sure if I have to do something else to make microG display in Turkish but after taking a look at Android documentation, I guess adding a new folder `values-tr` is enough.

Thanks for making microG by the way, I cannot express in words how much it has helped me.