### PR TITLE
Cast: Fix thread safety and memory leak in CastMediaRouteProvider

### DIFF
--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastMediaRouteProvider.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastMediaRouteProvider.java
@@ -36,13 +36,11 @@ import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.CastMediaControlIntent;
 
 import java.net.InetAddress;
-import java.io.UnsupportedEncodingException;
-import java.lang.Runnable;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CastMediaRouteProvider extends MediaRouteProvider {
     private static final String TAG = CastMediaRouteProvider.class.getSimpleName();
@@ -54,6 +52,8 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
     private NsdManager.DiscoveryListener mDiscoveryListener;
 
     private final List<String> customCategories = new ArrayList<>();
+
+    private final Object lock = new Object();
 
     private enum State {
         NOT_DISCOVERING,
@@ -182,7 +182,9 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
 
             @Override
             public void onDiscoveryStarted(String regType) {
-                CastMediaRouteProvider.this.state = State.DISCOVERING;
+                synchronized (lock) {
+                    CastMediaRouteProvider.this.state = State.DISCOVERING;
+                }
             }
 
             @Override
@@ -231,17 +233,23 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
 
             @Override
             public void onDiscoveryStopped(String serviceType) {
-                CastMediaRouteProvider.this.state = State.NOT_DISCOVERING;
+                synchronized (lock) {
+                    CastMediaRouteProvider.this.state = State.NOT_DISCOVERING;
+                }
             }
 
             @Override
             public void onStartDiscoveryFailed(String serviceType, int errorCode) {
-                CastMediaRouteProvider.this.state = State.NOT_DISCOVERING;
+                synchronized (lock) {
+                    CastMediaRouteProvider.this.state = State.NOT_DISCOVERING;
+                }
             }
 
             @Override
             public void onStopDiscoveryFailed(String serviceType, int errorCode) {
-                CastMediaRouteProvider.this.state = State.DISCOVERING;
+                synchronized (lock) {
+                    CastMediaRouteProvider.this.state = State.DISCOVERING;
+                }
             }
         };
     }
