### PR TITLE
Fix v2 licensing

### DIFF
--- a/vending-app/src/main/aidl/com/android/vending/licensing/ILicensingService.aidl
+++ b/vending-app/src/main/aidl/com/android/vending/licensing/ILicensingService.aidl
@@ -11,6 +11,6 @@ import com.android.vending.licensing.ILicenseV2ResultListener;
 
 interface ILicensingService {
     oneway void checkLicense(long nonce, String packageName, ILicenseResultListener listener);
-    oneway void checkLicenseV2(String packageName, ILicenseV2ResultListener listener, in Bundle extraParams);
+    oneway void checkLicenseV2(String packageName, ILicenseV2ResultListener listener, int unknown);
 
 }

--- a/vending-app/src/main/java/com/android/vending/licensing/LicensingService.kt
+++ b/vending-app/src/main/java/com/android/vending/licensing/LicensingService.kt
@@ -58,9 +58,9 @@ class LicensingService : Service() {
         override fun checkLicenseV2(
             packageName: String,
             listener: ILicenseV2ResultListener,
-            extraParams: Bundle
+            unknown: Int
         ): Unit = runBlocking {
-            Log.v(TAG, "checkLicenseV2($packageName, $extraParams)")
+            Log.v(TAG, "checkLicenseV2($packageName, $unknown)")
 
             val response = checkLicenseCommon(packageName, V2Parameters)
 


### PR DESCRIPTION
According to latest `com.pairip.licensecheck` behavior, the third parameter in the licensing v2 call is actually an integer and not a Bundle. I've tested this with current apps including v2 licensing, namely [`org.howwefeel.moodmeter`](https://play.google.com/store/apps/details?id=org.howwefeel.moodmeter) and [`fr.maif.digital.maifetmoi`](https://play.google.com/store/apps/details?id=fr.maif.digital.maifetmoi) (note: closes on emulator, but console log from the app indicate that license check is successful).

Regardless, I've verified against https://github.com/e-foundation/lvl-sample that it still works if an empty bundle is passed.

Related: https://gitlab.e.foundation/e/os/backlog/-/issues/3730

Special thanks to @prplwtf.