### PR TITLE
Bump GMS version to 25.39.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ def execResult(... args) {
 }
 
 def ignoreGit = providers.environmentVariable('GRADLE_MICROG_VERSION_WITHOUT_GIT').getOrElse('0') == '1'
-def gmsVersion = "25.09.32"
+def gmsVersion = "25.43.33"
 def gmsVersionCode = Integer.parseInt(gmsVersion.replaceAll('\\.', ''))
 def vendingVersion = "40.2.26"
 def vendingVersionCode = Integer.parseInt(vendingVersion.replaceAll('\\.', ''))


### PR DESCRIPTION
Not sure if there is a special procedure for this or rationale for when this should be updated, but since in https://github.com/microg/GmsCore/pull/2813 @ale5000-git just bumped it that way, I figured out I should do the same.

This is the version currently showing for me in Aurora Store, but they are new versions almost every week (I guess you are aware of https://support.google.com/product-documentation/answer/14343500 which already shows 25.40).

Also the same goes for PlayStore (vending) version (currently 48.4, not using a yy.ww scheme), but I do not know the last two digits as this one does not show up in Aurora.