### PR TITLE
Fix split install issue

### DIFF
--- a/vending-app/src/main/AndroidManifest.xml
+++ b/vending-app/src/main/AndroidManifest.xml
@@ -199,6 +199,11 @@
             android:exported="false"
             tools:targetApi="21" />
 
+        <receiver
+            android:name=".installer.InstallReceiver"
+            android:exported="false"
+            tools:targetApi="21" />
+
         <!-- Work account store -->
         <activity android:name="org.microg.vending.ui.WorkAppsActivity"
             android:exported="true"

--- a/vending-app/src/main/java/org/microg/vending/billing/core/GooglePlayApi.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/core/GooglePlayApi.kt
@@ -16,5 +16,6 @@ class GooglePlayApi {
         const val URL_DELIVERY = "$URL_FDFE/delivery"
         const val URL_ENTERPRISE_CLIENT_POLICY = "$URL_FDFE/getEnterpriseClientPolicy"
         const val URL_SYNC = "$URL_FDFE/sync"
+        const val URL_BULK = "$URL_FDFE/bulkGrantEntitlement"
     }
 }

--- a/vending-app/src/main/java/org/microg/vending/billing/core/HttpClient.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/core/HttpClient.kt
@@ -2,6 +2,7 @@ package org.microg.vending.billing.core
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import com.squareup.wire.Message
 import com.squareup.wire.ProtoAdapter
 import io.ktor.client.HttpClient
@@ -32,6 +33,7 @@ import java.io.IOException
 import java.io.OutputStream
 
 private const val POST_TIMEOUT = 8000L
