### PR TITLE
Add Activity recognition permission

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -62,6 +62,12 @@
         android:protectionLevel="dangerous" />
 
     <permission
+        android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION"
+        android:label="@string/perm_activity_recognition_label"
+        android:description="@string/perm_activity_recognition_description"
+        android:protectionLevel="normal" />
+
+    <permission
         android:name="com.google.android.gms.permission.AD_ID"
         android:label="@string/perm_ad_id_label"
         android:description="@string/perm_ad_id_description"

--- a/play-services-core/src/main/res/values/permissions.xml
+++ b/play-services-core/src/main/res/values/permissions.xml
@@ -90,6 +90,9 @@
     <string name="permission_service_YouTubeUser_label">YouTube usernames</string>
     <string name="permission_service_YouTubeUser_description">Allows app to access YouTube username(s) used with any associated Google account.</string>
 
+    <string name="perm_activity_recognition_label">Activity recognition</string>
+    <string name="perm_activity_recognition_description">Allows an app to receive periodic updates of your activity level from Google, for example, if you are walking, driving, cycling, or stationary.</string>
+
     <string name="permission_scope_www.googleapis.com_auth_activity">View the activity history of your Google Apps</string>
     <string name="permission_scope_www.googleapis.com_auth_adexchange.buyer">Manage your Ad Exchange buyer account configuration</string>
     <string name="permission_scope_www.googleapis.com_auth_adexchange.seller.readonly">View your Ad Exchange data</string>


### PR DESCRIPTION
From Android 10 it use `android.permission.ACTIVITY_RECOGNITION` but before 10 it was a gms permission (`com.google.android.gms.permission.ACTIVITY_RECOGNITION`), so declare it for old Apps / old Android versions.