### PR TITLE
fix(auth): replace deprecated NetworkInfo with NetworkCapabilities in LoginActivity

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
@@ -25,6 +25,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
@@ -290,15 +292,32 @@ public class LoginActivity extends AssistantActivity {
     }
 
     private void start() {
-        // Network check bypassed - always proceed (VPN/proxy connections not detected by getActiveNetworkInfo)
-        if (LastCheckinInfo.read(this).getAndroidId() == 0) {
-            new Thread(() -> {
-                Runnable next;
-                next = checkin(false) ? this::loadLoginPage : () -> showError(R.string.auth_general_error_desc);
-                LoginActivity.this.runOnUiThread(next);
-            }).start();
+        if (isNetworkAvailable()) {
+            if (LastCheckinInfo.read(this).getAndroidId() == 0) {
+                new Thread(() -> {
+                    Runnable next;
+                    next = checkin(false) ? this::loadLoginPage : () -> showError(R.string.auth_general_error_desc);
+                    LoginActivity.this.runOnUiThread(next);
+                }).start();
+            } else {
+                loadLoginPage();
+            }
         } else {
-            loadLoginPage();
+            showError(R.string.no_network_error_desc);
+        }
+    }
+
+    private boolean isNetworkAvailable() {
+        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+        if (SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            Network network = cm.getActiveNetwork();
+            if (network == null) return false;
+            NetworkCapabilities caps = cm.getNetworkCapabilities(network);
+            return caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+        } else {
+            NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+            return networkInfo != null && networkInfo.isConnected();
         }
     }
 

--- a/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/login/LoginActivity.java
@@ -290,20 +290,15 @@ public class LoginActivity extends AssistantActivity {
     }
 
     private void start() {
-        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo networkInfo = cm.getActiveNetworkInfo();
-        if (networkInfo != null && networkInfo.isConnected()) {
-            if (LastCheckinInfo.read(this).getAndroidId() == 0) {
-                new Thread(() -> {
-                    Runnable next;
-                    next = checkin(false) ? this::loadLoginPage : () -> showError(R.string.auth_general_error_desc);
-                    LoginActivity.this.runOnUiThread(next);
-                }).start();
-            } else {
-                loadLoginPage();
-            }
+        // Network check bypassed - always proceed (VPN/proxy connections not detected by getActiveNetworkInfo)
+        if (LastCheckinInfo.read(this).getAndroidId() == 0) {
+            new Thread(() -> {
+                Runnable next;
+                next = checkin(false) ? this::loadLoginPage : () -> showError(R.string.auth_general_error_desc);
+                LoginActivity.this.runOnUiThread(next);
+            }).start();
         } else {
-            showError(R.string.no_network_error_desc);
+            loadLoginPage();
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace deprecated `ConnectivityManager.getActiveNetworkInfo()` with the `NetworkCapabilities` API in `LoginActivity.start()`. The new path is gated on API 23 (M) because it relies on `getActiveNetwork()`, even though `NetworkCapabilities` itself is available since API 21.
- Retain fallback to `NetworkInfo.isConnected()` for Android versions below M (project `minSdk` is 19).
- No behavioral change on devices where the old API works correctly.

## Problem

On Android 14, `getActiveNetworkInfo()` returns `null` for non-system apps when the active connection is a VPN (e.g. Clash, v2ray). This causes the login screen to show the "no network" error even though the device has internet access.

This primarily affects users on **stock ROMs** (Honor, Huawei) where microG is installed as a user app rather than a system app. Custom ROM users are unaffected because microG is typically installed as a privileged system app, which has access to the deprecated API.

## Fix

```java
// Before (deprecated, fails on Android 14 with VPN):
NetworkInfo networkInfo = cm.getActiveNetworkInfo();
if (networkInfo != null && networkInfo.isConnected())

// After (works with VPN/proxy connections):
if (SDK_INT >= Build.VERSION_CODES.M) {
    Network network = cm.getActiveNetwork();
    NetworkCapabilities caps = cm.getNetworkCapabilities(network);
    return caps != null && caps.hasCapability(NET_CAPABILITY_INTERNET);
} else {
    NetworkInfo networkInfo = cm.getActiveNetworkInfo();
    return networkInfo != null && networkInfo.isConnected();
}
```

## Test plan

- [ ] Verify login works on Android 14 stock ROM (Honor/Huawei) with VPN active
- [ ] Verify login works on Android 14 stock ROM with WiFi only (no VPN)
- [ ] Verify login still shows "no network" error when truly offline
- [ ] Verify no regression on Android < M (fallback path)

## Scope

This PR only touches `LoginActivity.java`. There are 3 other call sites using the same deprecated API (`TriggerReceiver`, `McsService`, `gcm/TriggerReceiver`) which could be addressed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)