### PR TITLE
Fix getMapAsync() for LiteGoogleMap

### DIFF
--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/LiteGoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/LiteGoogleMap.kt
@@ -365,7 +365,7 @@ class LiteGoogleMapImpl(context: Context, var options: GoogleMapOptions) : Abstr
     }
 
     fun getMapAsync(callback: IOnMapReadyCallback) {
-        if (lastSnapshot == null) {
+        if (lastSnapshot != null) {
             Log.d(TAG, "Invoking callback instantly, as a snapshot is ready")
             callback.onMapReady(this)
         } else {


### PR DESCRIPTION
Spotify was crashing because of some lateinit property in Spotify snapshot ready callback was not initialized.

Looking at the condition we can observe that GmsCore was calling the snapshot ready callback when the snapshot was null, which does not make sense.

Inverting the logic and calling the callback when the snapshot was not null anymore fixed the issue and Spotify was able to display the snapshot.