### PR TITLE
Vending: Expand payment methods

### DIFF
--- a/vending-app/src/main/java/org/microg/vending/billing/ui/PlayWebViewActivity.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/ui/PlayWebViewActivity.kt
@@ -87,7 +87,7 @@ class PlayWebViewActivity : ComponentActivity() {
         }
         layout.addView(webView)
         setContentView(layout)
-        WebViewHelper(this, webView, ALLOWED_WEB_PREFIXES).openWebView(openUrl, account)
+        WebViewHelper(this, webView, ALLOWED_WEB_PREFIXES).openWebView(openUrl, account, action)
         setResult(RESULT_OK)
     }
 

--- a/vending-app/src/main/java/org/microg/vending/billing/ui/WebViewHelper.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/ui/WebViewHelper.kt
@@ -7,18 +7,24 @@ package org.microg.vending.billing.ui
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
+import android.os.Message
 import android.util.Log
 import android.view.View
 import android.webkit.CookieManager
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
+import android.widget.ProgressBar
+import android.widget.RelativeLayout
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.microg.gms.profile.Build
@@ -32,8 +38,9 @@ class WebViewHelper(
     private val webView: WebView,
     private val allowedPrefixes: Set<String> = emptySet()
 ) {
-    fun openWebView(url: String, account: Account?) {
-        prepareWebViewSettings(webView.settings)
+    fun openWebView(url: String, account: Account?, webAction: WebViewAction) {
+        prepareWebViewSettings(webView.settings, webAction == WebViewAction.ADD_PAYMENT_METHOD)
+        webView.webChromeClient = PayWebChromeClient(webAction)
         webView.webViewClient = object : WebViewClientCompat() {
             override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceErrorCompat) {
                 Log.e(TAG, "Error loading: $error")
@@ -113,9 +120,9 @@ class WebViewHelper(
         }
     }
 
-    private fun prepareWebViewSettings(settings: WebSettings) {
+    private fun prepareWebViewSettings(settings: WebSettings, enableMultiWindow: Boolean = false) {
         settings.javaScriptEnabled = true
-        settings.setSupportMultipleWindows(false)
+        settings.setSupportMultipleWindows(enableMultiWindow)
         settings.allowFileAccess = false
         settings.databaseEnabled = false
         settings.setNeedInitialFocus(false)
@@ -123,5 +130,66 @@ class WebViewHelper(
         settings.setSupportZoom(false)
         settings.javaScriptCanOpenWindowsAutomatically = false
         settings.userAgentString = Build.generateWebViewUserAgentString(settings.userAgentString)
+    }
+
+    private class PayWebChromeClient(val webAction: WebViewAction) : WebChromeClient() {
+
+        override fun onCreateWindow(view: WebView?, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message?): Boolean {
+            Log.d(TAG, "onCreateWindow: isDialog:$isDialog isUserGesture:$isUserGesture resultMsg: ${resultMsg.toString()}")
+            if (webAction != WebViewAction.ADD_PAYMENT_METHOD) {
+                return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg)
+            }
+            // Add third-party payment methods, such as PayPal/GrabPay/Alipay.
+            // WebView needs to support multi-window mode, and the child view will call the js method registered by the parent view
+            // to refresh the page and close it by itself.
+            var bottomSheetDialog: BottomSheetDialog? = null
+            val parentContext = view!!.context
+            val subWebView = WebView(parentContext).apply {
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                }
+                webViewClient = object : WebViewClientCompat() {
+                    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                        super.onPageStarted(view, url, favicon)
+                        Log.d(TAG, "sub_window starts loading: $url")
+                    }
+
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        super.onPageFinished(view, url)
+                        Log.d(TAG, "sub_window loaded : $url")
+                        visibility = View.VISIBLE
+                    }
+                }
+                webChromeClient = object : WebChromeClient() {
+                    override fun onCloseWindow(window: WebView?) {
+                        Log.d(TAG, "sub_window closed")
+                        bottomSheetDialog?.dismiss()
+                    }
+                }
+                layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
+                visibility = View.INVISIBLE
+            }
+            bottomSheetDialog = BottomSheetDialog(parentContext).apply {
+                setOnDismissListener { subWebView.destroy() }
+            }
+            val layout = RelativeLayout(parentContext)
+            layout.addView(ProgressBar(parentContext).apply {
+                layoutParams = RelativeLayout.LayoutParams(
+                    RelativeLayout.LayoutParams.WRAP_CONTENT,
+                    RelativeLayout.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    addRule(RelativeLayout.CENTER_HORIZONTAL)
+                    addRule(RelativeLayout.CENTER_VERTICAL)
+                }
+                isIndeterminate = true
+            })
+            bottomSheetDialog.setContentView(layout.apply { addView(subWebView) })
+            bottomSheetDialog.show()
+
+            (resultMsg?.obj as? WebView.WebViewTransport)?.webView = subWebView
+            resultMsg?.sendToTarget()
+            return true
+        }
     }
 }


### PR DESCRIPTION
Expand other payment methods based on the internal webview loading method.
1: The main interface for adding payment methods must support multi-window mode. Otherwise, an exception will be thrown when window.open is executed inside the web page, causing the registration data transfer method to fail.
2: Clicking Continue on the main page will redirect and execute to onCreateWindow in WebChromeClient, where a new webview is created to carry the directed page. Displaying the new webview in a dialog created based on the main page context can return data to the main page after the operation.
3: Currently the test can bind the PayPal payment method normally.