### PR TITLE
microg-ui-tools: Add Filipino strings

### DIFF
--- a/play-services-core/microg-ui-tools/src/main/res/values-fil/strings.xml
+++ b/play-services-core/microg-ui-tools/src/main/res/values-fil/strings.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2013-2017 microG Project Team
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="lib_name">microG UI Tools</string>
+    <string name="lib_license">Apache License 2.0, microG Team</string>
+
+    <string name="about_version_str">Bersyon %1$s</string>
+    <string name="about_name_version_str">%1$s %2$s</string>
+    <string name="about_default_license">Nakalaan ang lahat ng karapatan.</string>
+
+    <string name="prefcat_setup">Setup</string>
+
+    <string name="self_check_title">Sariling Pagsusuri</string>
+    <string name="self_check_desc">Tignan kung tamang na-set up ang system para magamit ang microG</string>
+
+    <string name="self_check_cat_permissions">Mga ibinigay na pahintulot</string>
+    <string name="self_check_name_permission">Pahintulot na %1$s:</string>
+    <string name="self_check_name_permission_interact_across_profiles">Pahintulot na mag-interact sa profile sa trabaho:</string>
+    <string name="self_check_resolution_permission">Pindutin dito para ibigay ang pahintulot. Ang hindi pagbigay ng pahintulot ay maaaring magresulta sa maling pag-uugali ng mga application.</string>
+
+    <string name="about_root_title">microG UI Demo</string>
+    <string name="about_root_summary">Pangkalahatang ideya</string>
+    <string name="about_root_version">Bersyon v0.1.0</string>
+    <string name="about_root_libraries">Mga kasamang library</string>
+
+    <string name="about_android_support_v4">v4 Support Library</string>
+    <string name="about_android_support_v7_appcompat">v7 appcompat Support Library</string>
+    <string name="about_android_support_v7_preference">v7 preference Support Library</string>
+    <string name="about_android_support_license">Apache License 2.0, The Android Open Source Project</string>
+</resources>


### PR DESCRIPTION
These were previously missing, as I didn't know that this component was the one that contained the self-check texts and some parts of the about page. This time they're here now.