### PR TITLE
feat: introduce CredentialProviderService minimal implementation

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.PROVIDE_DEFAULT_ENABLED_CREDENTIAL_SERVICE" />
 
     <permission
         android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"
@@ -577,6 +578,23 @@
             <intent-filter>
                 <action android:name="com.google.android.gms.credential.manager.service.firstparty.START" />
             </intent-filter>
+        </service>
+
+        <service
+            android:name="org.microg.gms.credential.CredentialProviderService"
+            android:exported="true"
+            android:permission="android.permission.BIND_CREDENTIAL_PROVIDER_SERVICE"
+            android:label="@string/gms_app_name">
+            <intent-filter>
+                <action android:name="android.service.credentials.CredentialProviderService" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.credentials.provider"
+                android:resource="@xml/credential_provider_platform" />
+            <meta-data
+                android:name="android.service.credentials.CredentialProviderService"
+                android:resource="@xml/credential_provider_platform" />
         </service>
 
         <activity

--- a/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialProviderService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialProviderService.kt
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2025 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.credential
+
+import android.credentials.ClearCredentialStateException
+import android.credentials.CreateCredentialException
+import android.credentials.GetCredentialException
+import android.os.Build
+import android.os.CancellationSignal
+import android.os.OutcomeReceiver
+import android.service.credentials.BeginCreateCredentialRequest
+import android.service.credentials.BeginCreateCredentialResponse
+import android.service.credentials.BeginGetCredentialRequest
+import android.service.credentials.BeginGetCredentialResponse
+import android.service.credentials.ClearCredentialStateRequest
+import android.service.credentials.CredentialProviderService
+import android.util.Log
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+class CredentialProviderService : CredentialProviderService() {
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "onCreate")
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    override fun onBeginGetCredential(
+        request: BeginGetCredentialRequest,
+        cancellationSignal: CancellationSignal,
+        callback: OutcomeReceiver<BeginGetCredentialResponse, GetCredentialException>
+    ) {
+        Log.d(TAG, "onBeginGetCredential")
+        callback.onError(GetCredentialException(GetCredentialException.TYPE_NO_CREDENTIAL))
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    override fun onBeginCreateCredential(
+        request: BeginCreateCredentialRequest,
+        cancellationSignal: CancellationSignal,
+        callback: OutcomeReceiver<BeginCreateCredentialResponse, CreateCredentialException>
+    ) {
+        Log.d(TAG, "onBeginCreateCredential")
+        callback.onError(CreateCredentialException(CreateCredentialException.TYPE_NO_CREATE_OPTIONS))
+    }
+
+    override fun onClearCredentialState(
+        request: ClearCredentialStateRequest,
+        cancellationSignal: CancellationSignal,
+        callback: OutcomeReceiver<Void, ClearCredentialStateException>
+    ) {
+        Log.d(TAG, "onClearCredentialState")
+        callback.onResult(null)
+    }
+
+    companion object {
+        private const val TAG = "CredentialProvider"
+    }
+}

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -456,4 +456,6 @@ Please set up a password, PIN, or pattern lock screen."</string>
     <string name="location_sharing_turn_off_confirm">Turn off</string>
     <string name="location_sharing_confirm_dialog_title">Enable Location Sharing</string>
     <string name="location_sharing_confirm_dialog_text">People you share your location with can always see:\n·Your name and photo\n·Your device\'s recent location,even when you\'re not using a Google service\n·Your device\'s battery power,and if it\'s charging\n·Your arrival and departure time,if they add a Location Sharing notification</string>
+
+    <string name="credential_provider_subtitle">microG credential provider</string>
 </resources>

--- a/play-services-core/src/main/res/xml/credential_provider_platform.xml
+++ b/play-services-core/src/main/res/xml/credential_provider_platform.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<credential-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsSubtitle="@string/credential_provider_subtitle">
+    <capabilities>
+        <capability>android.credentials.TYPE_PASSWORD_CREDENTIAL</capability>
+        <capability>android.credentials.TYPE_PUBLIC_KEY_CREDENTIAL</capability>
+    </capabilities>
+</credential-provider>


### PR DESCRIPTION
Introduce CredentialProviderService minimal implementation.

This allows 3rd party applications (like Down Dog Yoga) that are clearing credentials state at start to run properly.

The user would still have to select the microG credential provider manually in his Account preferences.

To make microG credential provider be automatically selected on a specific OS, the config_enabledCredentialProviderService and config_primaryCredentialProviderService resources can be overlayed.