### PR TITLE
IAP: Fix the exception in multiple account situations

### DIFF
--- a/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
@@ -151,7 +151,7 @@ class InAppBillingServiceImpl(private val context: Context) : IInAppBillingServi
         }
 
         private fun createIAPCore(context: Context, account: Account, pkgName: String): IAPCore {
-            val key = "$pkgName:$account"
+            val key = "$pkgName:${account.name}"
             val cacheEntry = iapCoreCacheMap[key]
             if (cacheEntry != null) {
                 if (cacheEntry.expiredAt > System.currentTimeMillis())


### PR DESCRIPTION
In the case of multiple accounts, when switching accounts to pay, there is a situation where the payment is made using the information of the previous account.