### PR TITLE
Account settings: Allow profile picture page

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/accountsettings/ui/MainActivity.kt
@@ -35,6 +35,7 @@ private val SCREEN_ID_TO_URL = hashMapOf(
     214 to "https://myaccount.google.com/dashboard",
     215 to "https://takeout.google.com",
     216 to "https://myaccount.google.com/inactive",
+    218 to "https://myaccount.google.com/profile-picture?interop=o",
     219 to "https://myactivity.google.com/myactivity",
     220 to "https://www.google.com/maps/timeline",
     224 to "https://myactivity.google.com/activitycontrols?settings=search",


### PR DESCRIPTION
No redirect when clicking on account avatar on Google App account management page