### PR TITLE
Fido: Fix Uber cannot create passkey

### DIFF
--- a/play-services-fido/src/main/java/com/google/android/gms/fido/fido2/api/common/EC2Algorithm.java
+++ b/play-services-fido/src/main/java/com/google/android/gms/fido/fido2/api/common/EC2Algorithm.java
@@ -16,6 +16,14 @@ import org.microg.gms.common.PublicApi;
 @PublicApi
 public enum EC2Algorithm implements Algorithm {
     /**
+     * ECDH-ES with HKDF-SHA-256
+     */
+    ECDH_HKDF_256(-25),
+    /**
+     * EdDSA with Ed25519
+     */
+    ED25519(-8),
+    /**
      * TPM_ECC_BN_P256 curve w/ SHA-256
      */
     ED256(-260),


### PR DESCRIPTION
【Uber】Manage Uber Account-Security-Create Pass Key page and click Create