### PR TITLE
Fix Google Photos crash caused by Phenotype Flag

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
@@ -75,6 +75,9 @@ private val CONFIGURATION_OPTIONS = mapOf(
         Flag("45668769", true, 0),
         Flag("45633067", true, 0),
     ),
+    "com.google.android.apps.photos" to arrayOf(
+        Flag("45617431", true, 0),
+    ),
 )
 
 class PhenotypeServiceImpl(val packageName: String?) : IPhenotypeService.Stub() {


### PR DESCRIPTION
Scene: Photos settings -> Preferences -> Memories -> Hide people and pets (Click to crash)