### PR TITLE
fix google login missing droidguard

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
@@ -353,7 +353,7 @@ public class LoginActivity extends AssistantActivity {
                 .token(oAuthToken).isAccessToken()
                 .addAccount()
                 .getAccountId()
-                .droidguardResults(null /*TODO*/)
+                .droidguardResults("null" /*TODO*/)
                 .getResponseAsync(new HttpFormClient.Callback<AuthResponse>() {
                     @Override
                     public void onResponse(AuthResponse response) {
@@ -430,6 +430,7 @@ public class LoginActivity extends AssistantActivity {
                 .hasPermission(true)
                 .addAccount()
                 .getAccountId()
+                .droidguardResults("null")
                 .getResponseAsync(new HttpFormClient.Callback<AuthResponse>() {
                     @Override
                     public void onResponse(AuthResponse response) {


### PR DESCRIPTION
1.Avoiding ANR that may occur during login (https://github.com/microg/GmsCore/pull/3192)
2.fix google login missing droidguard
Problem stack：
```
org.microg.gms.common.NotOkayException: Error=MissingDroidguard
 at org.microg.gms.common.HttpFormClient.request(HttpFormClient.java:96)
at org.microg.gms.common.HttpFormClient.lambda$requestAsync$0(HttpFormClient.java:210)
at org.microg.gms.common.HttpFormClient$$ExternalSyntheticLambda0.run(Unknown Source:8)
```

