### PR TITLE
build.gradle: vendingVersion 40.2.26 -> 49.1.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ def execResult(... args) {
 def ignoreGit = providers.environmentVariable('GRADLE_MICROG_VERSION_WITHOUT_GIT').getOrElse('0') == '1'
 def gmsVersion = "25.09.32"
 def gmsVersionCode = Integer.parseInt(gmsVersion.replaceAll('\\.', ''))
-def vendingVersion = "40.2.26"
+def vendingVersion = "49.1.32"
 def vendingVersionCode = Integer.parseInt(vendingVersion.replaceAll('\\.', ''))
 def gitVersionBase = !ignoreGit ? execResult('git', 'describe', '--tags', '--abbrev=0', '--match=v[0-9]*').trim().substring(1) : "v0.0.0.$gmsVersionCode"
 def gitCommitCount = !ignoreGit ? Integer.parseInt(execResult('git', 'rev-list', '--count', "v$gitVersionBase..HEAD").trim()) : 0


### PR DESCRIPTION
Bumps Vending version to 49.1.32 from 40.2.26.

Complements to #3092.

Source: https://www.apkmirror.com/apk/google-inc/google-play-store 