### PR TITLE
Fix the names of the components in the self-check

### DIFF
--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -128,9 +128,9 @@ Please set up a password, PIN, or pattern lock screen."</string>
     <string name="self_check_name_system_spoofs">System spoofs signature: </string>
     <string name="self_check_resolution_system_spoofs">Please check the documentation on which steps might be required.</string>
 
-    <string name="self_check_pkg_gms">Play Services (GmsCore)</string>
-    <string name="self_check_pkg_vending">Play Store (Phonesky)</string>
-    <string name="self_check_pkg_gsf">Services Framework (GSF)</string>
+    <string name="self_check_pkg_gms">microG Services</string>
+    <string name="self_check_pkg_vending">microG Companion</string>
+    <string name="self_check_pkg_gsf">microG Services Framework</string>
     <string name="self_check_name_app_installed"><xliff:g example="F-Droid">%1$s</xliff:g> installed: </string>
     <string name="self_check_resolution_app_installed">Install the application <xliff:g example="F-Droid">%1$s</xliff:g> or a compatible one. Please check the documentation on which applications are compatible.</string>
     <string name="self_check_name_correct_sig"><xliff:g example="F-Droid">%1$s</xliff:g> has correct signature: </string>


### PR DESCRIPTION
@mar-v-in

Fix the names of the components in the self-check.
How it was before it only cause confusion.

See also: https://github.com/microg/GsfProxy/pull/25