### PR TITLE
Integrity: Add cloudProjectNumber to IntegrityParams

### DIFF
--- a/vending-app/src/main/kotlin/com/google/android/finsky/integrityservice/IntegrityService.kt
+++ b/vending-app/src/main/kotlin/com/google/android/finsky/integrityservice/IntegrityService.kt
@@ -113,7 +113,8 @@ private class IntegrityServiceImpl(private val context: Context, override val li
             certificateSha256Digests = packageInfo.signaturesCompat.map {
                 it.toByteArray().sha256().encodeBase64(noPadding = true, noWrap = true, urlSafe = true)
             },
-            timestampAtRequest = timestamp
+            timestampAtRequest = timestamp,
+            cloudProjectNumber = cloudProjectNumber.takeIf { it > 0L }
         )
 
         val data = mutableMapOf(

--- a/vending-app/src/main/proto/Integrity.proto
+++ b/vending-app/src/main/proto/Integrity.proto
@@ -39,7 +39,7 @@ message IntegrityParams {
   optional string nonce = 3;
   repeated string certificateSha256Digests = 4;
   optional Timestamp timestampAtRequest = 5;
-  //  optional int64 unknownInt64 = 6;
+  optional int64 cloudProjectNumber = 6;
 }
 
 message InstalledAppsSignalDataWrapper {


### PR DESCRIPTION
Field 6 in IntegrityParams is the cloud project number. 

Adding this to the request may fix issues like https://github.com/microg/GmsCore/issues/2832 where FirebaseAppCheck is used, which in turn passes a cloud project number to the request.