### PR TITLE
Fido2: Fix instant use of screen lock

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/screenlock/ScreenLockTransportHandler.kt
@@ -259,13 +259,18 @@ class ScreenLockTransportHandler(private val activity: FragmentActivity, callbac
 
     override fun shouldBeUsedInstantly(options: RequestOptions): Boolean {
         if (options.type != RequestOptionsType.SIGN) return false
-        for (descriptor in options.signOptions.allowList.orEmpty()) {
+        // If there is an allow list, it means we try to login for a defined user.
+        // So if we have one of the allowed keys to login with the screen lock, we use it.
+        //
+        // We DON'T want to use instant connection if the allowList is empty, as the user
+        // may want to login with different user accounts, maybe on a hardware key
+        options.signOptions.allowList?.forEach {
             try {
-                val (type, data) = CredentialId.decodeTypeAndData(descriptor.id)
+                val (type, data) = CredentialId.decodeTypeAndData(it.id)
                 if (type == 1.toByte() && store.containsKey(options.rpId, data)) {
                     return true
                 }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Ignore
             }
         }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -121,7 +121,7 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
             // Check if we can directly open screen lock handling
             if (!requiresPrivilege && allowInstant) {
                 val instantTransport = transportHandlers.firstOrNull { it.isSupported && it.shouldBeUsedInstantly(options) }
-                if (instantTransport != null && instantTransport.transport in INSTANT_SUPPORTED_TRANSPORTS) {
+                if (instantTransport != null) {
                     window.setBackgroundDrawable(0.toDrawable())
                     startTransportHandling(instantTransport.transport, true)
                     return
@@ -342,7 +342,6 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
         const val KEY_CALLER = "caller"
 
         val IMPLEMENTED_TRANSPORTS = setOf(USB, SCREEN_LOCK, NFC)
-        val INSTANT_SUPPORTED_TRANSPORTS = setOf(SCREEN_LOCK)
     }
 }
 

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -6,8 +6,6 @@
 package org.microg.gms.fido.core.ui
 
 import android.content.Intent
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.util.Base64
@@ -37,6 +35,7 @@ import org.microg.gms.fido.core.transport.usb.UsbTransportHandler
 import org.microg.gms.utils.getApplicationLabel
 import org.microg.gms.utils.getFirstSignatureDigest
 import org.microg.gms.utils.toBase64
+import androidx.core.graphics.drawable.toDrawable
 
 const val TAG = "FidoUi"
 
@@ -95,19 +94,6 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
 
             Log.d(TAG, "onCreate caller=$callerPackage options=$options")
 
-            val requiresPrivilege =
-                options is BrowserRequestOptions && !database.isPrivileged(callerPackage, callerSignature)
-
-            // Check if we can directly open screen lock handling
-            if (!requiresPrivilege) {
-                val instantTransport = transportHandlers.firstOrNull { it.isSupported && it.shouldBeUsedInstantly(options) }
-                if (instantTransport != null && instantTransport.transport in INSTANT_SUPPORTED_TRANSPORTS) {
-                    window.setBackgroundDrawable(ColorDrawable(0))
-                    window.statusBarColor = Color.TRANSPARENT
-                    setTheme(org.microg.gms.base.core.R.style.Theme_Translucent)
-                }
-            }
-
             setTheme(androidx.appcompat.R.style.Theme_AppCompat_DayNight_NoActionBar)
             setContentView(R.layout.fido_authenticator_activity)
 
@@ -139,6 +125,7 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
             if (!requiresPrivilege && allowInstant) {
                 val instantTransport = transportHandlers.firstOrNull { it.isSupported && it.shouldBeUsedInstantly(options) }
                 if (instantTransport != null && instantTransport.transport in INSTANT_SUPPORTED_TRANSPORTS) {
+                    window.setBackgroundDrawable(0.toDrawable())
                     startTransportHandling(instantTransport.transport, true)
                     return
                 }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -120,10 +120,11 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
 
             // Check if we can directly open screen lock handling
             if (!requiresPrivilege && allowInstant) {
-                val instantTransport = transportHandlers.firstOrNull { it.isSupported && it.shouldBeUsedInstantly(options) }
-                if (instantTransport != null) {
+                transportHandlers.firstOrNull {
+                    it.isSupported && it.shouldBeUsedInstantly(options)
+                }?.let {
                     window.setBackgroundDrawable(0.toDrawable())
-                    startTransportHandling(instantTransport.transport, true)
+                    startTransportHandling(it.transport, true)
                     return
                 }
             }

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -22,7 +22,6 @@ import com.google.android.gms.fido.fido2.api.common.AuthenticationExtensionsPrfO
 import com.google.android.gms.fido.fido2.api.common.ErrorCode.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
-import org.microg.gms.common.GmsService
 import org.microg.gms.fido.core.*
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.Transport.*
@@ -53,8 +52,6 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
             else -> null
         }
 
-    private val service: GmsService
-        get() = GmsService.byServiceId(intent.getIntExtra(KEY_SERVICE, GmsService.UNKNOWN.SERVICE_ID))
     private val database by lazy { Database(this) }
     private val transportHandlers by lazy {
         setOfNotNull(

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/TransportSelectionFragment.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/TransportSelectionFragment.kt
@@ -10,9 +10,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
+import com.google.android.gms.fido.fido2.api.common.BrowserPublicKeyCredentialRequestOptions
+import com.google.android.gms.fido.fido2.api.common.PublicKeyCredentialRequestOptions
 import org.microg.gms.fido.core.R
 import org.microg.gms.fido.core.databinding.FidoTransportSelectionFragmentBinding
-import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.Transport.SCREEN_LOCK
 
 class TransportSelectionFragment : AuthenticatorActivityFragment() {
@@ -31,7 +32,15 @@ class TransportSelectionFragment : AuthenticatorActivityFragment() {
             findNavController().navigate(R.id.openUsbFragment, arguments.withIsFirst(false))
         }
         binding.setOnScreenLockClick {
-            startTransportHandling(SCREEN_LOCK)
+            if (options is PublicKeyCredentialRequestOptions ||
+                options is BrowserPublicKeyCredentialRequestOptions) {
+                findNavController().navigate(
+                    R.id.signInSelectionFragment,
+                    arguments.withIsFirst(false)
+                )
+            } else {
+                startTransportHandling(SCREEN_LOCK)
+            }
         }
         return binding.root
     }


### PR DESCRIPTION
I had 2 problems with the current implementation:

1. as soon as a FIDO key was registered on the device (screen lock), then I couldn't use hardware key for the website, even if the allowCredentials contained a single key with USB only

This is because of `localSavedUserKey` that makes the authentication use instantly the screen lock if we have a key saved for the domain.

2. I can't selection the user with screenLock after the transport selection

This PR fixes these 2 issues. And does a little cleanup, and a few comments to help understand what does what

MEMO: I use fido-core as a library.