### PR TITLE
FIDO: Credential selection, PIN authentication, screenlock authentication fixes

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/login/FidoHandler.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/login/FidoHandler.kt
@@ -14,6 +14,7 @@ import com.google.android.gms.fido.fido2.api.common.*
 import kotlinx.coroutines.CancellationException
 import org.json.JSONArray
 import org.json.JSONObject
+import org.microg.gms.fido.core.AuthenticatorResponseWrapper
 import org.microg.gms.fido.core.RequestHandlingException
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandlerCallback
@@ -68,9 +69,10 @@ class FidoHandler(private val activity: LoginActivity) : TransportHandlerCallbac
         })
     }
 
-    private fun sendSuccessResult(response: AuthenticatorResponse, transport: Transport) {
-        Log.d(TAG, "Finish with success response: $response")
+    private suspend fun sendSuccessResult(responseWrapper: AuthenticatorResponseWrapper, transport: Transport) {
+        val response = responseWrapper.responseChoices.get(0).second.invoke()
         if (response is AuthenticatorAssertionResponse) {
+            Log.d(TAG, "Finish with success response: $response")
             sendResult(JSONObject().apply {
                 val base64Flags = Base64.NO_PADDING + Base64.NO_WRAP + Base64.URL_SAFE
                 put("keyHandle", response.keyHandle?.toBase64(base64Flags))

--- a/play-services-fido/core/build.gradle
+++ b/play-services-fido/core/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'kotlin-parcelize'
 
 dependencies {
     api project(':play-services-fido')

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -39,7 +39,7 @@ class UserInfo(
 @Parcelize
 class AuthenticatorResponseWrapper (
     val responseChoices: List<Pair<UserInfo?, suspend () -> AuthenticatorResponse>>,
-    val deleteFunctions: List<() -> Unit> = listOf()
+    val deleteFunctions: List<suspend () -> Boolean> = ArrayList()
 ) : Parcelable
 
 val RequestOptions.registerOptions: PublicKeyCredentialCreationOptions

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -24,6 +24,7 @@ import java.net.HttpURLConnection
 import java.security.MessageDigest
 
 class RequestHandlingException(val errorCode: ErrorCode, message: String? = null) : Exception(message)
+class MissingPinException(message: String? = null): Exception(message)
 
 enum class RequestOptionsType { REGISTER, SIGN }
 
@@ -148,14 +149,6 @@ private suspend fun isAppIdAllowed(context: Context, appId: String, facetId: Str
 }
 
 suspend fun RequestOptions.checkIsValid(context: Context, facetId: String, packageName: String?) {
-    if (type == REGISTER) {
-        if (registerOptions.authenticatorSelection?.requireResidentKey == true) {
-            throw RequestHandlingException(
-                NOT_SUPPORTED_ERR,
-                "Resident credentials or empty 'allowCredentials' lists are not supported  at this time."
-            )
-        }
-    }
     if (type == SIGN) {
         if (signOptions.allowList.isNullOrEmpty()) {
             throw RequestHandlingException(NOT_ALLOWED_ERR, "Request doesn't have a valid list of allowed credentials.")

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -7,6 +7,7 @@ package org.microg.gms.fido.core
 
 import android.content.Context
 import android.net.Uri
+import android.os.Parcelable
 import android.util.Base64
 import com.android.volley.toolbox.JsonArrayRequest
 import com.android.volley.toolbox.JsonObjectRequest
@@ -15,6 +16,7 @@ import com.google.android.gms.fido.fido2.api.common.*
 import com.google.android.gms.fido.fido2.api.common.ErrorCode.*
 import com.google.common.net.InternetDomainName
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONObject
 import org.microg.gms.fido.core.RequestOptionsType.REGISTER
@@ -33,9 +35,12 @@ class UserInfo(
     val displayName: String? = null,
     val icon: String? = null
 )
+
+@Parcelize
 class AuthenticatorResponseWrapper (
-    val responseChoices: List<Pair<UserInfo?, suspend () -> AuthenticatorResponse>>
-)
+    val responseChoices: List<Pair<UserInfo?, suspend () -> AuthenticatorResponse>>,
+    val deleteFunctions: List<() -> Unit> = listOf()
+) : Parcelable
 
 val RequestOptions.registerOptions: PublicKeyCredentialCreationOptions
     get() = when (this) {

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -28,6 +28,14 @@ class MissingPinException(message: String? = null): Exception(message)
 class WrongPinException(message: String? = null): Exception(message)
 
 enum class RequestOptionsType { REGISTER, SIGN }
+class UserInfo(
+    val name: String,
+    val displayName: String? = null,
+    val icon: String? = null
+)
+class AuthenticatorResponseWrapper (
+    val responseChoices: List<Pair<UserInfo?, suspend () -> AuthenticatorResponse>>
+)
 
 val RequestOptions.registerOptions: PublicKeyCredentialCreationOptions
     get() = when (this) {
@@ -150,11 +158,6 @@ private suspend fun isAppIdAllowed(context: Context, appId: String, facetId: Str
 }
 
 suspend fun RequestOptions.checkIsValid(context: Context, facetId: String, packageName: String?) {
-    if (type == SIGN) {
-        if (signOptions.allowList.isNullOrEmpty()) {
-            throw RequestHandlingException(NOT_ALLOWED_ERR, "Request doesn't have a valid list of allowed credentials.")
-        }
-    }
     if (facetId.startsWith("https://")) {
         if (topDomainOf(Uri.parse(facetId).host) != topDomainOf(rpId)) {
             throw RequestHandlingException(NOT_ALLOWED_ERR, "RP ID $rpId not allowed from facet $facetId")

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/RequestHandling.kt
@@ -25,6 +25,7 @@ import java.security.MessageDigest
 
 class RequestHandlingException(val errorCode: ErrorCode, message: String? = null) : Exception(message)
 class MissingPinException(message: String? = null): Exception(message)
+class WrongPinException(message: String? = null): Exception(message)
 
 enum class RequestOptionsType { REGISTER, SIGN }
 

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/CoseKey.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/CoseKey.kt
@@ -19,20 +19,22 @@ class CoseKey(
     constructor(algorithm: Algorithm, x: BigInteger, y: BigInteger, curveId: Int, curvePointSize: Int) :
             this(algorithm, x.toByteArray(curvePointSize), y.toByteArray(curvePointSize), curveId)
 
-    fun encode(): ByteArray = CBORObject.NewMap().apply {
+    fun encode(): ByteArray = encodeAsCbor().EncodeToBytes(CBOREncodeOptions.DefaultCtap2Canonical)
+
+    fun encodeAsCbor(): CBORObject = CBORObject.NewMap().apply {
         set(KTY, 2.encodeAsCbor())
         set(ALG, algorithm.algoValue.encodeAsCbor())
         set(CRV, curveId.encodeAsCbor())
         set(X, x.encodeAsCbor())
         set(Y, y.encodeAsCbor())
-    }.EncodeToBytes(CBOREncodeOptions.DefaultCtap2Canonical)
+    }
 
     companion object {
-        private const val KTY = 1
-        private const val ALG = 3
-        private const val CRV = -1
-        private const val X = -2
-        private const val Y = -3
+        const val KTY = 1
+        const val ALG = 3
+        const val CRV = -1
+        const val X = -2
+        const val Y = -3
 
         fun BigInteger.toByteArray(size: Int): ByteArray {
             val res = ByteArray(size)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
@@ -37,6 +37,18 @@ class AuthenticatorClientPINRequest(
                 "newPinEnc=${newPinEnc?.contentToString()}, " +
                 "pinHashEnc=${pinHashEnc?.contentToString()})"
     }
+
+    companion object {
+        // PIN protocol versions
+        const val PIN_PROTOCOL_VERSION_ONE = 0x01
+
+        // PIN subcommands
+        const val GET_RETRIES = 0x01
+        const val GET_KEY_AGREEMENT = 0x02
+        const val SET_PIN = 0x03
+        const val CHANGE_PIN = 0x04
+        const val GET_PIN_TOKEN = 0x05
+    }
 }
 
 class AuthenticatorClientPINResponse(

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorClientPIN.kt
@@ -1,0 +1,54 @@
+package org.microg.gms.fido.core.protocol.msgs
+
+import com.upokecenter.cbor.CBORObject
+import org.microg.gms.fido.core.protocol.CoseKey
+import org.microg.gms.fido.core.protocol.decodeAsCoseKey
+import org.microg.gms.fido.core.protocol.encodeAsCbor
+
+class AuthenticatorClientPINCommand(request: AuthenticatorClientPINRequest) :
+    Ctap2Command<AuthenticatorClientPINRequest, AuthenticatorClientPINResponse>(request) {
+
+    override fun decodeResponse(obj: CBORObject) = AuthenticatorClientPINResponse.decodeFromCbor(obj)
+
+    override val timeout: Long
+        get() = 60000
+
+}
+
+class AuthenticatorClientPINRequest(
+    val pinProtocol: Int,
+    val subCommand: Int,
+    val keyAgreement: CoseKey? = null,
+    val pinAuth: ByteArray? = null,
+    val newPinEnc: ByteArray? = null,
+    val pinHashEnc: ByteArray? = null
+) : Ctap2Request(0x06, CBORObject.NewMap().apply {
+    set(0x01, pinProtocol.encodeAsCbor())
+    set(0x02, subCommand.encodeAsCbor())
+    if (keyAgreement != null) set(0x03, keyAgreement.encodeAsCbor())
+    if (pinAuth != null) set(0x04, pinAuth.encodeAsCbor())
+    if (newPinEnc != null) set(0x05, newPinEnc.encodeAsCbor())
+    if (pinHashEnc != null) set(0x06, pinHashEnc.encodeAsCbor())
+}) {
+    override fun toString(): String {
+        return "AuthenticatorClientPINRequest(pinProtocol=$pinProtocol, " +
+                "subCommand=$subCommand, keyAgreement=$keyAgreement, " +
+                "pinAuth=${pinAuth?.contentToString()}, " +
+                "newPinEnc=${newPinEnc?.contentToString()}, " +
+                "pinHashEnc=${pinHashEnc?.contentToString()})"
+    }
+}
+
+class AuthenticatorClientPINResponse(
+    val keyAgreement: CoseKey?,
+    val pinToken: ByteArray?,
+    val retries: Int?
+) : Ctap2Response {
+    companion object {
+        fun decodeFromCbor(obj: CBORObject) = AuthenticatorClientPINResponse(
+            obj.get(0x01)?.decodeAsCoseKey(),
+            obj.get(0x02)?.GetByteString(),
+            obj.get(0x03)?.AsInt32Value()
+        )
+    }
+}

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorGetNextAssertion.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/protocol/msgs/AuthenticatorGetNextAssertion.kt
@@ -1,0 +1,12 @@
+package org.microg.gms.fido.core.protocol.msgs
+
+import com.upokecenter.cbor.CBORObject
+
+class AuthenticatorGetNextAssertionCommand(request: AuthenticatorGetNextAssertionRequest) :
+    Ctap2Command<AuthenticatorGetNextAssertionRequest, AuthenticatorGetAssertionResponse>(request) {
+    override fun decodeResponse(obj: CBORObject) = AuthenticatorGetAssertionResponse.decodeFromCbor(obj)
+    override val timeout: Long
+        get() = 60000
+}
+
+class AuthenticatorGetNextAssertionRequest() : Ctap2Request(0x08)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
@@ -452,6 +452,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                             !pinRequested &&
                             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                             (
+                                    options.signOptions.requireUserVerification == null ||
                                     options.signOptions.requireUserVerification == REQUIRED ||
                                     options.signOptions.requireUserVerification == PREFERRED
                             )

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
@@ -44,7 +44,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
     open val isSupported: Boolean
         get() = false
 
-    open suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean = false, pin: String? = null): AuthenticatorResponse =
+    open suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean = false, pin: String? = null): AuthenticatorResponseWrapper =
         throw RequestHandlingException(ErrorCode.NOT_SUPPORTED_ERR)
 
     open fun shouldBeUsedInstantly(options: RequestOptions): Boolean = false
@@ -197,7 +197,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
         callerPackage: String,
         pinRequested: Boolean,
         pin: String?
-    ): AuthenticatorAttestationResponse {
+    ): suspend () -> AuthenticatorAttestationResponse {
         val (clientData, clientDataHash) = getClientDataAndHash(context, options, callerPackage)
 
         val requireResidentKey = when (options.registerOptions.authenticatorSelection?.residentKeyRequirement) {
@@ -253,12 +253,13 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
             connection.hasCtap1Support -> ctap1register(connection, options, clientDataHash)
             else -> throw IllegalStateException()
         }
-        return AuthenticatorAttestationResponse(
+        val authenticatorResponse = AuthenticatorAttestationResponse(
             keyHandle ?: ByteArray(0).also { Log.w(TAG, "keyHandle was null") },
             clientData,
             AnyAttestationObject(response.authData, response.fmt, response.attStmt).encode(),
             connection.transports.toTypedArray()
         )
+        return suspend { authenticatorResponse }
     }
 
 
@@ -268,7 +269,9 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
         clientDataHash: ByteArray,
         requireUserVerification: Boolean,
         pinToken: ByteArray? = null
-    ): Pair<AuthenticatorGetAssertionResponse, ByteArray?> {
+    ): List<Pair<AuthenticatorGetAssertionResponse, ByteArray?>> {
+        val responseList = ArrayList<Pair<AuthenticatorGetAssertionResponse, ByteArray?>>()
+
         val reqOptions = AuthenticatorGetAssertionRequest.Companion.Options(
             // The specification states that the WebAuthn requireUserVerification option should map to
             // the CTAP2 "uv" flag OR pinAuth/pinProtocol. Therefore, set this flag to false if
@@ -304,7 +307,16 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
             pinProtocol
         )
         val ctap2Response = connection.runCommand(AuthenticatorGetAssertionCommand(request))
-        return ctap2Response to ctap2Response.credential?.id
+        responseList.add(ctap2Response to ctap2Response.credential?.id)
+
+        for (i in 1..< (ctap2Response.numberOfCredentials ?: 0)) {
+            val nextRequest = AuthenticatorGetNextAssertionRequest()
+            val nextResponse = connection.runCommand(AuthenticatorGetNextAssertionCommand(nextRequest))
+
+            responseList.add(nextResponse to nextResponse.credential?.id)
+        }
+
+        return responseList
     }
 
     @RequiresApi(Build.VERSION_CODES.S)
@@ -401,7 +413,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
         options: RequestOptions,
         clientDataHash: ByteArray,
         rpIdHash: ByteArray
-    ): Pair<AuthenticatorGetAssertionResponse, ByteArray> {
+    ): List<Pair<AuthenticatorGetAssertionResponse, ByteArray>> {
         val cred = options.signOptions.allowList.orEmpty().firstOrNull { cred ->
             ctap1DeviceHasCredential(connection, clientDataHash, rpIdHash, cred)
         } ?: options.signOptions.allowList!!.first()
@@ -417,7 +429,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                     null,
                     null
                 )
-                return ctap2Response to cred.id
+                return listOf(ctap2Response to cred.id)
             } catch (e: CtapHidMessageStatusException) {
                 if (e.status != 0x6985) {
                     throw e
@@ -431,7 +443,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
         connection: CtapConnection,
         options: RequestOptions,
         clientDataHash: ByteArray
-    ): Pair<AuthenticatorGetAssertionResponse, ByteArray> {
+    ): List<Pair<AuthenticatorGetAssertionResponse, ByteArray>> {
         try {
             val rpIdHash = options.rpId.toByteArray().digest("SHA-256")
             return ctap1sign(connection, options, clientDataHash, rpIdHash)
@@ -456,10 +468,10 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
         callerPackage: String,
         pinRequested: Boolean,
         pin: String?
-    ): AuthenticatorAssertionResponse {
+    ): List<Pair<UserInfo?, suspend () -> AuthenticatorAssertionResponse>> {
         val (clientData, clientDataHash) = getClientDataAndHash(context, options, callerPackage)
 
-        val (response, credentialId) = when {
+        val responses: List<Pair<AuthenticatorGetAssertionResponse, ByteArray?>> = when {
             connection.hasCtap2Support -> {
                 try {
                     var pinToken: ByteArray? = null
@@ -517,13 +529,30 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
             connection.hasCtap1Support -> ctap1sign(connection, options, clientDataHash)
             else -> throw IllegalStateException()
         }
-        return AuthenticatorAssertionResponse(
-            credentialId ?: ByteArray(0).also { Log.w(TAG, "keyHandle was null") },
-            clientData,
-            response.authData,
-            response.signature,
-            null
-        )
+
+        val assertionResponses = ArrayList<Pair<UserInfo?, suspend () -> AuthenticatorAssertionResponse>>()
+
+        for ((response, credentialId) in responses) {
+            var name = response.user?.name
+            var displayName = response.user?.displayName
+            var icon = response.user?.icon
+
+            var userInfo: UserInfo? = null
+            if (name != null) {
+                userInfo = UserInfo(name, displayName, icon)
+            }
+
+            val assertionResponse = AuthenticatorAssertionResponse(
+                credentialId ?: ByteArray(0).also { Log.w(TAG, "keyHandle was null for key with display name $displayName") },
+                clientData,
+                response.authData,
+                response.signature,
+                null
+            )
+            assertionResponses.add(userInfo to suspend { assertionResponse })
+        }
+
+        return assertionResponses
     }
 
     companion object {

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/CtapNfcConnection.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/CtapNfcConnection.kt
@@ -41,12 +41,16 @@ class CtapNfcConnection(
         Log.d(TAG, "Send CTAP2 command: ${request.toBase64(Base64.NO_WRAP)}")
         var (statusCode, payload) = decodeResponseApdu(isoDep.transceive(request))
         Log.d(TAG, "Received CTAP2 response(${(statusCode.toInt() and 0xffff).toString(16)}): ${payload.toBase64(Base64.NO_WRAP)}")
-        while (statusCode == 0x9100.toShort()) {
+        while (statusCode == 0x9100.toShort() || (statusCode > 0x6100.toShort() && statusCode < 0x6200.toShort())) {
             Log.d(TAG, "Sending GETRESPONSE")
             val res = decodeResponseApdu(isoDep.transceive(encodeCommandApdu(0x00, 0xC0.toByte(), 0x00,0x00)))
             Log.d(TAG, "Received CTAP2 response(${(statusCode.toInt() and 0xffff).toString(16)}): ${payload.toBase64(Base64.NO_WRAP)}")
+            if (statusCode < 0x6200.toShort()) {
+                payload = payload.plus(res.second)
+            } else {
+                payload = res.second
+            }
             statusCode = res.first
-            payload = res.second
         }
         if (statusCode != 0x9000.toShort()) {
             throw CtapNfcMessageStatusException(statusCode.toInt() and 0xffff)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import org.microg.gms.fido.core.MissingPinException
 import org.microg.gms.fido.core.RequestOptionsType
+import org.microg.gms.fido.core.WrongPinException
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
 import org.microg.gms.fido.core.transport.TransportHandlerCallback
@@ -106,6 +107,8 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: MissingPinException) {
+                    throw e
+                } catch (e: WrongPinException) {
                     throw e
                 } catch (e: Exception) {
                     Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
@@ -22,6 +22,7 @@ import com.google.android.gms.fido.fido2.api.common.AuthenticatorResponse
 import com.google.android.gms.fido.fido2.api.common.RequestOptions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import org.microg.gms.fido.core.MissingPinException
 import org.microg.gms.fido.core.RequestOptionsType
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
@@ -53,20 +54,24 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
     suspend fun register(
         options: RequestOptions,
         callerPackage: String,
-        tag: Tag
+        tag: Tag,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAttestationResponse {
         return CtapNfcConnection(activity, tag).open {
-            register(it, activity, options, callerPackage)
+            register(it, activity, options, callerPackage, pinRequested, pin)
         }
     }
 
     suspend fun sign(
         options: RequestOptions,
         callerPackage: String,
-        tag: Tag
+        tag: Tag,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAssertionResponse {
         return CtapNfcConnection(activity, tag).open {
-            sign(it, activity, options, callerPackage)
+            sign(it, activity, options, callerPackage, pinRequested, pin)
         }
     }
 
@@ -74,16 +79,18 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
     suspend fun handle(
         options: RequestOptions,
         callerPackage: String,
-        tag: Tag
+        tag: Tag,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorResponse {
         return when (options.type) {
-            RequestOptionsType.REGISTER -> register(options, callerPackage, tag)
-            RequestOptionsType.SIGN -> sign(options, callerPackage, tag)
+            RequestOptionsType.REGISTER -> register(options, callerPackage, tag, pinRequested, pin)
+            RequestOptionsType.SIGN -> sign(options, callerPackage, tag, pinRequested, pin)
         }
     }
 
 
-    override suspend fun start(options: RequestOptions, callerPackage: String): AuthenticatorResponse {
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse {
         val adapter = NfcAdapter.getDefaultAdapter(activity)
         val newIntentListener = Consumer<Intent> {
             if (it?.action != NfcAdapter.ACTION_TECH_DISCOVERED) return@Consumer
@@ -95,8 +102,10 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
             while (true) {
                 val tag = waitForNewNfcTag(adapter)
                 try {
-                    return handle(options, callerPackage, tag)
+                    return handle(options, callerPackage, tag, pinRequested, pin)
                 } catch (e: CancellationException) {
+                    throw e
+                } catch (e: MissingPinException) {
                     throw e
                 } catch (e: Exception) {
                     Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
@@ -22,8 +22,10 @@ import com.google.android.gms.fido.fido2.api.common.AuthenticatorResponse
 import com.google.android.gms.fido.fido2.api.common.RequestOptions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import org.microg.gms.fido.core.AuthenticatorResponseWrapper
 import org.microg.gms.fido.core.MissingPinException
 import org.microg.gms.fido.core.RequestOptionsType
+import org.microg.gms.fido.core.UserInfo
 import org.microg.gms.fido.core.WrongPinException
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
@@ -58,7 +60,7 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
         tag: Tag,
         pinRequested: Boolean,
         pin: String?
-    ): AuthenticatorAttestationResponse {
+    ): suspend () -> AuthenticatorAttestationResponse {
         return CtapNfcConnection(activity, tag).open {
             register(it, activity, options, callerPackage, pinRequested, pin)
         }
@@ -70,7 +72,7 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
         tag: Tag,
         pinRequested: Boolean,
         pin: String?
-    ): AuthenticatorAssertionResponse {
+    ): List<Pair<UserInfo?, suspend () -> AuthenticatorAssertionResponse>> {
         return CtapNfcConnection(activity, tag).open {
             sign(it, activity, options, callerPackage, pinRequested, pin)
         }
@@ -83,15 +85,15 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
         tag: Tag,
         pinRequested: Boolean,
         pin: String?
-    ): AuthenticatorResponse {
+    ): AuthenticatorResponseWrapper {
         return when (options.type) {
-            RequestOptionsType.REGISTER -> register(options, callerPackage, tag, pinRequested, pin)
-            RequestOptionsType.SIGN -> sign(options, callerPackage, tag, pinRequested, pin)
+            RequestOptionsType.REGISTER -> AuthenticatorResponseWrapper(listOf(Pair(null, register(options, callerPackage, tag, pinRequested, pin))))
+            RequestOptionsType.SIGN -> AuthenticatorResponseWrapper(sign(options, callerPackage, tag, pinRequested, pin))
         }
     }
 
 
-    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse {
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponseWrapper {
         val adapter = NfcAdapter.getDefaultAdapter(activity)
         val newIntentListener = Consumer<Intent> {
             if (it?.action != NfcAdapter.ACTION_TECH_DISCOVERED) return@Consumer

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockCredentialStore.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockCredentialStore.kt
@@ -111,6 +111,10 @@ class ScreenLockCredentialStore(val context: Context) : SQLiteOpenHelper(context
         return keys
     }
 
+    fun deleteKey(rpId:String, keyId: ByteArray) {
+        keyStore.deleteEntry(getAlias(rpId, keyId))
+    }
+
     fun clearInvalidatedKeys() {
         // Iterate through the keys, try to initiate them, and delete them if this throws an
         // invalidated exception

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockCredentialStore.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockCredentialStore.kt
@@ -112,7 +112,9 @@ class ScreenLockCredentialStore(val context: Context) : SQLiteOpenHelper(context
     }
 
     fun deleteKey(rpId:String, keyId: ByteArray) {
-        keyStore.deleteEntry(getAlias(rpId, keyId))
+        val keyAlias = getAlias(rpId, keyId)
+        Log.w(TAG, "Deleting key with alias $keyAlias")
+        keyStore.deleteEntry(keyAlias)
     }
 
     fun clearInvalidatedKeys() {
@@ -129,6 +131,7 @@ class ScreenLockCredentialStore(val context: Context) : SQLiteOpenHelper(context
                 val signature = Signature.getInstance("SHA256withECDSA")
                 signature.initSign(key)
             } catch (e: KeyPermanentlyInvalidatedException) {
+                Log.w(TAG, "Removing permanently invalidated key with alias $alias")
                 keysToDelete.add(alias)
             } catch (e: Exception) {
                 // Any other exception, we just continue
@@ -248,6 +251,7 @@ class ScreenLockCredentialStore(val context: Context) : SQLiteOpenHelper(context
         // Use prepared statements to avoid SQL injections
         val preparedDeleteStatement = db.compileStatement("DELETE FROM $TABLE_DISPLAY_NAMES WHERE $COLUMN_KEY_ALIAS = ?")
         for (aliasToDelete in aliasesToDelete) {
+            Log.w(TAG, "Removing userinfo for key with alias $aliasToDelete, since key no longer exists")
             preparedDeleteStatement.bindString(1, aliasToDelete)
             preparedDeleteStatement.executeUpdateDelete()
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockCredentialStore.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockCredentialStore.kt
@@ -17,14 +17,20 @@ import android.security.keystore.StrongBoxUnavailableException
 import android.util.Base64
 import android.util.Log
 import androidx.annotation.RequiresApi
+import org.microg.gms.fido.core.UserInfo
 import org.microg.gms.utils.toBase64
-import java.security.*
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.ProviderException
+import java.security.PublicKey
+import java.security.Signature
 import java.security.cert.Certificate
 import java.security.spec.ECGenParameterSpec
 import kotlin.random.Random
 
 @RequiresApi(23)
-class ScreenLockCredentialStore(val context: Context) {
+class ScreenLockCredentialStore(val context: Context) : SQLiteOpenHelper(context, "screenlockcredentials.db", null, DATABASE_VERSION) {
     private val keyStore by lazy { KeyStore.getInstance("AndroidKeyStore").apply { load(null) } }
 
     private fun getAlias(rpId: String, keyId: ByteArray): String =
@@ -34,6 +40,8 @@ class ScreenLockCredentialStore(val context: Context) {
 
     @RequiresApi(23)
     fun createKey(rpId: String, challenge: ByteArray): ByteArray {
+        clearInvalidatedKeys()
+
         var useStrongbox = false
         if (SDK_INT >= 28) useStrongbox = context.packageManager.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)
         val keyId = Random.nextBytes(32)
@@ -81,12 +89,53 @@ class ScreenLockCredentialStore(val context: Context) {
                 }
             }
         }
-
         return keyId
     }
 
-    fun getPublicKey(rpId: String, keyId: ByteArray): PublicKey? =
-        keyStore.getCertificate(getAlias(rpId, keyId))?.publicKey
+    fun getPublicKey(rpId: String, keyId: ByteArray): PublicKey? {
+        clearInvalidatedKeys()
+        return keyStore.getCertificate(getAlias(rpId, keyId))?.publicKey
+    }
+
+    fun getPublicKeys(rpId: String): Collection<Pair<String, PublicKey>> {
+        clearInvalidatedKeys()
+
+        val keys = ArrayList<Pair<String, PublicKey>>()
+        for (alias in keyStore.aliases()) {
+            if (alias.endsWith(".$rpId")) {
+                val key = keyStore.getCertificate(alias).publicKey
+                keys.add(Pair(alias, key))
+            }
+        }
+
+        return keys
+    }
+
+    fun clearInvalidatedKeys() {
+        // Iterate through the keys, try to initiate them, and delete them if this throws an
+        // invalidated exception
+        val keysToDelete = ArrayList<String>()
+        for (alias in keyStore.aliases()) {
+            try {
+                // This is a bit of a hack, but if you try to initSign on a key that has been
+                // invalidated, it throws a KeyPermanentlyInvalidatedException if the key is
+                // invalidated. Otherwise, it throws an exception that I assume is related to
+                // the lack of biometric authentication
+                val key = keyStore.getKey(alias, null) as? PrivateKey
+                val signature = Signature.getInstance("SHA256withECDSA")
+                signature.initSign(key)
+            } catch (e: KeyPermanentlyInvalidatedException) {
+                keysToDelete.add(alias)
+            } catch (e: Exception) {
+                // Any other exception, we just continue
+            }
+        }
+
+        for (alias in keysToDelete) {
+            keyStore.deleteEntry(alias)
+        }
+    }
+
 
     fun getCertificateChain(rpId: String, keyId: ByteArray): Array<Certificate> =
         keyStore.getCertificateChain(getAlias(rpId, keyId))
@@ -107,5 +156,96 @@ class ScreenLockCredentialStore(val context: Context) {
 
     companion object {
         const val TAG = "FidoLockStore"
+
+        const val DATABASE_VERSION = 1
+
+        const val TABLE_DISPLAY_NAMES = "DISPLAY_NAMES_TABLE"
+        const val COLUMN_KEY_ALIAS = "KEY_ALIAS_COLUMN"
+        const val COLUMN_NAME = "NAME_COLUMN"
+        const val COLUMN_DISPLAY_NAME = "DISPLAY_NAME_COLUMN"
+        const val COLUMN_ICON = "ICON_COLUMN"
+    }
+
+    override fun onCreate(db: SQLiteDatabase?) {
+        onUpgrade(db, 0, DATABASE_VERSION)
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
+        if (db == null) {
+            return
+        }
+        if (oldVersion < 1) {
+            db.execSQL("CREATE TABLE $TABLE_DISPLAY_NAMES($COLUMN_KEY_ALIAS TEXT NOT NULL, $COLUMN_NAME TEXT NOT NULL, $COLUMN_DISPLAY_NAME TEXT, $COLUMN_ICON TEXT, UNIQUE($COLUMN_KEY_ALIAS) ON CONFLICT REPLACE)")
+        }
+    }
+
+    fun addUserInfo(rpId: String, keyId: ByteArray, userInfo: UserInfo) {
+        addUserInfo(rpId, keyId, userInfo.name, userInfo.displayName, userInfo.icon)
+    }
+
+    fun addUserInfo(rpId: String, keyId: ByteArray, name: String, displayName: String? = null, icon: String? = null) = writableDatabase.use {
+        // Since this function is not called very often, calling cleanDatabase here will probably not
+        // slow things down by much, and it will avoid the database growing larger than necessary
+        cleanDatabase(it)
+
+        // The key alias and display names are both coming from outside sources. Don't trust them
+        val keyAlias = getAlias(rpId, keyId)
+        val insertStatement = it.compileStatement("INSERT INTO $TABLE_DISPLAY_NAMES($COLUMN_KEY_ALIAS, $COLUMN_NAME, $COLUMN_DISPLAY_NAME, $COLUMN_ICON) VALUES(?, ?, ?, ?)")
+        insertStatement.bindString(1, keyAlias)
+        insertStatement.bindString(2, name)
+        if (displayName != null) insertStatement.bindString(3, displayName)
+        if (icon != null) insertStatement.bindString(4, icon)
+        insertStatement.executeInsert()
+    }
+
+    fun getUserInfo(rpId: String, keyId: ByteArray): UserInfo? = writableDatabase.use {
+        // Same argument as above, this function is not called often, so cleaning every time it's called
+        // should not slow down the phone a lot
+        cleanDatabase(it)
+
+        val keyAlias = getAlias(rpId, keyId)
+        val userInfoQuery = it.query(TABLE_DISPLAY_NAMES, arrayOf(COLUMN_NAME, COLUMN_DISPLAY_NAME, COLUMN_ICON), "$COLUMN_KEY_ALIAS = ?", arrayOf(keyAlias), null, null, null, null)
+
+        var name: String? = null
+        var displayName: String? = null
+        var icon: String? = null
+        userInfoQuery.use { cursor ->
+            if (cursor.moveToNext()) {
+                name = cursor.getString(0)
+                displayName = cursor.getString(1)
+                icon = cursor.getString(2)
+            }
+        }
+
+        if (name != null) {
+            return UserInfo(name!!, displayName, icon)
+        } else {
+            return null
+        }
+    }
+
+    private fun cleanDatabase(db: SQLiteDatabase) {
+        // Remove all display names that don't have an alias in the keystore
+        val aliases = HashSet<String>()
+        for (alias in keyStore.aliases()) {
+            aliases.add(alias)
+        }
+
+        val aliasesToDelete = HashSet<String>()
+        val knownAliases = db.query(TABLE_DISPLAY_NAMES, arrayOf(COLUMN_KEY_ALIAS), null, null, null, null, null)
+        knownAliases.use { cursor ->
+            while (cursor.moveToNext()) {
+                val databaseAlias = cursor.getString(0)
+                if (!aliases.contains(databaseAlias)) aliasesToDelete.add(databaseAlias)
+            }
+        }
+
+        // Since key IDs come from outside microG, treat them as potentially suspicious
+        // Use prepared statements to avoid SQL injections
+        val preparedDeleteStatement = db.compileStatement("DELETE FROM $TABLE_DISPLAY_NAMES WHERE $COLUMN_KEY_ALIAS = ?")
+        for (aliasToDelete in aliasesToDelete) {
+            preparedDeleteStatement.bindString(1, aliasToDelete)
+            preparedDeleteStatement.executeUpdateDelete()
+        }
     }
 }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
@@ -230,7 +230,7 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
     }
 
     @RequiresApi(24)
-    override suspend fun start(options: RequestOptions, callerPackage: String): AuthenticatorResponse =
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse =
         when (options.type) {
             RequestOptionsType.REGISTER -> register(options, callerPackage)
             RequestOptionsType.SIGN -> sign(options, callerPackage)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
@@ -7,21 +7,44 @@ package org.microg.gms.fido.core.transport.screenlock
 
 import android.app.KeyguardManager
 import android.os.Build.VERSION.SDK_INT
+import android.util.Base64
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
-import com.google.android.gms.fido.fido2.api.common.*
+import com.google.android.gms.fido.fido2.api.common.AuthenticatorAssertionResponse
+import com.google.android.gms.fido.fido2.api.common.AuthenticatorAttestationResponse
+import com.google.android.gms.fido.fido2.api.common.EC2Algorithm
+import com.google.android.gms.fido.fido2.api.common.ErrorCode
+import com.google.android.gms.fido.fido2.api.common.RequestOptions
 import com.google.android.gms.safetynet.SafetyNet
 import com.google.android.gms.tasks.await
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.microg.gms.common.Constants
-import org.microg.gms.fido.core.*
-import org.microg.gms.fido.core.protocol.*
+import org.microg.gms.fido.core.AuthenticatorResponseWrapper
+import org.microg.gms.fido.core.R
+import org.microg.gms.fido.core.RequestHandlingException
+import org.microg.gms.fido.core.RequestOptionsType
+import org.microg.gms.fido.core.UserInfo
+import org.microg.gms.fido.core.digest
+import org.microg.gms.fido.core.getApplicationName
+import org.microg.gms.fido.core.getClientDataAndHash
+import org.microg.gms.fido.core.protocol.AndroidKeyAttestationObject
+import org.microg.gms.fido.core.protocol.AndroidSafetyNetAttestationObject
+import org.microg.gms.fido.core.protocol.AttestedCredentialData
+import org.microg.gms.fido.core.protocol.AuthenticatorData
+import org.microg.gms.fido.core.protocol.CoseKey
+import org.microg.gms.fido.core.protocol.CredentialId
+import org.microg.gms.fido.core.protocol.NoneAttestationObject
+import org.microg.gms.fido.core.registerOptions
+import org.microg.gms.fido.core.rpId
+import org.microg.gms.fido.core.signOptions
+import org.microg.gms.fido.core.skipAttestation
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
 import org.microg.gms.fido.core.transport.TransportHandlerCallback
+import org.microg.gms.fido.core.type
 import java.security.Signature
 import java.security.interfaces.ECPublicKey
 import kotlin.coroutines.resume
@@ -104,7 +127,7 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
     suspend fun register(
         options: RequestOptions,
         callerPackage: String
-    ): AuthenticatorAttestationResponse {
+    ): suspend () -> AuthenticatorAttestationResponse {
         if (options.type != RequestOptionsType.REGISTER) throw RequestHandlingException(ErrorCode.INVALID_STATE_ERR)
         for (descriptor in options.registerOptions.excludeList.orEmpty()) {
             if (store.containsKey(options.rpId, descriptor.id)) {
@@ -118,7 +141,14 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
         val aaguid = if (options.registerOptions.skipAttestation) ByteArray(16) else AAGUID
         val keyId = store.createKey(options.rpId, clientDataHash)
         val publicKey =
-            store.getPublicKey(options.rpId, keyId) ?: throw RequestHandlingException(ErrorCode.INVALID_STATE_ERR)
+            store.getPublicKey(options.rpId, keyId)
+                ?: throw RequestHandlingException(ErrorCode.INVALID_STATE_ERR)
+
+        val name = options.registerOptions.user.name
+        val displayName = options.registerOptions.user.displayName
+        val icon = options.registerOptions.user.icon
+
+        store.addUserInfo(options.rpId, keyId, name, displayName, icon)
 
         // We're ignoring the signature object as we don't need it for registration
         val signature = getActiveSignature(options, callerPackage, keyId)
@@ -145,12 +175,14 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
             }
         }
 
-        return AuthenticatorAttestationResponse(
+        val response = AuthenticatorAttestationResponse(
             credentialId.encode(),
             clientData,
             attestationObject.encode(),
             arrayOf("internal")
         )
+
+        return suspend { response }
     }
 
     @RequiresApi(24)
@@ -188,7 +220,7 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
     suspend fun sign(
         options: RequestOptions,
         callerPackage: String
-    ): AuthenticatorAssertionResponse {
+    ): List<Pair<UserInfo?, suspend () -> AuthenticatorAssertionResponse>> {
         if (options.type != RequestOptionsType.SIGN) throw RequestHandlingException(ErrorCode.INVALID_STATE_ERR)
         val candidates = mutableListOf<CredentialId>()
         for (descriptor in options.signOptions.allowList.orEmpty()) {
@@ -201,6 +233,27 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
                 // Not in store or unknown id
             }
         }
+
+        // If there is no allowlist, add all keys with the given rpId as possible keys
+        if (options.signOptions.allowList?.isEmpty() != false) {
+            val keys = store.getPublicKeys(options.rpId)
+            for ((alias, key) in keys) {
+                val aliasSplit = alias.split(Regex("\\."), 3)
+                if (aliasSplit.size != 3) continue
+                val type: Int = aliasSplit[0].toIntOrNull() ?: continue
+                if (type != 1) continue
+
+                val data: ByteArray
+                try {
+                     data = Base64.decode(aliasSplit[1], Base64.DEFAULT)
+                } catch (e: Exception) {
+                    continue
+                }
+
+                candidates.add(CredentialId(type.toByte(), data, options.rpId, key))
+            }
+        }
+
         if (candidates.isEmpty()) {
             // Show a biometric prompt even if no matching key to effectively rate-limit
             showBiometricPrompt(getApplicationName(activity, options, callerPackage), null)
@@ -212,28 +265,38 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
 
         val (clientData, clientDataHash) = getClientDataAndHash(activity, options, callerPackage)
 
-        val credentialId = candidates.first()
-        val keyId = credentialId.data
-        val authenticatorData = getAuthenticatorData(options.rpId, null)
+        val credentialList = ArrayList<Pair<UserInfo?, suspend () -> AuthenticatorAssertionResponse>>()
 
-        val signature = getActiveSignature(options, callerPackage, keyId)
-        signature.update(authenticatorData.encode() + clientDataHash)
-        val sig = signature.sign()
+        for (credentialId in candidates) {
+            val keyId = credentialId.data
+            val authenticatorData = getAuthenticatorData(options.rpId, null)
+            val userInfo: UserInfo? = store.getUserInfo(options.rpId, keyId)
 
-        return AuthenticatorAssertionResponse(
-            credentialId.encode(),
-            clientData,
-            authenticatorData.encode(),
-            sig,
-            null
-        )
+            val responseCallable = suspend {
+                val signature = getActiveSignature(options, callerPackage, keyId)
+                signature.update(authenticatorData.encode() + clientDataHash)
+                val sig = signature.sign()
+
+                AuthenticatorAssertionResponse(
+                    credentialId.encode(),
+                    clientData,
+                    authenticatorData.encode(),
+                    sig,
+                    null
+                )
+            }
+
+            credentialList.add(userInfo to responseCallable)
+        }
+
+        return credentialList
     }
 
     @RequiresApi(24)
-    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse =
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponseWrapper =
         when (options.type) {
-            RequestOptionsType.REGISTER -> register(options, callerPackage)
-            RequestOptionsType.SIGN -> sign(options, callerPackage)
+            RequestOptionsType.REGISTER -> AuthenticatorResponseWrapper(listOf(Pair(null, register(options, callerPackage))))
+            RequestOptionsType.SIGN -> AuthenticatorResponseWrapper(sign(options, callerPackage))
         }
 
     override fun shouldBeUsedInstantly(options: RequestOptions): Boolean {

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -150,7 +150,9 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
                 throw e
             } catch (e: MissingPinException) {
                 throw e
-            } catch (e: Exception) {
+            } catch (e: WrongPinException) {
+                throw e
+            }  catch (e: Exception) {
                 Log.w(TAG, e)
             }
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -81,10 +81,12 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
         options: RequestOptions,
         callerPackage: String,
         device: UsbDevice,
-        iface: UsbInterface
+        iface: UsbInterface,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAttestationResponse {
         return CtapHidConnection(context, device, iface).open {
-            register(it, context, options, callerPackage)
+            register(it, context, options, callerPackage, pinRequested, pin)
         }
     }
 
@@ -92,10 +94,12 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
         options: RequestOptions,
         callerPackage: String,
         device: UsbDevice,
-        iface: UsbInterface
+        iface: UsbInterface,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorAssertionResponse {
         return CtapHidConnection(context, device, iface).open {
-            sign(it, context, options, callerPackage)
+            sign(it, context, options, callerPackage, pinRequested, pin)
         }
     }
 
@@ -119,7 +123,9 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
         options: RequestOptions,
         callerPackage: String,
         device: UsbDevice,
-        iface: UsbInterface
+        iface: UsbInterface,
+        pinRequested: Boolean,
+        pin: String?
     ): AuthenticatorResponse {
         Log.d(TAG, "Trying to use ${device.productName} for ${options.type}")
         invokeStatusChanged(
@@ -127,20 +133,22 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
             Bundle().apply { putParcelable(UsbManager.EXTRA_DEVICE, device) })
         try {
             return when (options.type) {
-                RequestOptionsType.REGISTER -> register(options, callerPackage, device, iface)
-                RequestOptionsType.SIGN -> sign(options, callerPackage, device, iface)
+                RequestOptionsType.REGISTER -> register(options, callerPackage, device, iface, pinRequested, pin)
+                RequestOptionsType.SIGN -> sign(options, callerPackage, device, iface, pinRequested, pin)
             }
         } finally {
             this.device = null
         }
     }
 
-    override suspend fun start(options: RequestOptions, callerPackage: String): AuthenticatorResponse {
+    override suspend fun start(options: RequestOptions, callerPackage: String, pinRequested: Boolean, pin: String?): AuthenticatorResponse {
         for (device in context.usbManager?.deviceList?.values.orEmpty()) {
             val iface = getCtapHidInterface(device) ?: continue
             try {
-                return handle(options, callerPackage, device, iface)
+                return handle(options, callerPackage, device, iface, pinRequested, pin)
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: MissingPinException) {
                 throw e
             } catch (e: Exception) {
                 Log.w(TAG, e)
@@ -151,7 +159,7 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
             val device = waitForNewUsbDevice()
             val iface = getCtapHidInterface(device) ?: continue
             try {
-                return handle(options, callerPackage, device, iface)
+                return handle(options, callerPackage, device, iface, pinRequested, pin)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -257,10 +257,10 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
     }
 
     @RequiresApi(24)
-    fun startTransportHandling(transport: Transport, instant: Boolean = false): Job = lifecycleScope.launchWhenResumed {
+    fun startTransportHandling(transport: Transport, instant: Boolean = false, pinRequested: Boolean = false, authenticatorPin: String? = null): Job = lifecycleScope.launchWhenResumed {
         val options = options ?: return@launchWhenResumed
         try {
-            finishWithSuccessResponse(getTransportHandler(transport)!!.start(options, callerPackage), transport)
+            finishWithSuccessResponse(getTransportHandler(transport)!!.start(options, callerPackage, pinRequested, authenticatorPin), transport)
         } catch (e: SecurityException) {
             Log.w(TAG, e)
             if (instant) {
@@ -274,6 +274,9 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
         } catch (e: RequestHandlingException) {
             Log.w(TAG, e)
             finishWithError(e.errorCode, e.message ?: e.errorCode.name)
+        } catch (e: MissingPinException) {
+            // Redirect the user to ask for a PIN code
+            navHostFragment.navController.navigate(R.id.openPinFragment)
         } catch (e: Exception) {
             Log.w(TAG, e)
             finishWithError(UNKNOWN_ERR, e.message ?: e.javaClass.simpleName)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -218,7 +218,7 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
 
     suspend fun finishWithSuccessResponse(responseWrapper: AuthenticatorResponseWrapper, transport: Transport) {
         if (responseWrapper.responseChoices.size != 1) {
-            val bundle = bundleOf("responseChoices" to responseWrapper.responseChoices, "transport" to transport)
+            val bundle = bundleOf("responseWrapper" to responseWrapper, "transport" to transport)
             navHostFragment.navController.navigate(R.id.openCredentialSelector, bundle)
             return
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -15,10 +15,10 @@ import android.util.Log
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
-import com.google.android.gms.fido.Fido
 import com.google.android.gms.fido.Fido.*
 import com.google.android.gms.fido.fido2.api.common.*
 import com.google.android.gms.fido.fido2.api.common.ErrorCode.*
@@ -216,7 +216,14 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
         )
     }
 
-    fun finishWithSuccessResponse(response: AuthenticatorResponse, transport: Transport) {
+    suspend fun finishWithSuccessResponse(responseWrapper: AuthenticatorResponseWrapper, transport: Transport) {
+        if (responseWrapper.responseChoices.size != 1) {
+            val bundle = bundleOf("responseChoices" to responseWrapper.responseChoices, "transport" to transport)
+            navHostFragment.navController.navigate(R.id.openCredentialSelector, bundle)
+            return
+        }
+        val response = responseWrapper.responseChoices[0].second.invoke()
+
         Log.d(TAG, "Finish with success response: $response")
         if (options is BrowserRequestOptions) database.insertPrivileged(callerPackage, callerSignature)
         val rpId = options?.rpId

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -12,6 +12,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
@@ -276,6 +277,10 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
             finishWithError(e.errorCode, e.message ?: e.errorCode.name)
         } catch (e: MissingPinException) {
             // Redirect the user to ask for a PIN code
+            navHostFragment.navController.navigate(R.id.openPinFragment)
+        } catch (e: WrongPinException) {
+            // Redirect the user, and inform them that the pin was wrong
+            Toast.makeText(baseContext, R.string.fido_wrong_pin, Toast.LENGTH_LONG).show()
             navHostFragment.navController.navigate(R.id.openPinFragment)
         } catch (e: Exception) {
             Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivityFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivityFragment.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.fido.fido2.api.common.ErrorCode
 import com.google.android.gms.fido.fido2.api.common.RequestOptions
@@ -21,6 +22,7 @@ import org.microg.gms.fido.core.transport.Transport
 
 @TargetApi(24)
 abstract class AuthenticatorActivityFragment : Fragment() {
+    private val pinViewModel: AuthenticatorPinViewModel by activityViewModels()
     val data: AuthenticatorActivityFragmentData
         get() = AuthenticatorActivityFragmentData(arguments ?: Bundle.EMPTY)
     val authenticatorActivity: AuthenticatorActivity?
@@ -28,7 +30,7 @@ abstract class AuthenticatorActivityFragment : Fragment() {
     val options: RequestOptions?
         get() = authenticatorActivity?.options
 
-    fun startTransportHandling(transport: Transport) = authenticatorActivity?.startTransportHandling(transport)
+    fun startTransportHandling(transport: Transport) = authenticatorActivity?.startTransportHandling(transport, pinRequested = pinViewModel.pinRequest, authenticatorPin = pinViewModel.pin)
     fun shouldStartTransportInstantly(transport: Transport) = authenticatorActivity?.shouldStartTransportInstantly(transport) == true
 
     abstract override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View?

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/CredentialSelectorFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/CredentialSelectorFragment.kt
@@ -117,7 +117,7 @@ class CredentialSelectorFragment : AuthenticatorActivityFragment() {
             // If credential is deleted, make leave the fragment, since the list is no longer valid
             // There is probably some way to update the list, but it doesn't seem to work from inside
             // the authenticatorActivity's lifecycleScope
-            if (deletionSucceeded) {
+            if (deletionSucceeded && findNavController().currentDestination?.id == R.id.credentialSelectorFragment) {
                 findNavController().navigateUp()
             }
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/CredentialSelectorFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/CredentialSelectorFragment.kt
@@ -1,0 +1,98 @@
+package org.microg.gms.fido.core.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.navOptions
+import com.google.android.gms.fido.fido2.api.common.AuthenticatorResponse
+import com.google.android.gms.fido.fido2.api.common.ErrorCode
+import kotlinx.coroutines.launch
+import org.microg.gms.fido.core.AuthenticatorResponseWrapper
+import org.microg.gms.fido.core.UserInfo
+import org.microg.gms.fido.core.R
+import org.microg.gms.fido.core.databinding.FidoCredentialSelectorFragmentBinding
+import org.microg.gms.fido.core.databinding.FidoCredentialSelectorListItemBinding
+import org.microg.gms.fido.core.transport.Transport
+
+class CredentialListAdapter(private val responseChoices: List<Pair<UserInfo?, suspend () -> AuthenticatorResponse>>, private val listSelectionFunction: (suspend () -> AuthenticatorResponse) -> Unit) : BaseAdapter() {
+    override fun getCount(): Int {
+        return responseChoices.size
+    }
+
+    override fun getItem(position: Int): Pair<UserInfo?, suspend () -> AuthenticatorResponse> {
+        return responseChoices[position]
+    }
+
+    override fun getItemId(position: Int): Long {
+        return position.toLong()
+    }
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+        var view = convertView
+        val inflater = LayoutInflater.from(parent?.context)
+        if (convertView == null) {
+            view = inflater.inflate(R.layout.fido_credential_selector_list_item, parent, false)
+        }
+
+        val (userInfo, function) = getItem(position)
+        // TODO: Set icons
+        if (userInfo != null) {
+            view?.findViewById<TextView>(R.id.credentialNameTextView)?.setText(userInfo.name)
+            if (userInfo.displayName != null) view?.findViewById<TextView>(R.id.credentialDisplayNameTextView)?.setText(userInfo.displayName)
+        }
+
+        val binding = FidoCredentialSelectorListItemBinding.bind(view!!)
+        binding.onCredentialSelection = View.OnClickListener {
+            view.setBackgroundColor(ContextCompat.getColor(it.context, androidx.appcompat.R.color.abc_color_highlight_material))
+            listSelectionFunction(function)
+        }
+
+        return view
+    }
+
+}
+
+class CredentialSelectorFragment : AuthenticatorActivityFragment() {
+    private lateinit var binding: FidoCredentialSelectorFragmentBinding
+    private lateinit var transport: Transport
+
+    @Suppress("UNCHECKED_CAST")
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FidoCredentialSelectorFragmentBinding.inflate(inflater, container, false)
+
+        transport = arguments?.get("transport") as Transport
+        val responseChoices = arguments?.get("responseChoices") as List<Pair<UserInfo?, suspend () -> AuthenticatorResponse>>
+        val adapter = CredentialListAdapter(responseChoices, this::onListSelection)
+        binding.fidoCredentialListView.adapter = adapter
+
+        return binding.root
+    }
+
+    fun onListSelection(function: suspend () -> AuthenticatorResponse) {
+        val authenticator = authenticatorActivity
+        authenticator?.lifecycleScope?.launch {
+            try {
+                authenticator.finishWithSuccessResponse(AuthenticatorResponseWrapper(listOf(null to function)), transport)
+            } catch (e: Exception) {
+                authenticator.finishWithError(ErrorCode.UNKNOWN_ERR, e.message ?: e.javaClass.simpleName)
+            }
+        }
+        if (!findNavController().navigateUp()) {
+            findNavController().navigate(
+                R.id.transportSelectionFragment,
+                arguments,
+                navOptions { popUpTo(R.id.usbFragment) { inclusive = true } })
+        }
+    }
+
+}

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/PinFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/PinFragment.kt
@@ -1,0 +1,57 @@
+package org.microg.gms.fido.core.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModel
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.navOptions
+import org.microg.gms.fido.core.R
+import org.microg.gms.fido.core.databinding.FidoPinFragmentBinding
+
+class AuthenticatorPinViewModel : ViewModel() {
+    var pinRequest: Boolean = false
+    var pin: String? = null
+}
+
+class PinFragment: AuthenticatorActivityFragment() {
+    private lateinit var binding: FidoPinFragmentBinding
+    private val pinViewModel: AuthenticatorPinViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FidoPinFragmentBinding.inflate(inflater, container, false)
+        binding.onCancel = View.OnClickListener {
+            leaveFragment()
+        }
+        binding.onEnterPin = View.OnClickListener {
+            enterPin()
+        }
+
+        return binding.root
+    }
+
+    fun enterPin () {
+        val textEditor = view?.findViewById<EditText>(R.id.pin_editor)
+        if (textEditor != null) {
+            pinViewModel.pin = textEditor.text.toString()
+        }
+        leaveFragment()
+    }
+
+    fun leaveFragment() {
+        pinViewModel.pinRequest = true
+        if (!findNavController().navigateUp()) {
+            findNavController().navigate(
+                R.id.transportSelectionFragment,
+                arguments,
+                navOptions { popUpTo(R.id.usbFragment) { inclusive = true } })
+        }
+    }
+}

--- a/play-services-fido/core/src/main/res/layout/fido_credential_selector_fragment.xml
+++ b/play-services-fido/core/src/main/res/layout/fido_credential_selector_fragment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ListView
+            android:id="@+id/fido_credential_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/play-services-fido/core/src/main/res/layout/fido_credential_selector_list_item.xml
+++ b/play-services-fido/core/src/main/res/layout/fido_credential_selector_list_item.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable
+            name="onCredentialSelection"
+            type="android.view.View.OnClickListener" />
+    </data>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:onClick="@{onCredentialSelection}">
+
+        <ImageView
+            android:id="@+id/credentialIcon"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_fido_fingerprint"
+            android:contentDescription="@string/credential_icon_description" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="60dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:orientation="vertical"
+            app:layout_constraintStart_toEndOf="@+id/credentialIcon"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/credentialNameTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/unknown_credential"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+            <TextView
+                android:id="@+id/credentialDisplayNameTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/play-services-fido/core/src/main/res/layout/fido_credential_selector_list_item.xml
+++ b/play-services-fido/core/src/main/res/layout/fido_credential_selector_list_item.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <data>
         <variable
             name="onCredentialSelection"
             type="android.view.View.OnClickListener" />
+
+        <variable
+            name="onDeleteCredential"
+            type="android.view.View.OnClickListener" />
     </data>
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:onClick="@{onCredentialSelection}">
@@ -46,6 +50,18 @@
                 android:text=""
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
         </LinearLayout>
+
+        <Button
+            android:id="@+id/deleteCredentialButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/fido_delete_credential"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:onClick="@{onDeleteCredential}"
+            android:visibility="gone" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/play-services-fido/core/src/main/res/layout/fido_pin_fragment.xml
+++ b/play-services-fido/core/src/main/res/layout/fido_pin_fragment.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable
+            name="onEnterPin"
+            type="android.view.View.OnClickListener" />
+        <variable
+            name="onCancel"
+            type="android.view.View.OnClickListener" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/pin_fragment_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/fido_pin_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/pin_editor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:ems="10"
+            android:hint="@string/fido_pin_hint"
+            android:inputType="textPassword"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pin_fragment_title"
+            android:autofillHints="password" />
+
+        <Button
+            android:id="@+id/pin_fragment_ok"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/fido_pin_ok"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pin_editor"
+            android:onClick="@{onEnterPin}"/>
+
+        <Button
+            android:id="@+id/pin_fragment_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/fido_pin_cancel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/pin_fragment_ok"
+            android:onClick="@{onCancel}"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/play-services-fido/core/src/main/res/navigation/nav_fido_authenticator.xml
+++ b/play-services-fido/core/src/main/res/navigation/nav_fido_authenticator.xml
@@ -58,10 +58,23 @@
     <fragment
         android:id="@+id/nfcFragment"
         android:name="org.microg.gms.fido.core.ui.NfcTransportFragment"
-        tools:layout="@layout/fido_nfc_transport_fragment" />
+        tools:layout="@layout/fido_nfc_transport_fragment">
+        <action
+            android:id="@+id/openPinFragment"
+            app:destination="@id/pinFragment" />
+    </fragment>
     <fragment
         android:id="@+id/usbFragment"
         android:name="org.microg.gms.fido.core.ui.UsbTransportFragment"
-        tools:layout="@layout/fido_usb_transport_fragment" />
+        tools:layout="@layout/fido_usb_transport_fragment">
+        <action
+            android:id="@+id/openPinFragment"
+            app:destination="@id/pinFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/pinFragment"
+        android:name="org.microg.gms.fido.core.ui.PinFragment"
+        tools:layout="@layout/fido_pin_fragment" />
 
 </navigation>

--- a/play-services-fido/core/src/main/res/navigation/nav_fido_authenticator.xml
+++ b/play-services-fido/core/src/main/res/navigation/nav_fido_authenticator.xml
@@ -52,6 +52,9 @@
         <action
             android:id="@+id/openUsbFragment"
             app:destination="@id/usbFragment" />
+        <action
+            android:id="@+id/openCredentialSelector"
+            app:destination="@id/credentialSelectorFragment" />
     </fragment>
 
     <fragment android:id="@+id/bluetoothFragment" />
@@ -62,6 +65,9 @@
         <action
             android:id="@+id/openPinFragment"
             app:destination="@id/pinFragment" />
+        <action
+            android:id="@+id/openCredentialSelector"
+            app:destination="@id/credentialSelectorFragment" />
     </fragment>
     <fragment
         android:id="@+id/usbFragment"
@@ -70,11 +76,19 @@
         <action
             android:id="@+id/openPinFragment"
             app:destination="@id/pinFragment" />
+        <action
+            android:id="@+id/openCredentialSelector"
+            app:destination="@id/credentialSelectorFragment" />
     </fragment>
 
     <fragment
         android:id="@+id/pinFragment"
         android:name="org.microg.gms.fido.core.ui.PinFragment"
         tools:layout="@layout/fido_pin_fragment" />
+
+    <fragment
+        android:id="@+id/credentialSelectorFragment"
+        android:name="org.microg.gms.fido.core.ui.CredentialSelectorFragment"
+        tools:layout="@layout/fido_credential_selector_fragment" />
 
 </navigation>

--- a/play-services-fido/core/src/main/res/values/strings.xml
+++ b/play-services-fido/core/src/main/res/values/strings.xml
@@ -29,4 +29,6 @@
     <string name="fido_pin_ok">OK</string>
     <string name="fido_pin_cancel">Cancel</string>
     <string name="fido_wrong_pin">Wrong PIN entered!</string>
+    <string name="unknown_credential">Unknown credential</string>
+    <string name="credential_icon_description">Credential icon</string>
 </resources>

--- a/play-services-fido/core/src/main/res/values/strings.xml
+++ b/play-services-fido/core/src/main/res/values/strings.xml
@@ -31,4 +31,5 @@
     <string name="fido_wrong_pin">Wrong PIN entered!</string>
     <string name="unknown_credential">Unknown credential</string>
     <string name="credential_icon_description">Credential icon</string>
+    <string name="fido_delete_credential">Delete</string>
 </resources>

--- a/play-services-fido/core/src/main/res/values/strings.xml
+++ b/play-services-fido/core/src/main/res/values/strings.xml
@@ -24,4 +24,8 @@
     <string name="fido_transport_selection_biometric">Use this device with screen lock</string>
     <string name="fido_transport_usb_wait_connect_body">Please connect your USB security key.</string>
     <string name="fido_transport_usb_wait_confirm_body">Please tap the golden ring or disc on %1$s.</string>
+    <string name="fido_pin_title">Please enter the PIN for your authenticator</string>
+    <string name="fido_pin_hint">4 to 63 characters</string>
+    <string name="fido_pin_ok">OK</string>
+    <string name="fido_pin_cancel">Cancel</string>
 </resources>

--- a/play-services-fido/core/src/main/res/values/strings.xml
+++ b/play-services-fido/core/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="fido_pin_hint">4 to 63 characters</string>
     <string name="fido_pin_ok">OK</string>
     <string name="fido_pin_cancel">Cancel</string>
+    <string name="fido_wrong_pin">Wrong PIN entered!</string>
 </resources>


### PR DESCRIPTION
It was near impossible to start working on credential selection without touching code that had already been touched in my previous pull requests, so this pull request contains all the code of pull requests #2194 and #2199, and builds on top of that. Sorry I couldn't find a better way to do this.

If there are several available credentials when trying to sign in to a web page and the allowList is empty, the user is now brought to a page that displays a list of available credentials. The credential chosen from the list is used to log in to the page. If the credentials are taken from the Screen Lock credential store, each credential in the list also has a button to delete the credential (I didn't find another, better place to put this functionality).

Each time a user tries to sign in or register a new key using the ScreenLock mechanism, the key store is cleaned up by deleting invalidated keys. Keys can become invalidated for instance if the user adds new fingerprints to their biometric reader. User info (including display name and icon) is tied to each credential key using an SqLite database in ScreenLockCredentialStore.kt. Each time the database is accessed, it is pruned by removing entries that refer to keys that no longer exist, for instance if they were deleted or invalidated.

Since Android keys require biometric authentication to be unlocked, and we don't know which credential to unlock until the user has selected it, the AuthenticatorActivity no longer receives the credentials themselves, but instead an asynchronous function to get the credential. In case the credential is already available (such as for credentials from an NFC or Bluetooth key), this function just returns the credential directly. In the case of Screen lock credentials, this function prompts the user for biometric authentication and uses this to unlock the key from the keystore, and then returns the credential.

I have tested this with NFC and Screenlock credentials on my own phone. I don't have access to a Bluetooth key, so this is still untested.

At the moment, the list of available credentials from the Screenlock method is shown before the user has supplied any biometric authentication. If you think this is a security risk, I could change it so the user has to provide authentication before being shown the list, but in that case I think the user would still have to give biometric again later to unlock the chosen credential.