### PR TITLE
Account Settings: Take product name into MyActivity page

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
@@ -8,6 +8,7 @@ package org.microg.gms.accountsettings.ui
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.Log
 import android.view.View
 import android.webkit.WebView
@@ -131,6 +132,8 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val screenId = intent?.getIntExtra(EXTRA_SCREEN_ID, -1).takeIf { it != -1 } ?: ACTION_TO_SCREEN_ID[intent.action] ?: 1
+        val product = intent?.getStringExtra(EXTRA_SCREEN_MY_ACTIVITY_PRODUCT)
+
         val screenOptions = intent.extras?.keySet().orEmpty()
             .filter { it.startsWith(EXTRA_SCREEN_OPTIONS_PREFIX) }
             .map { it.substring(EXTRA_SCREEN_OPTIONS_PREFIX.length) to intent.getStringExtra(it) }
@@ -150,6 +153,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         if (screenId in SCREEN_ID_TO_URL) {
+            val screenUrl = SCREEN_ID_TO_URL[screenId]?.run { if (screenId == 547 && !product.isNullOrEmpty()) { replace("search", product) } else { this } }
             val layout = RelativeLayout(this)
             layout.addView(ProgressBar(this).apply {
                 layoutParams = RelativeLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
@@ -164,7 +168,7 @@ class MainActivity : AppCompatActivity() {
             }
             layout.addView(webView)
             setContentView(layout)
-            WebViewHelper(this, webView, ALLOWED_WEB_PREFIXES).openWebView(SCREEN_ID_TO_URL[screenId], accountName)
+            WebViewHelper(this, webView, ALLOWED_WEB_PREFIXES).openWebView(screenUrl, accountName)
             setResult(RESULT_OK)
         } else {
             Log.w(TAG, "Unknown screen id, can't open corresponding web page")

--- a/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/extensions.kt
@@ -19,5 +19,6 @@ const val EXTRA_SCREEN_OPTIONS_PREFIX = "extra.screen."
 const val EXTRA_FALLBACK_URL = "extra.fallbackUrl"
 const val EXTRA_FALLBACK_AUTH = "extra.fallbackAuth"
 const val EXTRA_THEME_CHOICE = "extra.themeChoice"
+const val EXTRA_SCREEN_MY_ACTIVITY_PRODUCT = "extra.screen.myactivityProduct"
 
 const val OPTION_SCREEN_FLAVOR = "screenFlavor"


### PR DESCRIPTION
Fixed the issue in YouTube settings where clicking Manage all history would redirect to Google search history.
Google search history and YouTube Manage all history share the same screenId.