### PR TITLE
Asset: Optimize resource download logic

### DIFF
--- a/vending-app/src/main/kotlin/com/google/android/finsky/assetmoduleservice/AssetModuleService.kt
+++ b/vending-app/src/main/kotlin/com/google/android/finsky/assetmoduleservice/AssetModuleService.kt
@@ -76,6 +76,12 @@ class AssetModuleServiceImpl(
                 throw AssetPackException(AssetPackErrorCode.API_NOT_AVAILABLE)
             }
         }
+        if (packageDownloadData[packageName] != null && packageDownloadData[packageName]?.moduleNames?.all {
+                packageDownloadData[packageName]?.getModuleData(it)?.status == AssetPackStatus.COMPLETED
+            } == true && params.installedAssetModules.isEmpty()) {
+            Log.d(TAG, "startDownload: resetAllModuleStatus ")
+            packageDownloadData[packageName]?.resetAllModuleStatus()
+        }
         params.moduleNames.forEach {
             val moduleData = packageDownloadData[packageName]?.getModuleData(it)
             if (moduleData?.status != AssetPackStatus.DOWNLOADING && moduleData?.status != AssetPackStatus.COMPLETED) {
@@ -107,6 +113,15 @@ class AssetModuleServiceImpl(
 
     override suspend fun getSessionStates(params: GetSessionStatesParameters, packageName: String, callback: IAssetModuleServiceCallback?) {
         val listBundleData: MutableList<Bundle> = mutableListOf()
+
+        if (packageDownloadData[packageName] != null && packageDownloadData[packageName]?.moduleNames?.all {
+                packageDownloadData[packageName]?.getModuleData(it)?.status == AssetPackStatus.COMPLETED
+            } == true && params.installedAssetModules.isEmpty()) {
+            Log.d(TAG, "getSessionStates: resetAllModuleStatus: $listBundleData")
+            packageDownloadData[packageName]?.resetAllModuleStatus()
+            callback?.onGetSessionStates(listBundleData)
+            return
+        }
 
         packageDownloadData[packageName]?.moduleNames?.forEach { moduleName ->
             if (moduleName in params.installedAssetModules) return@forEach
@@ -197,6 +212,12 @@ class AssetModuleServiceImpl(
             if (packageDownloadData[packageName] == null) {
                 throw AssetPackException(AssetPackErrorCode.API_NOT_AVAILABLE)
             }
+        }
+        if (packageDownloadData[packageName] != null && packageDownloadData[packageName]?.moduleNames?.all {
+                packageDownloadData[packageName]?.getModuleData(it)?.status == AssetPackStatus.COMPLETED
+            } == true && params.installedAssetModules.isEmpty()) {
+            Log.d(TAG, "requestDownloadInfo: resetAllModuleStatus ")
+            packageDownloadData[packageName]?.resetAllModuleStatus()
         }
         params.moduleNames.forEach {
             val packData = packageDownloadData[packageName]?.getModuleData(it)

--- a/vending-app/src/main/kotlin/com/google/android/finsky/assetmoduleservice/DownloadData.kt
+++ b/vending-app/src/main/kotlin/com/google/android/finsky/assetmoduleservice/DownloadData.kt
@@ -6,7 +6,9 @@
 package com.google.android.finsky.assetmoduleservice
 
 import android.content.Context
+import android.util.Log
 import com.google.android.finsky.getChunkFile
+import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import com.google.android.play.core.assetpacks.protocol.CompressionFormat
 import java.io.File
 import java.io.Serializable
@@ -34,6 +36,12 @@ data class DownloadData(
             status = statusCode
         }
     }
+
+    fun resetAllModuleStatus() {
+        // After the user clears the data, the completed module needs to be reset
+        status = AssetPackStatus.NOT_INSTALLED
+        moduleNames.forEach { getModuleData(it).resetStatus() }
+    }
 }
 
 fun DownloadData?.merge(data: DownloadData?): DownloadData? {
@@ -57,6 +65,10 @@ data class ModuleData(
 ) : Serializable {
     fun incrementBytesDownloaded(bytes: Long) {
         bytesDownloaded += bytes
+    }
+    fun resetStatus() {
+        bytesDownloaded = 0
+        status = AssetPackStatus.NOT_INSTALLED
     }
 }
 


### PR DESCRIPTION
When the user clears the game data of downloaded resources through the system page, the module content will not be re-downloaded after reopening the game.
e.g.  Mortal Kombat<com.wb.goog.mkx> ,  Little Nightmares<com.playdigious.littlenightmare>