### PR TITLE
Better discovery on how to translate microG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # microG Services
 
 [![Build status](https://github.com/microg/GmsCore/actions/workflows/build.yml/badge.svg)](https://github.com/microg/GmsCore/actions/workflows/build.yml)
-<a href="https://hosted.weblate.org/engage/microg/">
+<a href=TRANSLATION.md>
 <img src="https://hosted.weblate.org/widget/microg/svg-badge.svg" alt="Translation status" />
 </a>
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-microG Services
-=======
+# microG Services
+
 [![Build status](https://github.com/microg/GmsCore/actions/workflows/build.yml/badge.svg)](https://github.com/microg/GmsCore/actions/workflows/build.yml)
+<a href="https://hosted.weblate.org/engage/microg/">
+<img src="https://hosted.weblate.org/widget/microg/svg-badge.svg" alt="Translation status" />
+</a>
 
 microG Services is a FLOSS (Free/Libre Open Source Software) framework to allow applications designed for Google Play Services to run on systems, where Play Services is not available.
 
 ### Please refer to the [wiki](https://github.com/microg/GmsCore/wiki) for downloads and instructions
+
+## Translations
+
+If you'd like to help translate microG, take a look at [TRANSLATION](TRANSLATION.md).
 
 
 License

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,9 @@
+# How to translate microG
+
+microG can be translated using Weblate. The microG project is hosted at https://hosted.weblate.org/projects/microg/.
+
+> At the moment, [microG-UI-tools](play-services-core/microg-ui-tools), an internal component, is not available for translation using Weblate. You may want to open a PR for this. This component hosts strings for the "Self-Check" menu and a few other things.
+
+Preferably do not open a PR for components that can be translated with Weblate. Otherwise, merge conflicts can happen. If you already made a PR, you can try [importing](https://docs.weblate.org/en/latest/user/files.html#uploading-translations) the files manually into Weblate for each component.
+
+If your language is not available for translation from a quick look, you may need to first create an account, set your language in your settings, check the project again, and then you should be able to add it.


### PR DESCRIPTION
microG currently does not advertise its Weblate instance anywhere. Because of this, most people don't know that microG has one. The only way to tell is by checking commits and checking the import translation commits. 

This PR attempts at addressing that by giving documentation on how translations work and pointing to it in README.

* Creates a TRANSLATION.md file meant to explain the state of translations for the microG project
* Adds a widget that shows how translated out of the supported languages microG is
* Adds a section that points to TRANSLATION.md in the README
* Inside README, the lack of microG-UI-tools in Weblate is pointed out so that translators are aware of this issue and can translate it without realizing it only after a release happens

Fixes #2303