@@ -250,22 +258,26 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
             String id, String name, InetAddress host, int port, String
             deviceVersion, String friendlyName, String modelName, String
             iconPath, int status) {
-        if (!this.castDevices.containsKey(id)) {
-            // TODO: Capabilities
-            int capabilities = CastDevice.CAPABILITY_VIDEO_OUT | CastDevice.CAPABILITY_AUDIO_OUT;
+        synchronized (lock) {
+            if (!this.castDevices.containsKey(id)) {
+                // TODO: Capabilities
+                int capabilities = CastDevice.CAPABILITY_VIDEO_OUT | CastDevice.CAPABILITY_AUDIO_OUT;
 
-            CastDevice castDevice = new CastDevice(id, name, host, port, deviceVersion, friendlyName, modelName, iconPath, status, capabilities);
-            this.castDevices.put(id, castDevice);
-            this.serviceCastIds.put(name, id);
+                CastDevice castDevice = new CastDevice(id, name, host, port, deviceVersion, friendlyName, modelName, iconPath, status, capabilities);
+                this.castDevices.put(id, castDevice);
+                this.serviceCastIds.put(name, id);
+            }
         }
 
         publishRoutesInMainThread();
     }
 
     private void onChromeCastLost(String name) {
-        String id = this.serviceCastIds.remove(name);
-        if (id != null) {
-            this.castDevices.remove(id);
+        synchronized (lock) {
+            String id = this.serviceCastIds.remove(name);
+            if (id != null) {
+                this.castDevices.remove(id);
+            }
         }
 
         publishRoutesInMainThread();
@@ -278,29 +290,34 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
             return;
         }
 
-        if (request != null && request.isValid() && request.isActiveScan()) {
-            if (request.getSelector() != null) {
-                for (String category : request.getSelector().getControlCategories()) {
-                    if (CastMediaControlIntent.isCategoryForCast(category)) {
-                        this.customCategories.add(category);
+        synchronized (lock) {
+            if (request != null && request.isValid() && request.isActiveScan()) {
+                if (request.getSelector() != null) {
+                    for (String category : request.getSelector().getControlCategories()) {
+                        if (CastMediaControlIntent.isCategoryForCast(category)) {
+                            this.customCategories.add(category);
+                        }
                     }
                 }
-            }
-            if (this.state == State.NOT_DISCOVERING) {
-                mNsdManager.discoverServices("_googlecast._tcp.", NsdManager.PROTOCOL_DNS_SD, mDiscoveryListener);
-                this.state = State.DISCOVERY_REQUESTED;
-            }
-        } else {
-            if (this.state == State.DISCOVERING) {
-                mNsdManager.stopServiceDiscovery(mDiscoveryListener);
-                this.state = State.DISCOVERY_STOP_REQUESTED;
+                if (this.state == State.NOT_DISCOVERING) {
+                    mNsdManager.discoverServices("_googlecast._tcp.", NsdManager.PROTOCOL_DNS_SD, mDiscoveryListener);
+                    this.state = State.DISCOVERY_REQUESTED;
+                }
+            } else {
+                if (this.state == State.DISCOVERING) {
+                    mNsdManager.stopServiceDiscovery(mDiscoveryListener);
+                    this.state = State.DISCOVERY_STOP_REQUESTED;
+                }
             }
         }
     }
 
     @Override
     public RouteController onCreateRouteController(String routeId) {
-        CastDevice castDevice = this.castDevices.get(routeId);
+        CastDevice castDevice;
+        synchronized (lock) {
+            castDevice = this.castDevices.get(routeId);
+        }
         if (castDevice == null) {
             return null;
         }
@@ -309,21 +326,23 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
 
     private void publishRoutesInMainThread() {
         Handler mainHandler = new Handler(this.getContext().getMainLooper());
-        mainHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                publishRoutes();
-            }
-        });
+        mainHandler.post(this::publishRoutes);
     }
 
     private void publishRoutes() {
+        List<CastDevice> devices;
+        List<String> categories;
+        synchronized (lock) {
+            devices = new ArrayList<>(this.castDevices.values());
+            categories = new ArrayList<>(this.customCategories);
+        }
+
         MediaRouteProviderDescriptor.Builder builder = new MediaRouteProviderDescriptor.Builder();
-        for (CastDevice castDevice : this.castDevices.values()) {
+        for (CastDevice castDevice : devices) {
             ArrayList<IntentFilter> controlFilters = new ArrayList<>(BASE_CONTROL_FILTERS);
             // Include any app-specific control filters that have been requested.
             // TODO: Do we need to check with the device?
-            for (String category : this.customCategories) {
+            for (String category : categories) {
                 IntentFilter filter = new IntentFilter();
                 filter.addCategory(category);
                 controlFilters.add(filter);

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastMediaRouteProvider.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastMediaRouteProvider.java
@@ -39,8 +39,10 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class CastMediaRouteProvider extends MediaRouteProvider {
     private static final String TAG = CastMediaRouteProvider.class.getSimpleName();
@@ -51,7 +53,7 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
     private NsdManager mNsdManager;
     private NsdManager.DiscoveryListener mDiscoveryListener;
 
-    private final List<String> customCategories = new ArrayList<>();
+    private final Set<String> customCategories = new HashSet<>();
 
     private final Object lock = new Object();
 
@@ -293,6 +295,7 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
         synchronized (lock) {
             if (request != null && request.isValid() && request.isActiveScan()) {
                 if (request.getSelector() != null) {
+                    this.customCategories.clear();
                     for (String category : request.getSelector().getControlCategories()) {
                         if (CastMediaControlIntent.isCategoryForCast(category)) {
                             this.customCategories.add(category);
@@ -303,11 +306,9 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
                     mNsdManager.discoverServices("_googlecast._tcp.", NsdManager.PROTOCOL_DNS_SD, mDiscoveryListener);
                     this.state = State.DISCOVERY_REQUESTED;
                 }
-            } else {
-                if (this.state == State.DISCOVERING) {
-                    mNsdManager.stopServiceDiscovery(mDiscoveryListener);
-                    this.state = State.DISCOVERY_STOP_REQUESTED;
-                }
+            } else if (this.state == State.DISCOVERING) {
+                mNsdManager.stopServiceDiscovery(mDiscoveryListener);
+                this.state = State.DISCOVERY_STOP_REQUESTED;
             }
         }
     }
@@ -331,10 +332,10 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
 
     private void publishRoutes() {
         List<CastDevice> devices;
-        List<String> categories;
+        Set<String> categories;
         synchronized (lock) {
             devices = new ArrayList<>(this.castDevices.values());
-            categories = new ArrayList<>(this.customCategories);
+            categories = new HashSet<>(this.customCategories);
         }
 
         MediaRouteProviderDescriptor.Builder builder = new MediaRouteProviderDescriptor.Builder();

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastMediaRouteProvider.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastMediaRouteProvider.java
@@ -19,11 +19,9 @@ package org.microg.gms.cast;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.IntentFilter;
-import android.net.Uri;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdServiceInfo;
 import android.os.Bundle;
-import android.os.AsyncTask;
 import android.os.Handler;
 import android.util.Log;
 
@@ -34,18 +32,13 @@ import androidx.mediarouter.media.MediaRouteProvider;
 import androidx.mediarouter.media.MediaRouteProviderDescriptor;
 import androidx.mediarouter.media.MediaRouter;
 
-import com.google.android.gms.common.images.WebImage;
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.CastMediaControlIntent;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Inet4Address;
-import java.net.UnknownHostException;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.lang.Thread;
 import java.lang.Runnable;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -54,13 +47,13 @@ import java.util.HashMap;
 public class CastMediaRouteProvider extends MediaRouteProvider {
     private static final String TAG = CastMediaRouteProvider.class.getSimpleName();
 
-    private Map<String, CastDevice> castDevices = new HashMap<String, CastDevice>();
-    private Map<String, String> serviceCastIds = new HashMap<String, String>();
+    private final Map<String, CastDevice> castDevices = new HashMap<>();
+    private final Map<String, String> serviceCastIds = new HashMap<>();
 
     private NsdManager mNsdManager;
     private NsdManager.DiscoveryListener mDiscoveryListener;
 
-    private List<String> customCategories = new ArrayList<String>();
+    private final List<String> customCategories = new ArrayList<>();
 
     private enum State {
         NOT_DISCOVERING,
@@ -70,7 +63,7 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
     }
     private State state = State.NOT_DISCOVERING;
 
-    private static final ArrayList<IntentFilter> BASE_CONTROL_FILTERS = new ArrayList<IntentFilter>();
+    private static final ArrayList<IntentFilter> BASE_CONTROL_FILTERS = new ArrayList<>();
     static {
         IntentFilter filter;
 
@@ -214,15 +207,15 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
                             return;
                         }
                         try {
-                            String id = new String(attributes.get("id"), "UTF-8");
-                            String deviceVersion = new String(attributes.get("ve"), "UTF-8");
-                            String friendlyName = new String(attributes.get("fn"), "UTF-8");
-                            String modelName = new String(attributes.get("md"), "UTF-8");
-                            String iconPath = new String(attributes.get("ic"), "UTF-8");
-                            int status = Integer.parseInt(new String(attributes.get("st"), "UTF-8"));
+                            String id = new String(attributes.get("id"), StandardCharsets.UTF_8);
+                            String deviceVersion = new String(attributes.get("ve"), StandardCharsets.UTF_8);
+                            String friendlyName = new String(attributes.get("fn"), StandardCharsets.UTF_8);
+                            String modelName = new String(attributes.get("md"), StandardCharsets.UTF_8);
+                            String iconPath = new String(attributes.get("ic"), StandardCharsets.UTF_8);
+                            int status = Integer.parseInt(new String(attributes.get("st"), StandardCharsets.UTF_8));
 
                             onChromeCastDiscovered(id, name, host, port, deviceVersion, friendlyName, modelName, iconPath, status);
-                        } catch (UnsupportedEncodingException | NullPointerException ex) {
+                        } catch (NullPointerException ex) {
                             Log.e(TAG, "Error getting cast details from DNS-SD response", ex);
                             return;
                         }
@@ -327,7 +320,7 @@ public class CastMediaRouteProvider extends MediaRouteProvider {
     private void publishRoutes() {
         MediaRouteProviderDescriptor.Builder builder = new MediaRouteProviderDescriptor.Builder();
         for (CastDevice castDevice : this.castDevices.values()) {
-            ArrayList<IntentFilter> controlFilters = new ArrayList<IntentFilter>(BASE_CONTROL_FILTERS);
+            ArrayList<IntentFilter> controlFilters = new ArrayList<>(BASE_CONTROL_FILTERS);
             // Include any app-specific control filters that have been requested.
             // TODO: Do we need to check with the device?
             for (String category : this.customCategories) {


### PR DESCRIPTION
## Problem 

`CastMediaRouteProvider` has no thread synchronisation for its shared mutable state, which can be accessed across numerous threads (NSD callbacks + main thread). 
This has been causing `ConcurrentModificationException` crashes, which seems to be consistently reproducible whenever opening the Google Home app. 

<details>
<summary>Stacktrace</summary>

```
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1603)
	at java.util.HashMap$ValueIterator.next(HashMap.java:1631)
	at org.microg.gms.cast.CastMediaRouteProvider.publishRoutes(CastMediaRouteProvider.java:329)
	at org.microg.gms.cast.CastMediaRouteProvider.access$500(CastMediaRouteProvider.java:54)
	at org.microg.gms.cast.CastMediaRouteProvider$2.run(CastMediaRouteProvider.java:322)
	at android.os.Handler.handleCallback(Handler.java:995)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.loopOnce(Looper.java:265)
	at android.os.Looper.loop(Looper.java:358)
	at android.app.ActivityThread.main(ActivityThread.java:10049)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:616)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1115)
```

</details>

The inner `customCategories` collection is also appended to for every discovery request, causing it to grow indefinitely.

## Changes

- Add synchronisation by introducing a shared `lock` object to guard shared state
- Fix unbounded category growth by switching to a `Set` and replacing contents on each discovery request
- Minor code cleanup

## Testing

Just to note, **I have the [ReVanced version](https://github.com/ReVanced/GmsCore) installed on my device** as I do not have root-level access. I understand their fork has a few minor differences, though this specific implementation appears to be completely unchanged.

I have deployed these changes onto my personal device and it has been working as expected.

## Issues

Fixes #2449