### PR TITLE
Phenotype: GBoard: set enable_voice_in_handwriting

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
@@ -51,6 +51,7 @@ private val CONFIGURATION_OPTIONS = mapOf(
         Flag("enable_voice_in_chinese", true, 0),
         Flag("enable_voice_in_japanese", true, 0),
         Flag("enable_voice_in_korean", true, 0),
+        Flag("enable_voice_in_handwriting", true, 0),
     ),
     "com.google.android.libraries.communications.conference.device#com.google.android.apps.tachyon" to arrayOf(
         // Enable Google Meet calling using mobile phone number


### PR DESCRIPTION
Added new configuration parameters to solve the problem of speech not displaying content in Gboard handwriting mode.