### PR TITLE
MovingWifiHelper: Fix _SNCF_WIFI_INTERCITES

### DIFF
--- a/play-services-location/core/provider/src/main/kotlin/org/microg/gms/location/network/wifi/MovingWifiHelper.kt
+++ b/play-services-location/core/provider/src/main/kotlin/org/microg/gms/location/network/wifi/MovingWifiHelper.kt
@@ -247,7 +247,7 @@ class MovingWifiHelper(private val context: Context) {
     
     private fun parseSncf(location: Location, data: ByteArray): Location {
         val json = JSONObject(data.decodeToString())
-        if(json.getInt("fix") == -1) throw RuntimeException("GPS not valid")
+        if(json.has("fix") && json.getInt("fix") == -1) throw RuntimeException("GPS not valid")
         location.accuracy = 100f
         location.latitude = json.getDouble("latitude")
         location.longitude = json.getDouble("longitude")


### PR DESCRIPTION
The new JSON dosen't include a "fix" field on french intercity trains anymore, but they're still in use on TGVs and OUIGO