### PR TITLE
IAP: Implement old getBuyIntent through forwarding to new one

### DIFF
--- a/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
@@ -232,7 +232,8 @@ class InAppBillingServiceImpl(private val context: Context) : IInAppBillingServi
         developerPayload: String?
     ): Bundle {
         if (Log.isLoggable(TAG, Log.DEBUG)) Log.d(TAG, "getBuyIntent(apiVersion=$apiVersion, packageName=$packageName, sku=$sku, type=$type, developerPayload=$developerPayload)")
-        return resultBundle(BillingResponseCode.BILLING_UNAVAILABLE, "Not yet implemented")
+        return runCatching { getBuyIntentExtraParams(apiVersion, packageName!!, sku!!, type!!, developerPayload, null) }
+            .getOrDefault(resultBundle(BillingResponseCode.BILLING_UNAVAILABLE, "Not yet implemented"))
     }
 
     override fun getPurchases(


### PR DESCRIPTION
Fixed the issue that the payment pop-up page could not be displayed after clicking on the payment.
e.g. uk.co.nationalrail.google