### PR TITLE
Fido: fix support when targetSdk>=35

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/nfc/NfcTransportHandler.kt
@@ -6,12 +6,14 @@
 package org.microg.gms.fido.core.transport.nfc
 
 import android.app.Activity
+import android.app.ActivityOptions
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.IsoDep
+import android.os.Build.VERSION.SDK_INT
 import android.util.Log
 import androidx.core.app.OnNewIntentProvider
 import androidx.core.app.PendingIntentCompat
@@ -39,7 +41,17 @@ class NfcTransportHandler(private val activity: Activity, callback: TransportHan
 
     private suspend fun waitForNewNfcTag(adapter: NfcAdapter): Tag {
         val intent = Intent(activity, activity.javaClass).apply { addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP) }
-        val pendingIntent: PendingIntent = PendingIntentCompat.getActivity(activity, 0, intent, 0, true)!!
+        val piOptions = if (SDK_INT >= 34) {
+            ActivityOptions.makeBasic().apply {
+                pendingIntentCreatorBackgroundActivityStartMode =
+                    ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
+            }.toBundle()
+        } else null
+        val pendingIntent: PendingIntent = PendingIntentCompat.getActivity(
+            activity, 0, intent,
+            0,
+            piOptions,
+            true)!!
         adapter.enableForegroundDispatch(
             activity,
             pendingIntent,

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbDevicePermissionManager.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbDevicePermissionManager.kt
@@ -8,6 +8,7 @@ package org.microg.gms.fido.core.transport.usb
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.hardware.usb.UsbDevice
@@ -25,7 +26,11 @@ private object UsbDevicePermissionReceiver : BroadcastReceiver() {
 
     fun register(context: Context) = synchronized(this) {
         if (!registered) {
-            context.registerReceiver(this, IntentFilter(context.usbPermissionCallbackAction))
+            if (SDK_INT >= 33) {
+                context.registerReceiver(this, IntentFilter(context.usbPermissionCallbackAction), RECEIVER_NOT_EXPORTED)
+            } else {
+                context.registerReceiver(this, IntentFilter(context.usbPermissionCallbackAction))
+            }
             registered = true
         }
     }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbDevicePermissionManager.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbDevicePermissionManager.kt
@@ -7,13 +7,13 @@ package org.microg.gms.fido.core.transport.usb
 
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
-import android.os.Build.VERSION.SDK_INT
 import androidx.core.app.PendingIntentCompat
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
 import kotlinx.coroutines.CompletableDeferred
 
 private val Context.usbPermissionCallbackAction
@@ -25,11 +25,7 @@ private object UsbDevicePermissionReceiver : BroadcastReceiver() {
 
     fun register(context: Context) = synchronized(this) {
         if (!registered) {
-            if (SDK_INT >= 33) {
-                context.registerReceiver(this, IntentFilter(context.usbPermissionCallbackAction), RECEIVER_NOT_EXPORTED)
-            } else {
-                context.registerReceiver(this, IntentFilter(context.usbPermissionCallbackAction))
-            }
+            ContextCompat.registerReceiver(context, this, IntentFilter(context.usbPermissionCallbackAction), RECEIVER_NOT_EXPORTED)
             registered = true
         }
     }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbDevicePermissionManager.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbDevicePermissionManager.kt
@@ -5,7 +5,6 @@
 
 package org.microg.gms.fido.core.transport.usb
 
-import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Context.RECEIVER_NOT_EXPORTED

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -20,19 +20,13 @@ import android.util.Base64
 import android.util.Log
 import androidx.annotation.RequiresApi
 import com.google.android.gms.fido.fido2.api.common.*
-import com.upokecenter.cbor.CBORObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.delay
 import org.microg.gms.fido.core.*
-import org.microg.gms.fido.core.protocol.*
-import org.microg.gms.fido.core.protocol.msgs.*
-import org.microg.gms.fido.core.transport.CtapConnection
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
 import org.microg.gms.fido.core.transport.TransportHandlerCallback
 import org.microg.gms.fido.core.transport.usb.ctaphid.CtapHidConnection
-import org.microg.gms.fido.core.transport.usb.ctaphid.CtapHidMessageStatusException
 import org.microg.gms.utils.toBase64
 
 @RequiresApi(21)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -7,12 +7,14 @@ package org.microg.gms.fido.core.transport.usb
 
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.hardware.usb.UsbConstants.*
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
+import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
@@ -112,7 +114,11 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
                 deferred.complete(device)
             }
         }
-        context.registerReceiver(receiver, IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED))
+        if (SDK_INT >= 33) {
+            context.registerReceiver(receiver, IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED), RECEIVER_NOT_EXPORTED)
+        } else {
+            context.registerReceiver(receiver, IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED))
+        }
         invokeStatusChanged(TransportHandlerCallback.STATUS_WAITING_FOR_DEVICE)
         val device = deferred.await()
         context.unregisterReceiver(receiver)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -7,18 +7,18 @@ package org.microg.gms.fido.core.transport.usb
 
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.hardware.usb.UsbConstants.*
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
-import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
 import com.google.android.gms.fido.fido2.api.common.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -108,11 +108,7 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
                 deferred.complete(device)
             }
         }
-        if (SDK_INT >= 33) {
-            context.registerReceiver(receiver, IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED), RECEIVER_NOT_EXPORTED)
-        } else {
-            context.registerReceiver(receiver, IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED))
-        }
+        ContextCompat.registerReceiver(context, receiver, IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED), RECEIVER_NOT_EXPORTED)
         invokeStatusChanged(TransportHandlerCallback.STATUS_WAITING_FOR_DEVICE)
         val device = deferred.await()
         context.unregisterReceiver(receiver)


### PR DESCRIPTION
If we use fido-core with targetSdk=35, using NFC fails with `Background activity launch blocked!`

This is because starting with SDK35, either the creator or the sender of the pendingIntent need to allow background activity launch (cf https://developer.android.com/guide/components/activities/background-starts#opt-in-required)