### PR TITLE
Phenotype: About using Gemini in Gmail

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -218,8 +219,12 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
     public Bundle requestGoogleAccountsAccess(String packageName) throws RemoteException {
         PackageUtils.assertGooglePackagePermission(context, GooglePackagePermission.ACCOUNT);
         if (SDK_INT >= 26) {
+            Map<Account, Integer> visibilityForPackage = get(context).getAccountsAndVisibilityForPackage(packageName, AuthConstants.DEFAULT_ACCOUNT_TYPE);
             for (Account account : get(context).getAccountsByType(AuthConstants.DEFAULT_ACCOUNT_TYPE)) {
-                AccountManager.get(context).setAccountVisibility(account, packageName, VISIBILITY_VISIBLE);
+                Integer visibility = visibilityForPackage.get(account);
+                if (visibility != null && visibility != VISIBILITY_VISIBLE) {
+                    get(context).setAccountVisibility(account, packageName, VISIBILITY_VISIBLE);
+                }
             }
             Bundle res = new Bundle();
             res.putString("Error", "Ok");

--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
@@ -62,7 +62,11 @@ private val CONFIGURATION_OPTIONS = mapOf(
         Flag("45620220", true, 0),
         // Show Audio Call Button
         Flag("45613814", true, 0),
-    )
+    ),
+    "com.google.apps_mobile.common.services.gmail.android#com.google.android.gm" to arrayOf(
+        Flag("45661535", encodeSupportedLanguageList(), 0),
+        Flag("45700179", encodeSupportedLanguageList(), 0)
+    ),
 )
 
 class PhenotypeServiceImpl(val packageName: String?) : IPhenotypeService.Stub() {

--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/extensions.kt
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2025 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.phenotype
+
+private val supportedLanguages = listOf(
+    "bs", "pt", "ja", "ko", "fr", "it", "de", "zh", "nl",
+    "iw", "he", "tr", "cs", "id", "in", "sv", "da", "no",
+    "nb", "pl", "vi", "th", "fi", "uk", "ar", "el", "ru",
+    "hu", "ro", "ca"
+)
+
+fun encodeSupportedLanguageList(): ByteArray {
+    return supportedLanguages.flatMap { lang ->
+        listOf(0x0A.toByte(), 0x02.toByte()) + lang.toByteArray(Charsets.UTF_8).toList()
+    }.toByteArray()
+}


### PR DESCRIPTION
Added Phenotype configuration to use Gemini related functions in Gmail menu bar.
The requestGoogleAccountsAccess method needs to be adapted.