### PR TITLE
Fix app crash caused 

### DIFF
--- a/play-services-base/core/src/main/java/org/microg/gms/auth/AuthRequest.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/auth/AuthRequest.java
@@ -233,7 +233,7 @@ public class AuthRequest extends HttpFormClient.Request {
         return this;
     }
 
-    public AuthRequest oauth2IncludeEmail(String oauth2IncludeProfile) {
+    public AuthRequest oauth2IncludeEmail(String oauth2IncludeEmail) {
         this.oauth2IncludeEmail = oauth2IncludeEmail;
         return this;
     }

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/identity/IdentitySignInService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/identity/IdentitySignInService.kt
@@ -81,13 +81,14 @@ class IdentitySignInServiceImpl(private val context: Context, private val client
             }
             val bundle = Bundle().apply {
                 val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                    .requestEmail()
                     .requestIdToken(request.googleIdTokenRequestOptions.serverClientId).build()
                 putByteArray(BEGIN_SIGN_IN_REQUEST, SafeParcelableSerializer.serializeToBytes(request))
                 putByteArray(GOOGLE_SIGN_IN_OPTIONS, SafeParcelableSerializer.serializeToBytes(options))
                 putString(CLIENT_PACKAGE_NAME, clientPackageName)
                 requestMap[request.sessionId] = options
             }
-            callback.onResult(Status.SUCCESS, BeginSignInResult(performGooogleSignIn(bundle)))
+            callback.onResult(Status.SUCCESS, BeginSignInResult(performGoogleSignIn(bundle)))
         } else if (request.passkeyJsonRequestOptions.isSupported) {
             fun JSONObject.getArrayOrNull(key: String) = if (has(key)) getJSONArray(key) else null
             fun <T> JSONArray.map(fn: (JSONObject) -> T): List<T> =  (0 until length()).map { fn(getJSONObject(it)) }
@@ -143,14 +144,16 @@ class IdentitySignInServiceImpl(private val context: Context, private val client
         }
         val bundle = Bundle().apply {
             val options =
-                GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).requestIdToken(request.serverClientId)
+                GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                    .requestEmail()
+                    .requestIdToken(request.serverClientId)
                     .build()
             putByteArray(GET_SIGN_IN_INTENT_REQUEST, SafeParcelableSerializer.serializeToBytes(request))
             putByteArray(GOOGLE_SIGN_IN_OPTIONS, SafeParcelableSerializer.serializeToBytes(options))
             putString(CLIENT_PACKAGE_NAME, clientPackageName)
             requestMap[request.sessionId] = options
         }
-        callback.onResult(Status.SUCCESS, performGooogleSignIn(bundle))
+        callback.onResult(Status.SUCCESS, performGoogleSignIn(bundle))
     }
 
     override fun getPhoneNumberHintIntent(
@@ -160,7 +163,7 @@ class IdentitySignInServiceImpl(private val context: Context, private val client
         callback.onResult(Status.CANCELED, null)
     }
 
-    private fun performGooogleSignIn(bundle: Bundle): PendingIntent {
+    private fun performGoogleSignIn(bundle: Bundle): PendingIntent {
         val intent = Intent(ACTION_ASSISTED_SIGN_IN).apply {
             `package` = context.packageName
             putExtras(bundle)

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
@@ -156,7 +156,7 @@ suspend fun performSignIn(context: Context, packageName: String, options: Google
     SignInConfigurationService.setDefaultSignInInfo(context, packageName, account, options?.toJson())
     return GoogleSignInAccount(
         id,
-        tokenId?.replace('-', '+')?.replace('_', '/'),
+        tokenId,
         account.name,
         displayName,
         photoUrl?.let { Uri.parse(it) },

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
@@ -156,7 +156,7 @@ suspend fun performSignIn(context: Context, packageName: String, options: Google
     SignInConfigurationService.setDefaultSignInInfo(context, packageName, account, options?.toJson())
     return GoogleSignInAccount(
         id,
-        tokenId,
+        tokenId?.replace('-', '+')?.replace('_', '/'),
         account.name,
         displayName,
         photoUrl?.let { Uri.parse(it) },


### PR DESCRIPTION
1. Parameter abnormality cause Login crash. 
2. The authorization domain of IdentitySignInService does not match the authorization domain of AuthorizationService, resulting in a login failure. <com.yahoo.mobile.client.android.finance>