### PR TITLE
Maps: Fixed a crash caused by transition animation

### DIFF
--- a/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
+++ b/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
@@ -556,7 +556,7 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
             Log.d(TAG_LOGO, "create: ${context.packageName},\n$options")
             val mapContext = MapContext(context)
             MapsInitializer.initialize(mapContext)
-            val mapView = MapView(mapContext, options.toHms())
+            val mapView = MapView(mapContext, options.toHms()).apply { visibility = View.INVISIBLE }
             this.mapView = mapView
             view.addView(mapView)
             mapView.onCreate(savedInstanceState?.toHms())
@@ -685,6 +685,8 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
             }
             internalOnInitializedCallbackList.clear()
             fakeWatermark { Log.d(TAG_LOGO, "fakeWatermark success") }
+
+            mapView?.visibility = View.VISIBLE
         }
 
         tryRunUserInitializedCallbacks(tag = "initMap")
@@ -723,6 +725,7 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
     }
 
     override fun onStop() {
+        mapView?.visibility = View.INVISIBLE
         mapView?.onStop()
     }
 
@@ -791,8 +794,8 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
             if (!wasCallbackActive) isInvokingInitializedCallbacks.set(false)
         } else {
             Log.d(
-                    "$TAG:$tag",
-                    "Initialized callbacks could not be run at this point, as the map view has not been created yet."
+                "$TAG:$tag",
+                "Initialized callbacks could not be run at this point, as the map view has not been created yet."
             )
         }
     }

--- a/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
+++ b/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
@@ -794,8 +794,8 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
             if (!wasCallbackActive) isInvokingInitializedCallbacks.set(false)
         } else {
             Log.d(
-                "$TAG:$tag",
-                "Initialized callbacks could not be run at this point, as the map view has not been created yet."
+                    "$TAG:$tag",
+                    "Initialized callbacks could not be run at this point, as the map view has not been created yet."
             )
         }
     }

--- a/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
+++ b/play-services-maps/core/hms/src/main/kotlin/org/microg/gms/maps/hms/GoogleMap.kt
@@ -692,7 +692,10 @@ class GoogleMapImpl(private val context: Context, var options: GoogleMapOptions)
         tryRunUserInitializedCallbacks(tag = "initMap")
     }
 
-    override fun onResume() = mapView?.onResume() ?: Unit
+    override fun onResume() {
+        mapView?.visibility = View.VISIBLE
+        mapView?.onResume()
+    }
     override fun onPause() = mapView?.onPause() ?: Unit
     override fun onDestroy() {
         Log.d(TAG, "onDestroy")

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -590,7 +590,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
     override fun onCreate(savedInstanceState: Bundle?) {
         if (!created) {
             Log.d(TAG, "create");
-            val mapView = MapView(mapContext)
+            val mapView = MapView(mapContext).apply { visibility = View.INVISIBLE }
             this.mapView = mapView
             view.addView(mapView)
             mapView.onCreate(savedInstanceState?.toMapbox())
@@ -800,6 +800,8 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
                 }
 
                 isMyLocationEnabled = locationEnabled
+
+                view.visibility = View.VISIBLE
             }
         }
     }
@@ -886,6 +888,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
 
     override fun onStop() {
         Log.d(TAG, "onStop")
+        mapView?.visibility = View.INVISIBLE
         isStarted = false
         mapView?.onStop()
     }

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -830,6 +830,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
 
     override fun onResume() {
         Log.d(TAG, "onResume")
+        mapView?.visibility = View.VISIBLE
         if (!isStarted) {
             // onStart was not called, invoke mapView.onStart() now
             mapView?.onStart()


### PR DESCRIPTION
When using Mister D <rs.mrdonesi.mobile>, I found that it crashed when adding an address. The reason is that the application uses TransitionManager for transition animation processing, and Mapview's involvement will cause problems, so I have dealt with it here.