### PR TITLE
iap: add billing init method

### DIFF
--- a/vending-app/src/main/aidl/com/android/vending/billing/IInAppBillingInitializeCallback.aidl
+++ b/vending-app/src/main/aidl/com/android/vending/billing/IInAppBillingInitializeCallback.aidl
@@ -7,5 +7,5 @@ package com.android.vending.billing;
 import android.os.Bundle;
 
 interface IInAppBillingInitializeCallback {
-    void onInitializeResponse(in Bundle bundle);
+    void callback(in Bundle bundle);
 }

--- a/vending-app/src/main/aidl/com/android/vending/billing/IInAppBillingService.aidl
+++ b/vending-app/src/main/aidl/com/android/vending/billing/IInAppBillingService.aidl
@@ -443,5 +443,13 @@ interface IInAppBillingService {
 
     void delegateToBackend(in Bundle bundle, IInAppBillingDelegateToBackendCallback callback) = 2000;
 
-    void billingInitialize(int apiVersion, String packageName, in Bundle extraParams, IInAppBillingInitializeCallback callback) = 2100;
+    /**
+     * @param apiVersion billing API version that the app is using, must be 22 or later
+     * @param packageName package name of the calling app
+     * @param extraParams a Bundle with the following optional keys:
+     *        "callingPackage" - String
+     *        "enablePendingPurchases" - Boolean
+     * @param callback callback that is invoked with the result, see IInAppBillingInitializeCallback.aidl for details
+     */
+    void initialize(int apiVersion, String packageName, in Bundle extraParams, IInAppBillingInitializeCallback callback) = 2100;
 }

--- a/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
@@ -711,7 +711,7 @@ class InAppBillingServiceImpl(private val context: Context) : IInAppBillingServi
         Log.d(TAG, "delegateToBackend Not yet implemented")
     }
 
-    override fun billingInitialize(
+    override fun initialize(
         apiVersion: Int,
         packageName: String?,
         extraParams: Bundle?,
@@ -719,7 +719,7 @@ class InAppBillingServiceImpl(private val context: Context) : IInAppBillingServi
     ) {
         extraParams?.keySet()
         Log.w(TAG, "initialize: apiVersion: $apiVersion packageName:$packageName params:$extraParams")
-        callback?.onInitializeResponse(resultBundle(BillingResponseCode.OK, "", bundleOf(
+        callback?.callback(resultBundle(BillingResponseCode.OK, "", bundleOf(
             "BILLING_API_VERSION_KEY" to apiVersion
         )))
     }


### PR DESCRIPTION
Fix issue where the latest versions of YouTube and Google One cannot launch IAP payment.
youtube version:21.10.500
google one version:1.300.880965289