### PR TITLE
Auth: Set forceRefreshToken when requested

### DIFF
--- a/play-services-base/src/main/java/com/google/android/gms/auth/api/signin/GoogleSignInOptions.java
+++ b/play-services-base/src/main/java/com/google/android/gms/auth/api/signin/GoogleSignInOptions.java
@@ -294,7 +294,7 @@ public class GoogleSignInOptions extends AbstractSafeParcelable implements Api.A
          */
         public Builder requestServerAuthCode(String serverClientId, boolean forceCodeForRefreshToken) {
             this.serverAuthCodeRequested = true;
-            this.forceCodeForRefreshToken = true;
+            this.forceCodeForRefreshToken = forceCodeForRefreshToken;
             this.serverClientId = serverClientId;
             return this;
 

--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManager.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManager.java
@@ -56,6 +56,7 @@ public class AuthManager {
     public String includeProfile;
     public boolean isGmsApp;
     public boolean ignoreStoredPermission = false;
+    public boolean forceRefreshToken = false;
 
     public AuthManager(Context context, String accountName, String packageName, String service) {
         this.context = context;
@@ -316,7 +317,7 @@ public class AuthManager {
         }
         if (isPermitted() || isTrustGooglePermitted(context)) {
             String token = getAuthToken();
-            if (token != null) {
+            if (token != null && !forceRefreshToken) {
                 AuthResponse response = new AuthResponse();
                 response.issueAdvice = "stored";
                 response.auth = token;

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/identity/AuthorizationService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/identity/AuthorizationService.kt
@@ -73,7 +73,7 @@ class AuthorizationServiceImpl(val context: Context, val packageName: String, ov
                 setAccountName(account.name)
                 request?.requestedScopes?.forEach { requestScopes(it) }
                 if (request?.idTokenRequested == true && request.serverClientId != null) requestIdToken(request.serverClientId)
-                if (request?.serverAuthCodeRequested == true && request.serverClientId != null) requestServerAuthCode(request.serverClientId)
+                if (request?.serverAuthCodeRequested == true && request.serverClientId != null) requestServerAuthCode(request.serverClientId, request.forceCodeForRefreshToken)
             }.build()
             val intent = Intent(context, AuthSignInActivity::class.java).apply {
                 `package` = Constants.GMS_PACKAGE_NAME

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/extensions.kt
@@ -94,6 +94,7 @@ fun getServerAuthTokenManager(context: Context, packageName: String, options: Go
     val serverAuthTokenManager = AuthManager(context, account.name, packageName, "oauth2:server:client_id:${options.serverClientId}:api_scope:${options.scopeUris.joinToString(" ")}")
     serverAuthTokenManager.includeEmail = if (options.includeEmail) "1" else "0"
     serverAuthTokenManager.includeProfile = if (options.includeProfile) "1" else "0"
+    serverAuthTokenManager.forceRefreshToken = options.isForceCodeForRefreshToken
     serverAuthTokenManager.setOauth2Prompt("auto")
     serverAuthTokenManager.setItCaveatTypes("2")
     return serverAuthTokenManager


### PR DESCRIPTION
Fixed the issue where after logging out of Google account, some apps would prompt that they could not log in with Google account when logging in again. e.g. de.mcdonalds.mcdonaldsinfoapp