### PR TITLE
Fix microG settings icon not following system theme

### DIFF
--- a/play-services-core/src/main/res/drawable-v21/ic_app_settings_system.xml
+++ b/play-services-core/src/main/res/drawable-v21/ic_app_settings_system.xml
@@ -7,7 +7,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="225.27"
-    android:viewportHeight="225.27">
+    android:viewportHeight="225.27"
+    android:tint="?android:attr/colorControlNormal">
     <group>
         <path
             android:pathData="m151.55,151.53a55,55 0,0 1,-66.39 8.74"


### PR DESCRIPTION
Fix microG settings icon not following system theme, fix https://github.com/microg/GmsCore/issues/2616

# Preview:

![Screenshot_20241111-135909_Settings](https://github.com/user-attachments/assets/c0119c20-78bd-48df-9fa4-a0971d58fe5d)
![Screenshot_20241111-135917_Settings](https://github.com/user-attachments/assets/0f7ec49f-8996-4459-9fcc-0d5be4637049)
