### PR TITLE
AppSet: Set a default random ID

### DIFF
--- a/play-services-appset/core/src/main/kotlin/org/microg/gms/appset/AppSetService.kt
+++ b/play-services-appset/core/src/main/kotlin/org/microg/gms/appset/AppSetService.kt
@@ -19,6 +19,7 @@ import com.google.android.gms.common.internal.GetServiceRequest
 import com.google.android.gms.common.internal.IGmsCallbacks
 import org.microg.gms.BaseService
 import org.microg.gms.common.GmsService
+import java.util.UUID
 
 private const val TAG = "AppSetService"
 private val FEATURES = arrayOf(Feature("app_set_id", 1L))
@@ -37,6 +38,6 @@ class AppSetService : BaseService(TAG, GmsService.APP_SET) {
 class AppSetServiceImpl : IAppSetService.Stub() {
     override fun getAppSetIdInfo(params: AppSetIdRequestParams?, callback: IAppSetIdCallback?) {
         Log.d(TAG, "AppSetServiceImp getAppSetIdInfo is called -> ${params?.toString()} ")
-        callback?.onAppSetInfo(Status.SUCCESS, AppSetInfoParcel("00000000-0000-0000-0000-000000000000", AppSetIdInfo.SCOPE_APP))
+        callback?.onAppSetInfo(Status.SUCCESS, AppSetInfoParcel(UUID.randomUUID().toString(), AppSetIdInfo.SCOPE_APP))
     }
 }


### PR DESCRIPTION
When the application connects to the service, using the ID "0000-xxx" will result in no response. 
Changing to a random ID will work properly.
e.g. de.zalando.mobile