### PR TITLE
Fix vending build info initialization parameter is null

### DIFF
--- a/play-services-base/core/src/main/kotlin/org/microg/gms/profile/ProfileManager.kt
+++ b/play-services-base/core/src/main/kotlin/org/microg/gms/profile/ProfileManager.kt
@@ -325,8 +325,10 @@ object ProfileManager {
                 Log.v(TAG, "<data key=\"$key\" value=\"$value\" />")
             }
         }
-        applyProfileData(profileData)
-        activeProfile = PROFILE_REMOTE
+        if (profileData.isNotEmpty()) {
+            applyProfileData(profileData)
+            activeProfile = PROFILE_REMOTE
+        }
     }
 
     fun getProfileName(context: Context, profile: String): String? = getProfileName { getProfileXml(context, profile) }
@@ -375,6 +377,11 @@ object ProfileManager {
             Log.w(TAG, e)
             return false
         }
+    }
+
+    @JvmStatic
+    fun resetActiveProfile() {
+        activeProfile = null
     }
 
     @JvmStatic

--- a/vending-app/src/main/java/org/microg/vending/billing/Utils.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/Utils.kt
@@ -300,12 +300,6 @@ fun getUserAgent(): String {
 
 fun createDeviceEnvInfo(context: Context): DeviceEnvInfo? {
     try {
-        if (Build.DEVICE == null || Build.PRODUCT == null || Build.MODEL == null || Build.MANUFACTURER == null
-            || Build.FINGERPRINT == null || Build.VERSION.RELEASE == null || Build.BRAND == null) {
-            Log.w(TAG, "createDeviceEnvInfo Build info some properties are null")
-            ProfileManager.resetActiveProfile()
-            ProfileManager.ensureInitialized(context)
-        }
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         return DeviceEnvInfo(
             gpVersionCode = VENDING_VERSION_CODE,
@@ -321,15 +315,15 @@ fun createDeviceEnvInfo(context: Context): DeviceEnvInfo? {
             gpLastUpdateTime = packageInfo.lastUpdateTime,
             gpFirstInstallTime = packageInfo.firstInstallTime,
             gpSourceDir = packageInfo.applicationInfo.sourceDir!!,
-            device = Build.DEVICE!!,
+            device = Build.DEVICE ?: "",
             displayMetrics = getDisplayInfo(context),
             telephonyData = getTelephonyData(context),
-            product = Build.PRODUCT!!,
-            model = Build.MODEL!!,
-            manufacturer = Build.MANUFACTURER!!,
-            fingerprint = Build.FINGERPRINT!!,
-            release = Build.VERSION.RELEASE!!,
-            brand = Build.BRAND!!,
+            product = Build.PRODUCT ?: "",
+            model = Build.MODEL ?: "",
+            manufacturer = Build.MANUFACTURER ?: "",
+            fingerprint = Build.FINGERPRINT ?: "",
+            release = Build.VERSION.RELEASE ?: "",
+            brand = Build.BRAND ?: "",
             batteryLevel = getBatteryLevel(context),
             timeZoneOffset = if (SDK_INT >= 24) TimeZone.getDefault().rawOffset.toLong() else 0,
             locationData = getLocationData(context),

--- a/vending-app/src/main/java/org/microg/vending/billing/Utils.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/Utils.kt
@@ -25,6 +25,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.os.bundleOf
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import org.microg.gms.profile.Build
+import org.microg.gms.profile.ProfileManager
 import org.microg.gms.utils.digest
 import org.microg.gms.utils.getExtendedPackageInfo
 import org.microg.gms.utils.toBase64
@@ -299,6 +300,12 @@ fun getUserAgent(): String {
 
 fun createDeviceEnvInfo(context: Context): DeviceEnvInfo? {
     try {
+        if (Build.DEVICE == null || Build.PRODUCT == null || Build.MODEL == null || Build.MANUFACTURER == null
+            || Build.FINGERPRINT == null || Build.VERSION.RELEASE == null || Build.BRAND == null) {
+            Log.w(TAG, "createDeviceEnvInfo Build info some properties are null")
+            ProfileManager.resetActiveProfile()
+            ProfileManager.ensureInitialized(context)
+        }
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         return DeviceEnvInfo(
             gpVersionCode = VENDING_VERSION_CODE,


### PR DESCRIPTION
Reproduction steps:
1.Install vending without installing mg
2.Find an APP to trigger IAP and trigger build info initialization
3.install mg
4.IAP problem found

The problem is that the build info of vending depends on mg. If mg is not installed, the parameters in the build are null. The build info is initialized only once, so it will not be initialized again after mg is installed, resulting in the parameters in the build being null all the time.