### PR TITLE
Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,8 @@
+jdk:
+  - openjdk17
+install:
+  #Default - ./gradlew clean -Pgroup=com.github.microg -Pversion=branch-commit-1 -xtest -xlint assemble publishToMavenLocal
+  - sed -i '/withJavadocJar/d' gradle/publish-android.gradle
+  - ./gradlew clean -Pgroup=$GROUP -Pversion=$VERSION -xtest -xlint publishToMavenLocal
+env:
+  GRADLE_MICROG_VERSION_WITHOUT_GIT: 1


### PR DESCRIPTION
MicroG libs [aren't updated on maven central for a moment now](https://central.sonatype.com/artifact/org.microg.gms/play-services-fido-core), this patch allow to use Jitpack to get them: https://jitpack.io/#p1gp1g/GmsCore 

Jitpack autoupdate the libraries, as soon as they continue to build


