### PR TITLE
Added RCS support 

### DIFF
--- a/play-services-rcs/src/main/java/org/microg/gms/rcs/contacts/RcsContactsService.java
+++ b/play-services-rcs/src/main/java/org/microg/gms/rcs/contacts/RcsContactsService.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2023 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.rcs.contacts;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+public class RcsContactsService extends Service {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/play-services-rcs/src/main/java/org/microg/gms/rcs/provider/RcsCapabilityProvider.java
+++ b/play-services-rcs/src/main/java/org/microg/gms/rcs/provider/RcsCapabilityProvider.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2023 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.rcs.provider;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class RcsCapabilityProvider extends ContentProvider {
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+}


### PR DESCRIPTION

monitored logcat on device with real play services to see what messages does during rcs setup. it just looks for com.google.android.gms.rcs.START and try to bind IRcsEngineController. when that missing, it show "chat features unavailable" and stop. so i just did same thing in microg. now when messages look for that service, microg return the controller instead of nothing.
tested this on redmi note 8 pro with airtel you can see in video. messages already have jibe client inside. it was never broken. microg was just not returning anything to it. #2994

https://github.com/user-attachments/assets/47de85a3-33e8-4948-9ac2-a4cf95bdd9a3

