### PR TITLE
Fix the issue where location updates fail to callback when `maxUpdate…

### DIFF
--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LastLocationCapsule.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LastLocationCapsule.kt
@@ -44,6 +44,7 @@ class LastLocationCapsule(private val context: Context) {
             else -> return null
         } ?: return null
         val cliff = if (effectiveGranularity == GRANULARITY_COARSE) max(maxUpdateAgeMillis, TIME_COARSE_CLIFF) else maxUpdateAgeMillis
+        if (cliff == 0L) return location
         val elapsedRealtimeDiff = SystemClock.elapsedRealtime() - location.elapsedMillis
         if (elapsedRealtimeDiff > cliff) return null
         if (elapsedRealtimeDiff <= maxUpdateAgeMillis) return location


### PR DESCRIPTION
Fix the issue where location updates fail to callback when `maxUpdateAgeMillis` is set to 0.
eg:
app:Navionics® Boating
packagename:it.navionics.singleAppMarineLakesHD


https://github.com/user-attachments/assets/772b3ddb-a691-4926-9986-233b03af3375

