### PR TITLE
Google 2FA: prevent infinite request loop if registration fails

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -368,7 +368,7 @@
             android:exported="false"
             android:process=":persistent">
             <intent-filter>
-                <action android:name="org.microg.gms.gcm.REGISTERED" />
+                <action android:name="org.microg.gms.gcm.CONNECTED" />
                 <action android:name="org.microg.gms.gcm.REGISTER_ACCOUNT" />
                 <action android:name="org.microg.gms.gcm.NOTIFY_COMPLETE" />
 

--- a/play-services-core/src/main/kotlin/org/microg/gms/gcm/GcmInGmsService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/gcm/GcmInGmsService.kt
@@ -155,7 +155,8 @@ class GcmInGmsService : LifecycleService() {
                 Log.d(TAG, "start handle gcm message")
                 intent.extras?.let { notifyVerificationInfo(it) }
             }
-            ACTION_GCM_REGISTERED -> {
+            ACTION_GCM_REGISTER_ALL_ACCOUNTS,
+            ACTION_GCM_CONNECTED -> {
                 updateLocalAccountGroups()
             }
             ACTION_GCM_REGISTER_ACCOUNT -> {

--- a/play-services-core/src/main/kotlin/org/microg/gms/gcm/extensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/gcm/extensions.kt
@@ -12,12 +12,12 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 
 const val ACTION_GCM_RECONNECT = "org.microg.gms.gcm.RECONNECT"
-const val ACTION_GCM_REGISTERED = "org.microg.gms.gcm.REGISTERED"
+const val ACTION_GCM_CONNECTED = "org.microg.gms.gcm.CONNECTED"
 const val ACTION_GCM_REGISTER_ACCOUNT = "org.microg.gms.gcm.REGISTER_ACCOUNT"
+const val ACTION_GCM_REGISTER_ALL_ACCOUNTS = "org.microg.gms.gcm.REGISTER_ALL_ACCOUNTS"
 const val ACTION_GCM_NOTIFY_COMPLETE = "org.microg.gms.gcm.NOTIFY_COMPLETE"
 const val KEY_GCM_REGISTER_ACCOUNT_NAME = "register_account_name"
 const val EXTRA_NOTIFICATION_ACCOUNT = "notification_account"
-const val ACTION_RETRY_REGISTER_GCM_IN_GMS = "org.microg.gms.gcm.RETRY_REGISTER_GCM_IN_GMS"
 
 const val GMS_NOTS_OAUTH_SERVICE = "oauth2:https://www.googleapis.com/auth/notifications"
 const val GMS_NOTS_BASE_URL = "https://notifications-pa.googleapis.com"

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountsFragment.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.microg.gms.auth.AuthConstants
 import org.microg.gms.common.Constants
-import org.microg.gms.gcm.ACTION_GCM_REGISTERED
+import org.microg.gms.gcm.ACTION_GCM_CONNECTED
+import org.microg.gms.gcm.ACTION_GCM_REGISTER_ALL_ACCOUNTS
 import org.microg.gms.people.DatabaseHelper
 import org.microg.gms.people.PeopleManager
 import org.microg.gms.settings.SettingsContract
@@ -65,7 +66,7 @@ class AccountsFragment : PreferenceFragmentCompat() {
         }).also { it.isCircular = true } else null
 
     private fun registerGcmInGms() {
-        Intent(ACTION_GCM_REGISTERED).apply {
+        Intent(ACTION_GCM_REGISTER_ALL_ACCOUNTS).apply {
             `package` = Constants.GMS_PACKAGE_NAME
         }.let { requireContext().sendBroadcast(it) }
     }


### PR DESCRIPTION
Fix an issue where regId acquisition failure in
GcmInGmsService#registerGcmInGms caused an infinite request loop,
leading to excessive wakeups and increased power consumption.