### PR TITLE
Auth: Fix exceptions caused by folding screens

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -553,7 +553,7 @@
             android:enabled="true"
             android:exported="true"
             android:process=":ui"
-            android:configChanges="keyboardHidden|keyboard|orientation|screenSize"
+            android:configChanges="keyboardHidden|keyboard|orientation|screenSize|smallestScreenSize|layoutDirection"
             android:launchMode="singleTask"
             android:excludeFromRecents="false">
             <intent-filter>

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AssistedSignInActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AssistedSignInActivity.kt
@@ -7,6 +7,7 @@ package org.microg.gms.auth.signin
 
 import android.accounts.AccountManager
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
@@ -91,10 +92,14 @@ class AssistedSignInActivity : AppCompatActivity() {
                 errorResult(Status(CommonStatusCodes.ERROR, "accounts is empty."))
                 return
             }
-            AssistedSignInFragment(googleSignInOptions!!, beginSignInRequest!!, accounts, clientPackageName!!,
-                { errorResult(it) },
-                { loginResult(it) })
-                .show(supportFragmentManager, AssistedSignInFragment.TAG)
+            val fragment = supportFragmentManager.findFragmentByTag(AssistedSignInFragment.TAG)
+            if (fragment != null) {
+                val assistedSignInFragment = fragment as AssistedSignInFragment
+                assistedSignInFragment.cancelLogin(true)
+            } else {
+                AssistedSignInFragment.newInstance(clientPackageName!!, googleSignInOptions!!, beginSignInRequest!!)
+                    .show(supportFragmentManager, AssistedSignInFragment.TAG)
+            }
             return
         }
 
@@ -114,7 +119,7 @@ class AssistedSignInActivity : AppCompatActivity() {
         startActivityForResult(intent, REQUEST_CODE_SIGN_IN)
     }
 
-    private fun errorResult(status: Status) {
+    fun errorResult(status: Status) {
         Log.d(TAG, "errorResult: $status")
         setResult(RESULT_CANCELED, Intent().apply {
             putExtra(AuthConstants.STATUS, SafeParcelableSerializer.serializeToBytes(status))
@@ -122,7 +127,7 @@ class AssistedSignInActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun loginResult(googleSignInAccount: GoogleSignInAccount?) {
+    fun loginResult(googleSignInAccount: GoogleSignInAccount?) {
         if (googleSignInAccount == null) {
             errorResult(Status(CommonStatusCodes.CANCELED, "User cancelled."))
             return

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AssistedSignInActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AssistedSignInActivity.kt
@@ -7,7 +7,6 @@ package org.microg.gms.auth.signin
 
 import android.accounts.AccountManager
 import android.content.Intent
-import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity


### PR DESCRIPTION
Fixed the issue with the quick login pop-up window on the folding screen.

11-01 16:37:06.109 20931 20931 E AndroidRuntime: Process: com.google.android.gms:ui, PID: 20931
11-01 16:37:06.109 20931 20931 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.google.android.gms/org.microg.gms.auth.signin.AssistedSignInActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment org.microg.gms.auth.signin.AssistedSignInFragment: could not find Fragment constructor
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4866)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:5090)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:7386)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:7260)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:77)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:50)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:149)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:103)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:3157)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:117)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:205)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:293)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.processInnerLoop(ActivityThread.java:10193)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.loopProcess(ActivityThread.java:10185)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:10176)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
11-01 16:37:06.109 20931 20931 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1252)