### PR TITLE
TapAndPay: Add getActiveWalletId dummy

### DIFF
--- a/play-services-tapandpay/core/src/main/kotlin/org/microg/gms/tapandpay/TapAndPayService.kt
+++ b/play-services-tapandpay/core/src/main/kotlin/org/microg/gms/tapandpay/TapAndPayService.kt
@@ -105,6 +105,11 @@ class TapAndPayImpl : ITapAndPayService.Stub() {
         callbacks.onStatus(Status.SUCCESS)
     }
 
+    override fun getActiveWalletId(callbacks: ITapAndPayServiceCallbacks) {
+        Log.d(TAG, "getActiveWalletId: ")
+        callbacks.onActiveWalletIdRetrieved(Status(TAP_AND_PAY_NO_ACTIVE_WALLET), "")
+    }
+
     override fun getTokenStatus(tokenProvider: Int, issuerTokenId: String, callbacks: ITapAndPayServiceCallbacks) {
         Log.d(TAG, "getTokenStatus($tokenProvider, $issuerTokenId)")
         callbacks.onTokenStatusRetrieved(Status(TAP_AND_PAY_NO_ACTIVE_WALLET), null)

--- a/play-services-tapandpay/src/main/aidl/com/google/android/gms/tapandpay/internal/ITapAndPayService.aidl
+++ b/play-services-tapandpay/src/main/aidl/com/google/android/gms/tapandpay/internal/ITapAndPayService.aidl
@@ -23,7 +23,7 @@ interface ITapAndPayService {
 //    void retrieveInAppPaymentCredential(in RetrieveInAppPaymentCredentialRequest request, ITapAndPayServiceCallbacks callbacks) = 15;
 //    void getActiveCardsForAccount(in GetActiveCardsForAccountRequest request, ITapAndPayServiceCallbacks callbacks) = 17;
 //    void getAnalyticsContext(ITapAndPayServiceCallbacks callbacks) = 19;
-//    void getActiveWalletId(ITapAndPayServiceCallbacks callbacks) = 20;
+    void getActiveWalletId(ITapAndPayServiceCallbacks callbacks) = 20;
     void getTokenStatus(int tokenProvider, String issuerTokenId, ITapAndPayServiceCallbacks callbacks) = 21;
 //    void issuerTokenize(int tokenProvider, String issuerTokenId, String s2, ITapAndPayServiceCallbacks callbacks) = 22;
 //    void requestSelectToken(int tokenProvider, String issuerTokenId, ITapAndPayServiceCallbacks callbacks) = 23;


### PR DESCRIPTION
Fix the issue where Bradesco shows a white screen after confirming the card number input.
app name:Bradesco 
package name:com.bradesco

Steps to reproduce:
1. Open Bradesco
2. Enter card number
3. Tap confirm
 → The app navigates to a white screen instead of proceeding normally.