### PR TITLE
play-services-auth-workaccount: Remove maxSdkVersion from perms

### DIFF
--- a/play-services-auth-workaccount/core/src/main/AndroidManifest.xml
+++ b/play-services-auth-workaccount/core/src/main/AndroidManifest.xml
@@ -6,15 +6,9 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission
-        android:name="android.permission.AUTHENTICATE_ACCOUNTS"
-        android:maxSdkVersion="22" />
-    <uses-permission
-        android:name="android.permission.GET_ACCOUNTS"
-        android:maxSdkVersion="22" />
-    <uses-permission
-        android:name="android.permission.MANAGE_ACCOUNTS"
-        android:maxSdkVersion="22" />
+    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
 
     <application>
 


### PR DESCRIPTION
* This is causing them not to be granted at all on newer devices, _potentially_ leading to issues.
* They're already declared in play-services-core as well.

Bug: #2868