### PR TITLE
Generate Creator class for com.google.firebase.dynamiclinks.internal.DynamicLinkData by adding respective annotation

### DIFF
--- a/firebase-dynamic-links/build.gradle
+++ b/firebase-dynamic-links/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 //    api project(':firebase-common-ktx')
 //    api project(':firebase-components')
     api 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10'
+
+    annotationProcessor project(':safe-parcel-processor')
 }
 
 apply from: '../gradle/publish-android.gradle'

--- a/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/DynamicLinkData.java
+++ b/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/DynamicLinkData.java
@@ -10,12 +10,14 @@ package com.google.firebase.dynamiclinks.internal;
 import android.os.Parcel;
 import androidx.annotation.NonNull;
 import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
 import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
 
 import android.os.Bundle;
 import android.net.Uri;
 import org.microg.gms.utils.ToStringHelper;
 
+@SafeParcelable.Class
 public class DynamicLinkData extends AbstractSafeParcelable {
     @Field(1)
     public final String dynamicLink;
@@ -35,6 +37,7 @@ public class DynamicLinkData extends AbstractSafeParcelable {
     @Field(6)
     public final Uri redirectUrl;
 
+    @Constructor
     public DynamicLinkData(@Param(1) String dynamicLink, @Param(2) String deepLink, @Param(3) int minVersion, @Param(4) long clickTimestamp, @Param(5) Bundle extensionBundle, @Param(6) Uri redirectUrl) {
         this.dynamicLink = dynamicLink;
         this.deepLink = deepLink;


### PR DESCRIPTION
Fixes #2596
After refactor via https://github.com/microg/GmsCore/commit/3ccb5f456e7ee05bd3e445567194707b5b02fe0a the `@SafeParcelable.Class` annotation is still missing in `com.google.firebase.dynamiclinks.internal.DynamicLinkData`. Also the safe-parcelable process needs to be added to the gradle build file.
@mar-v-in When searching for "AbstractSafeParcelable" in the source tree I do see that there are more places where the annotation is missing. If you like, I might fix those with this PR too.

best