### PR TITLE
Phenotype: resolve Gmail failing to send emails with attachments

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
@@ -70,6 +70,11 @@ private val CONFIGURATION_OPTIONS = mapOf(
         Flag("45661535", encodeSupportedLanguageList(), 0),
         Flag("45700179", encodeSupportedLanguageList(), 0)
     ),
+    "gmail_android.user#com.google.android.gm" to arrayOf(
+        Flag("45624002", true, 0),
+        Flag("45668769", true, 0),
+        Flag("45633067", true, 0),
+    ),
 )
 
 class PhenotypeServiceImpl(val packageName: String?) : IPhenotypeService.Stub() {


### PR DESCRIPTION
After merging this PR, the following steps are required:

1. Delete Gmail data to allow Gmail to re-trigger configuration fetching.

2. Close and restart Gmail.

3. Delete the emails awaiting upload or wait for the upload to complete.

4. Once there are no more emails awaiting upload, the email can be sent successfully.