+private const val TAG = "HttpClient"
 
 class HttpClient {
 
@@ -60,32 +62,44 @@ class HttpClient {
     }
 
     suspend fun download(
-        url: String,
-        downloadTo: OutputStream,
-        params: Map<String, String> = emptyMap(),
-        emitProgress: (bytesDownloaded: Long) -> Unit = {}
+            url: String,
+            downloadTo: OutputStream,
+            params: Map<String, String> = emptyMap(),
+            downloadedBytes: Long = 0,
+            emitProgress: (bytesDownloaded: Long) -> Unit = {}
     ) {
-        client.prepareGet(url.asUrl(params)).execute { response ->
-            val body: ByteReadChannel = response.body()
-
-            // Modified version of `ByteReadChannel.copyTo(OutputStream, Long)` to indicate progress
-            val buffer = ByteArrayPool.borrow()
-            try {
-                var copied = 0L
-                val bufferSize = buffer.size
-
-                do {
-                    val rc = body.readAvailable(buffer, 0, bufferSize)
-                    copied += rc
-                    if (rc > 0) {
-                        downloadTo.write(buffer, 0, rc)
-                        emitProgress(copied)
+        try {
+            Log.d(TAG, "download downloadedBytes:$downloadedBytes")
+            client.prepareGet(url.asUrl(params)){
+                if (downloadedBytes > 0) {
+                    headers {
+                        append(HttpHeaders.Range, "bytes=$downloadedBytes-")
                     }
-                } while (rc > 0)
-            } finally {
-                ByteArrayPool.recycle(buffer)
+                }
+            }.execute { response ->
+                val body: ByteReadChannel = response.body()
+                // Modified version of `ByteReadChannel.copyTo(OutputStream, Long)` to indicate progress
+                val buffer = ByteArrayPool.borrow()
+                try {
+                    var copied = downloadedBytes
+                    val bufferSize = buffer.size
+
+                    do {
+                        val rc = body.readAvailable(buffer, 0, bufferSize)
+                        copied += rc
+                        if (rc > 0) {
+                            downloadTo.write(buffer, 0, rc)
+                            emitProgress(copied)
+                        }
+                    } while (rc > 0)
+                } finally {
+                    ByteArrayPool.recycle(buffer)
+                }
+                // don't close `downloadTo` yet
             }
-            // don't close `downloadTo` yet
+        } catch (e: Exception) {
+            Log.w(TAG, "download error : $e")
+            throw e
         }
     }
 

--- a/vending-app/src/main/java/org/microg/vending/enterprise/InstallProgress.kt
+++ b/vending-app/src/main/java/org/microg/vending/enterprise/InstallProgress.kt
@@ -5,13 +5,15 @@
 
 package org.microg.vending.enterprise
 
+import android.app.PendingIntent
+
 internal sealed interface InstallProgress
 
 internal data class Downloading(
     val bytesDownloaded: Long,
     val bytesTotal: Long
 ) : InstallProgress, AppState
-internal data object CommitingSession : InstallProgress
+internal data class CommitingSession(val installIntent: PendingIntent? = null, val deleteIntent: PendingIntent? = null) : InstallProgress
 internal data object InstallComplete : InstallProgress
 internal data class InstallError(
     val errorMessage: String

--- a/vending-app/src/main/kotlin/com/android/vending/installer/Constants.kt
+++ b/vending-app/src/main/kotlin/com/android/vending/installer/Constants.kt
@@ -12,6 +12,11 @@ private const val FILE_SAVE_PATH = "phonesky-download-service"
 internal const val TAG = "GmsPackageInstaller"
 
 const val KEY_BYTES_DOWNLOADED = "bytes_downloaded"
+const val VENDING_INSTALL_ACTION = "com.android.vending.ACTION_INSTALL"
+const val VENDING_INSTALL_DELETE_ACTION = "com.android.vending.ACTION_INSTALL_DELETE"
+const val SESSION_ID = "session_id"
+const val SESSION_RESULT_RECEIVER_INTENT = "session_result_receiver_intent"
+const val SPLIT_LANGUAGE_TAG = "config."
 
 fun Context.packageDownloadLocation() = File(cacheDir, FILE_SAVE_PATH).apply {
     if (!exists()) mkdir()

--- a/vending-app/src/main/kotlin/com/android/vending/installer/Install.kt
+++ b/vending-app/src/main/kotlin/com/android/vending/installer/Install.kt
@@ -1,11 +1,7 @@
-/*
- * SPDX-FileCopyrightText: 2025 e foundation
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package com.android.vending.installer
 
 import android.annotation.SuppressLint
+import android.app.KeyguardManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -13,9 +9,12 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageInstaller
 import android.content.pm.PackageInstaller.SessionParams
 import android.os.Build
+import android.os.PowerManager
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.content.pm.PackageInfoCompat
 import com.google.android.finsky.splitinstallservice.PackageComponent
+import com.google.android.finsky.splitinstallservice.SplitInstallService
 import kotlinx.coroutines.CompletableDeferred
 import org.microg.vending.billing.core.HttpClient
 import org.microg.vending.enterprise.CommitingSession
@@ -25,126 +24,156 @@ import org.microg.vending.enterprise.InstallError
 import org.microg.vending.enterprise.InstallProgress
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStream
+import java.util.ArrayList
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal suspend fun Context.installPackages(
-    packageName: String,
-    componentFiles: List<File>,
-    isUpdate: Boolean = false
-) = installPackagesInternal(
-    packageName = packageName,
-    componentNames = componentFiles.map { it.name },
-    isUpdate = isUpdate
-) { session, fileName, to ->
-    val component = componentFiles.find { it.name == fileName }!!
-    FileInputStream(component).use { it.copyTo(to) }
-    component.delete()
+        packageName: String,
+        componentFiles: List<File>,
+        isUpdate: Boolean = false
+) {
+    val notifyId = createNotificationId(packageName, emptyList())
+    installPackagesInternal(
+            packageName = packageName,
+            componentNames = componentFiles.map { it.name },
+            notifyId = notifyId,
+            isUpdate = isUpdate
+    ) {_, notifyId, fileName, to ->
+        val component = componentFiles.find { it.name == fileName }!!
+        FileInputStream(component).use { it.copyTo(to) }
+        component.delete()
+    }
 }
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal suspend fun Context.installPackagesFromNetwork(
-    packageName: String,
-    components: List<PackageComponent>,
-    httpClient: HttpClient = HttpClient(),
-    isUpdate: Boolean = false,
-    emitProgress: (session: Int, InstallProgress) -> Unit = { _, _ -> }
+        packageName: String,
+        components: List<PackageComponent>,
+        httpClient: HttpClient = HttpClient(),
+        isUpdate: Boolean = false,
+        emitProgress: (notifyId: Int, InstallProgress) -> Unit = { _, _ -> }
 ) {
 
     val downloadProgress = mutableMapOf<PackageComponent, Long>()
-
+    val versionTempDir = this.createInstallTempDir(packageName)
+    //Generate a notifyId based on the package name and download module to prevent multiple notifications from appearing when the download content is the same
+    val notifyId = createNotificationId(packageName, components)
     installPackagesInternal(
-        packageName = packageName,
-        componentNames = components.map { it.componentName },
-        isUpdate = isUpdate,
-        emitProgress = emitProgress,
-    ) { session, fileName, to ->
+            packageName = packageName,
+            componentNames = components.map { it.componentName },
+            notifyId = notifyId,
+            isUpdate = isUpdate,
+            emitProgress = emitProgress,
+    ) {tempFiles, notifyId, fileName, to ->
         val component = components.find { it.componentName == fileName }!!
-        Log.v(TAG, "installing $fileName for $packageName from network")
-        // Emit progress for the first time as soon as possible, before any network interaction
-        emitProgress(session, Downloading(
-            bytesDownloaded = downloadProgress.values.sum(),
-            bytesTotal = components.sumOf { it.size }
-        ))
-        httpClient.download(component.url, to) { progress ->
-            downloadProgress[component] = progress
-            emitProgress(session, Downloading(
-                bytesDownloaded = downloadProgress.values.sum(),
-                bytesTotal = components.sumOf { it.size }
-            ))
+
+        // Create a temporary file to store the downloaded APK (as a subdirectory based on versionCode)
+        val tempFile = File(versionTempDir, "$fileName.apk")
+        val downloadedBytes = if (tempFile.exists()) tempFile.length() else 0L
+        Log.v(TAG, "installing $fileName for $packageName from network apk size:" + component.size + " downloaded: " + downloadedBytes)
+        if (downloadedBytes < component.size) {
+            httpClient.download(component.url, FileOutputStream(tempFile, downloadedBytes > 0), downloadedBytes = downloadedBytes) { progress ->
+                downloadProgress[component] = progress
+                emitProgress(notifyId, Downloading(
+                        bytesDownloaded = downloadProgress.values.sum(),
+                        bytesTotal = components.sumOf { it.size }
+                ))
+            }
         }
+        tempFiles.add(tempFile.absolutePath)
+        tempFile.inputStream().use { inputStream ->
+            inputStream.copyTo(to)
+        }
+
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 private suspend fun Context.installPackagesInternal(
-    packageName: String,
-    componentNames: List<String>,
-    isUpdate: Boolean = false,
-    emitProgress: (session: Int, InstallProgress) -> Unit = { _, _ -> },
-    writeComponent: suspend (session: Int, componentName: String, to: OutputStream) -> Unit
+        packageName: String,
+        componentNames: List<String>,
+        notifyId: Int,
+        isUpdate: Boolean = false,
+        emitProgress: (notifyId: Int, InstallProgress) -> Unit = { _, _ -> },
+        writeComponent: suspend (tempFiles:MutableList<String>, notifyId: Int, componentName: String, to: OutputStream) -> Unit
 ) {
     Log.v(TAG, "installPackages start")
-
+    Log.d(TAG, "installPackagesInternal: ${this is SplitInstallService}")
     val packageInstaller = packageManager.packageInstaller
-    val installed = packageManager.getInstalledPackages(0).any {
-        it.applicationInfo.packageName == packageName
-    }
     // Contrary to docs, MODE_INHERIT_EXISTING cannot be used if package is not yet installed.
     val params = SessionParams(
-        if (!installed || isUpdate) SessionParams.MODE_FULL_INSTALL
-        else SessionParams.MODE_INHERIT_EXISTING
+            if (isUpdate) SessionParams.MODE_FULL_INSTALL
+            else SessionParams.MODE_INHERIT_EXISTING
     )
     params.setAppPackageName(packageName)
     params.setAppLabel(packageName)
     params.setInstallLocation(PackageInfo.INSTALL_LOCATION_INTERNAL_ONLY)
     try {
         @SuppressLint("PrivateApi") val method = SessionParams::class.java.getDeclaredMethod(
-            "setDontKillApp", Boolean::class.javaPrimitiveType
+                "setDontKillApp", Boolean::class.javaPrimitiveType
         )
         method.invoke(params, true)
     } catch (e: Exception) {
         Log.w(TAG, "Error setting dontKillApp", e)
     }
+    val sessionId: Int
     var session: PackageInstaller.Session? = null
-    // might throw, but we need no handling here as we don't emit progress beforehand
-    val sessionId: Int = packageInstaller.createSession(params)
     try {
+        sessionId = packageInstaller.createSession(params)
         session = packageInstaller.openSession(sessionId)
+        val tempFiles = mutableListOf<String>()
         for (component in componentNames) {
             session.openWrite(component, 0, -1).use { outputStream ->
-                writeComponent(sessionId, component, outputStream)
-                session!!.fsync(outputStream)
+                try {
+                    writeComponent(tempFiles, notifyId, component, outputStream)
+                    session!!.fsync(outputStream)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Error writing component notifyId $notifyId")
+                    emitProgress(notifyId, InstallError("Download Error"))
+                    throw e
+                }
             }
         }
         val deferred = CompletableDeferred<Unit>()
-
+        Log.e(TAG, "installPackagesInternal pendingSessions size: ${SessionResultReceiver.pendingSessions.size}")
         SessionResultReceiver.pendingSessions[sessionId] = SessionResultReceiver.OnResult(
-            onSuccess = {
-                deferred.complete(Unit)
-                emitProgress(sessionId, InstallComplete)
-                        },
-            onFailure = { message ->
-                deferred.completeExceptionally(RuntimeException(message))
-                emitProgress(sessionId, InstallError(message ?: "UNKNOWN"))
-            }
+                onSuccess = {
+                    deferred.complete(Unit)
+                    emitProgress(notifyId, InstallComplete)
+                },
+                onFailure = { message ->
+                    deferred.completeExceptionally(RuntimeException(message))
+                    emitProgress(notifyId, InstallError(message ?: "UNKNOWN"))
+                }
         )
-
+        val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         val intent = Intent(this, SessionResultReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(this, sessionId, intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+        intent.putStringArrayListExtra(SessionResultReceiver.KEY_TEMP_FILES, ArrayList(tempFiles))
+        intent.putExtra(SessionResultReceiver.KEY_NOTIFY_ID, notifyId)
+        val pendingIntent = PendingIntent.getBroadcast(
+                this, sessionId, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        )
+        emitProgress(notifyId, CommitingSession(createPendingIntent(VENDING_INSTALL_ACTION, sessionId, pendingIntent)
+                , createPendingIntent(VENDING_INSTALL_DELETE_ACTION, sessionId, null)))
+        if (!keyguardManager.isKeyguardLocked) {
+            session.commit(pendingIntent.intentSender)
+            // don't abandon if `finally` step is reached after this point
+            session = null
 
-        emitProgress(sessionId, CommitingSession)
-        session.commit(pendingIntent.intentSender)
-        // don't abandon if `finally` step is reached after this point
-        session = null
-
-        Log.d(TAG, "installPackages session commit")
-        return deferred.await()
+            Log.d(TAG, "installPackages session commit")
+            return deferred.await()
+        } else {
+            Log.d(TAG, "installPackagesInternal: The screen is locked and waiting for the user to click the notification to install")
+            // don't abandon if `finally` step is reached after this point
+            session = null
+            throw Exception("The device screen is off, waiting for installation")
+        }
     } catch (e: IOException) {
-        Log.e(TAG, "Error installing packages", e)
-        emitProgress(sessionId, InstallError(e.message ?: "UNKNOWN"))
+        Log.w(TAG, "Error installing packages", e)
         throw e
     } finally {
         // discard downloaded data
@@ -153,4 +182,48 @@ private suspend fun Context.installPackagesInternal(
             it.abandon()
         }
     }
+}
+
+private fun Context.createInstallTempDir(packageName: String) : File {
+    val versionCode =PackageInfoCompat.getLongVersionCode(
+            packageManager.getPackageInfo(packageName, 0)
+    )
+
+    val tempDir = File(cacheDir, "temp_apk").apply {
+        if (!exists()) mkdirs()
+    }
+
+    val packageTempDir = File(tempDir, packageName).apply {
+        if (!exists()) mkdirs()
+    }
+
+    val versionTempDir = File(packageTempDir, versionCode.toString()).apply {
+        if (!exists()) mkdirs()
+    }
+    return versionTempDir
+}
+
+
+private fun createNotificationId(packageName: String, components: List<PackageComponent>) : Int{
+    val hash = (packageName + components.joinToString("") { it.componentName }).hashCode()
+    return hash and Int.MAX_VALUE
+}
+
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+private fun Context.createPendingIntent(action: String, sessionId: Int, pendingIntent: PendingIntent? = null): PendingIntent {
+    val installIntent = Intent(this.applicationContext, InstallReceiver::class.java).apply {
+        this.action = action
+        putExtra(SESSION_ID, sessionId)
+        if (pendingIntent != null) {
+            putExtra(SESSION_RESULT_RECEIVER_INTENT, pendingIntent)
+        }
+    }
+
+    val pendingInstallIntent = PendingIntent.getBroadcast(
+            this.applicationContext,
+            0,
+            installIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+    return pendingInstallIntent
 }

--- a/vending-app/src/main/kotlin/com/android/vending/installer/InstallReceiver.kt
+++ b/vending-app/src/main/kotlin/com/android/vending/installer/InstallReceiver.kt
@@ -1,0 +1,37 @@
+package com.android.vending.installer
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+class InstallReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "onReceive: " + intent.action)
+        val sessionId = intent.getIntExtra(SESSION_ID, -1)
+        Log.d(TAG, "onReceive sessionId: $sessionId")
+        if (intent.action == VENDING_INSTALL_ACTION) {
+            if (sessionId != -1) {
+                val packageInstaller = context.packageManager.packageInstaller
+                var session: PackageInstaller.Session? = null
+                session = packageInstaller.openSession(sessionId)
+                Log.d(TAG, "onReceive: $session")
+                val pendingIntent = intent.getParcelableExtra<PendingIntent>(SESSION_RESULT_RECEIVER_INTENT)
+                if (pendingIntent != null) {
+                    session.commit(pendingIntent.intentSender)
+                }
+            }
+        } else if (intent.action == VENDING_INSTALL_DELETE_ACTION) {
+            if (sessionId != -1) {
+                val packageInstaller = context.packageManager.packageInstaller
+                val session = packageInstaller.openSession(sessionId)
+                session.abandon()
+            }
+        }
+    }
+}

--- a/vending-app/src/main/kotlin/com/android/vending/installer/InstallService.kt
+++ b/vending-app/src/main/kotlin/com/android/vending/installer/InstallService.kt
@@ -122,6 +122,7 @@ class InstallService : Service() {
             val downloadUrls = runCatching {
 
                 client.requestDownloadUrls(
+                        this,
                     dependency.packageName,
                     dependency.versionCode!!.toLong(),
                     auth!!
@@ -179,6 +180,7 @@ class InstallService : Service() {
         val downloadUrls = runCatching {
 
             client.requestDownloadUrls(
+                    this,
                 app.packageName,
                 app.versionCode!!.toLong(),
                 auth!!,

--- a/vending-app/src/main/kotlin/com/android/vending/installer/SessionResultReceiver.kt
+++ b/vending-app/src/main/kotlin/com/android/vending/installer/SessionResultReceiver.kt
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2025 e foundation
- * SPDX-License-Identifier: Apache-2.0
- */
-
 package com.android.vending.installer
 
 import android.content.BroadcastReceiver
@@ -12,19 +7,31 @@ import android.content.pm.PackageInstaller
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
-import com.google.android.finsky.splitinstallservice.SplitInstallManager
+import java.io.File
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 internal class SessionResultReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, -1)
         val sessionId = intent.getIntExtra(PackageInstaller.EXTRA_SESSION_ID, -1)
+        val notifyId = intent.getIntExtra(KEY_NOTIFY_ID, -1)
         Log.d(TAG, "onReceive status: $status sessionId: $sessionId")
         try {
             when (status) {
                 PackageInstaller.STATUS_SUCCESS -> {
                     Log.d(TAG, "SessionResultReceiver received a successful transaction")
+                    val tempFiles = intent.getStringArrayListExtra(KEY_TEMP_FILES)
+                    if (!tempFiles.isNullOrEmpty()) {
+                        for (filePath in tempFiles) {
+                            val file = File(filePath)
+                            if (file.exists()) {
+                                val deleted = file.delete()
+                                Log.d(TAG, "Deleted temp file: $filePath, success: $deleted")
+                            }
+                        }
+                    }
                     if (sessionId != -1) {
                         pendingSessions[sessionId]?.apply { onSuccess() }
                         pendingSessions.remove(sessionId)
@@ -41,8 +48,16 @@ internal class SessionResultReceiver : BroadcastReceiver() {
                     val errorMessage = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
                     Log.w(TAG, "SessionResultReceiver received a failed transaction result: $errorMessage")
                     if (sessionId != -1) {
-                        pendingSessions[sessionId]?.apply { onFailure(errorMessage) }
-                        pendingSessions.remove(sessionId)
+                        val onResult = pendingSessions[sessionId]
+                        if (onResult != null) {
+                            onResult.apply { onFailure(errorMessage) }
+                            pendingSessions.remove(sessionId)
+                        } else {
+                            //Prevent notifications from being removed after the process is killed
+                            Log.d(TAG, "onReceive onResult is null")
+                            val notificationManager = NotificationManagerCompat.from(context)
+                            notificationManager.cancel(notifyId)
+                        }
                     }
                 }
             }
@@ -55,11 +70,13 @@ internal class SessionResultReceiver : BroadcastReceiver() {
     }
 
     data class OnResult(
-        val onSuccess: () -> Unit,
-        val onFailure: (message: String?) -> Unit
+            val onSuccess: () -> Unit,
+            val onFailure: (message: String?) -> Unit
     )
 
     companion object {
         val pendingSessions: MutableMap<Int, OnResult> = mutableMapOf()
+        const val KEY_TEMP_FILES = "temp_files"
+        const val KEY_NOTIFY_ID = "notify_id"
     }
 }

--- a/vending-app/src/main/kotlin/com/google/android/finsky/splitinstallservice/SplitInstallManager.kt
+++ b/vending-app/src/main/kotlin/com/google/android/finsky/splitinstallservice/SplitInstallManager.kt
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2024 microG Project Team
+ * SPDX-FileCopyrightText: 2025 microG Project Team
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.google.android.finsky.splitinstallservice
@@ -10,17 +10,20 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.collection.arraySetOf
 import androidx.core.content.pm.PackageInfoCompat
 import com.android.vending.installer.KEY_BYTES_DOWNLOADED
+import com.android.vending.installer.SPLIT_LANGUAGE_TAG
 import com.android.vending.installer.installPackagesFromNetwork
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.microg.vending.billing.AuthManager
 import org.microg.vending.billing.core.HttpClient
 import org.microg.vending.delivery.requestDownloadUrls
 import org.microg.vending.enterprise.Downloading
-import org.microg.vending.splitinstall.SPLIT_LANGUAGE_TAG
 import org.microg.vending.ui.notifySplitInstallProgress
 
 private const val KEY_LANGUAGE = "language"
@@ -30,6 +33,7 @@ private const val KEY_TOTAL_BYTES_TO_DOWNLOAD = "total_bytes_to_download"
 private const val KEY_STATUS = "status"
 private const val KEY_ERROR_CODE = "error_code"
 private const val KEY_SESSION_ID = "session_id"
+private const val KEY_MODULE_NAMES = "module_names"
 private const val KEY_SESSION_STATE = "session_state"
 
 private const val ACTION_UPDATE_SERVICE = "com.google.android.play.core.splitinstall.receiver.SplitInstallUpdateIntentService"
@@ -39,71 +43,77 @@ private const val TAG = "SplitInstallManager"
 class SplitInstallManager(val context: Context) {
 
     private var httpClient: HttpClient = HttpClient()
+    private val mutex = Mutex()
 
     suspend fun splitInstallFlow(callingPackage: String, splits: List<Bundle>): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return false
+        var packagesToDownload: List<String> = listOf()
+        var components:List<PackageComponent>? = null
+        mutex.withLock {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return false
 //        val callingPackage = runCatching { PackageUtils.getAndCheckCallingPackage(context, packageName) }.getOrNull() ?: return
-        if (splits.all { it.getString(KEY_LANGUAGE) == null && it.getString(KEY_MODULE_NAME) == null }) return false
-        Log.v(TAG, "splitInstallFlow: start")
+            if (splits.all { it.getString(KEY_LANGUAGE) == null && it.getString(KEY_MODULE_NAME) == null }) return false
+            Log.v(TAG, "splitInstallFlow: start")
 
-        val packagesToDownload = splits.mapNotNull { split ->
-            split.getString(KEY_LANGUAGE)?.let { "$SPLIT_LANGUAGE_TAG$it" }
-                ?: split.getString(KEY_MODULE_NAME)
-        }.filter { shouldDownload(callingPackage, it) }
+            packagesToDownload = splits.mapNotNull { split ->
+                split.getString(KEY_LANGUAGE)?.let { "$SPLIT_LANGUAGE_TAG$it" }
+                        ?: split.getString(KEY_MODULE_NAME)
+            }.filter { shouldDownload(callingPackage, it) }
 
-        Log.v(TAG, "splitInstallFlow will query for these packages: $packagesToDownload")
-        if (packagesToDownload.isEmpty()) return false
-
-        val authData = runCatching { withContext(Dispatchers.IO) {
-            AuthManager.getAuthData(context)
-        } }.getOrNull()
-        Log.v(TAG, "splitInstallFlow oauthToken: $authData")
-        if (authData?.authToken.isNullOrEmpty()) return false
-        authData!!
+            Log.v(TAG, "splitInstallFlow will query for these packages: $packagesToDownload")
+            if (packagesToDownload.isEmpty()) return false
 
 
-        val components = runCatching {
-            httpClient.requestDownloadUrls(
-                packageName = callingPackage,
-                versionCode = PackageInfoCompat.getLongVersionCode(
-                    context.packageManager.getPackageInfo(callingPackage, 0)
-                ),
-                auth = authData,
-                requestSplitPackages = packagesToDownload
-            )
-        }.getOrNull()
-        Log.v(TAG, "splitInstallFlow requestDownloadUrls returned these components: $components")
-        if (components.isNullOrEmpty()) {
-            return false
-        }
+            val authData = runCatching { withContext(Dispatchers.IO) {
+                AuthManager.getAuthData(context)
+            } }.getOrNull()
+            Log.v(TAG, "splitInstallFlow oauthToken: $authData")
+            if (authData?.authToken.isNullOrEmpty()) return false
+            authData!!
 
-        components.forEach {
-            splitInstallRecord[it] = DownloadStatus.PENDING
+            components = runCatching {
+                httpClient.requestDownloadUrls(
+                        context = context,
+                        packageName = callingPackage,
+                        versionCode = PackageInfoCompat.getLongVersionCode(
+                                context.packageManager.getPackageInfo(callingPackage, 0)
+                        ),
+                        auth = authData,
+                        requestSplitPackages = packagesToDownload
+                )
+            }.getOrNull()
+
+            Log.v(TAG, "splitInstallFlow requestDownloadUrls returned these components: $components")
+            if (components.isNullOrEmpty()) {
+                return false
+            }
+            components!!.forEach {
+                splitInstallRecord[it] = DownloadStatus.PENDING
+            }
         }
 
         val success = runCatching {
 
             var lastNotification = 0L
             context.installPackagesFromNetwork(
-                packageName = callingPackage,
-                components = components,
-                httpClient = httpClient,
-                isUpdate = false
-            ) { session, progress ->
+                    packageName = callingPackage,
+                    components = components!!,
+                    httpClient = httpClient,
+                    isUpdate = false
+            ) { notifyId, progress ->
                 // Android rate limits notification updates by some vague rule of "not too many in less than one second"
                 if (progress !is Downloading || lastNotification + 250 < System.currentTimeMillis()) {
-                    context.notifySplitInstallProgress(callingPackage, session, progress)
+                    context.notifySplitInstallProgress(callingPackage, notifyId, progress)
                     lastNotification = System.currentTimeMillis()
                 }
             }
         }.isSuccess
 
         return if (success) {
-            sendCompleteBroad(context, callingPackage, components.sumOf { it.size })
-            components.forEach { splitInstallRecord[it] = DownloadStatus.COMPLETE }
+            sendCompleteBroad(context, callingPackage, components!!.sumOf { it.size }, packagesToDownload)
+            components!!.forEach { splitInstallRecord[it] = DownloadStatus.COMPLETE }
             true
         } else {
-            components.forEach { splitInstallRecord[it] = DownloadStatus.FAILED }
+            components!!.forEach { splitInstallRecord[it] = DownloadStatus.FAILED }
             false
         }
     }
@@ -115,21 +125,37 @@ class SplitInstallManager(val context: Context) {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun shouldDownload(callingPackage: String, splitName: String): Boolean {
         return splitInstallRecord.keys.find { it.packageName == callingPackage && it.componentName == splitName }
-            ?.let {
-                splitInstallRecord[it] == DownloadStatus.FAILED
-        } ?: true
+                ?.let {
+                    splitInstallRecord[it] == DownloadStatus.FAILED
+                } ?: true
     }
 
-    private fun sendCompleteBroad(context: Context, packageName: String, bytes: Long) {
-        Log.d(TAG, "sendCompleteBroadcast: $bytes bytes")
+    private fun sendCompleteBroad(context: Context, packageName: String, bytes: Long, moduleList: List<String>) {
+        Log.d(TAG, "sendCompleteBroadcast: $bytes bytes splits:$moduleList")
+        val moduleNames = arraySetOf<String>()
+        val languages = arraySetOf<String>()
+        moduleList?.forEach {
+            if (it.startsWith(SPLIT_LANGUAGE_TAG)) {
+                languages.add(it)
+            } else {
+                moduleNames.add(it)
+            }
+        }
+        Log.d(TAG, "sendInstallCompleteBroad: moduleNames -> $moduleNames languages -> $languages")
         val extra = Bundle().apply {
             putInt(KEY_STATUS, 5)
             putInt(KEY_ERROR_CODE, 0)
             putInt(KEY_SESSION_ID, 0)
             putLong(KEY_TOTAL_BYTES_TO_DOWNLOAD, bytes)
-            //putString(KEY_LANGUAGES, intent.getStringExtra(KEY_LANGUAGE))
+            if (languages.isNotEmpty()) {
+                putStringArrayList(KEY_LANGUAGES, ArrayList(languages))
+            }
+            if (moduleNames.isNotEmpty()) {
+                putStringArrayList(KEY_MODULE_NAMES, ArrayList(moduleNames))
+            }
             putLong(KEY_BYTES_DOWNLOADED, bytes)
         }
+
         val broadcastIntent = Intent(ACTION_UPDATE_SERVICE).apply {
             setPackage(packageName)
             putExtra(KEY_SESSION_STATE, extra)

--- a/vending-app/src/main/proto/BulkGrant.proto
+++ b/vending-app/src/main/proto/BulkGrant.proto
@@ -1,0 +1,28 @@
+option java_package = "com.google.android.finsky";
+option java_multiple_files = true;
+
+message BulkRequestWrapper {
+	optional BulkRequest request = 1;
+}
+
+message BulkRequest {
+	optional string packageName = 1;
+	optional BulkGrant grant = 2;
+}
+
+message BulkGrant{
+	optional int32 grantLevel = 4;
+}
+
+message BulkResponseWrapper {
+	optional BulkResponse response = 1;
+	optional BulkBulkResponseError error = 2;
+}
+
+message BulkResponse {
+
+}
+
+message BulkBulkResponseError {
+	optional string errorMsg = 2;
+}

--- a/vending-app/src/main/res/values-zh-rCN/strings.xml
+++ b/vending-app/src/main/res/values-zh-rCN/strings.xml
@@ -44,4 +44,5 @@
     <string name="vending_overview_enterprise_row_mandatory_missing_hint">你的设备缺少由你的管理员选择的强制应用。</string>
     <string name="vending_overview_enterprise_no_apps_available">你的管理员尚未提供应用。</string>
     <string name="vending_overview_row_installed">已安装的应用</string>
+    <string name="installer_notification_progress_splitinstall_click_install">点击安装 %s 所需的组件</string>
 </resources>

--- a/vending-app/src/main/res/values/strings.xml
+++ b/vending-app/src/main/res/values/strings.xml
@@ -56,5 +56,6 @@
     <string name="installer_notification_progress_splitinstall_commiting">Installing required components for %s</string>
     <string name="download_notification_attachment_file">Additional files for %s</string>
     <string name="download_notification_tips">Downloading</string>
+    <string name="installer_notification_progress_splitinstall_click_install">Click to install the components required by %s</string>
 
 </resources>


### PR DESCRIPTION
Extract the optimization and resubmit it to https://github.com/microg/GmsCore/pull/2799
- Download notifications for split packages should be dismissible.
- After a split package is downloaded, clicking the notification should trigger installation (to handle cases where the install prompt can't appear due to a locked screen).
- Prevent multiple notifications for the same split package download.
- Remove notifications when the network is disconnected or the download fails.
- Implement resumable downloads to save data usage.
- Ensure device synchronization to avoid missing split package information.
- Support account elevation to prevent failure in accessing split package data.