### PR TITLE
Bump `gmsVersion` to 25.19.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ def execResult(... args) {
 }
 
 def ignoreGit = providers.environmentVariable('GRADLE_MICROG_VERSION_WITHOUT_GIT').getOrElse('0') == '1'
-def gmsVersion = "25.09.32"
+def gmsVersion = "25.19.31"
 def gmsVersionCode = Integer.parseInt(gmsVersion.replaceAll('\\.', ''))
 def vendingVersion = "40.2.26"
 def vendingVersionCode = Integer.parseInt(vendingVersion.replaceAll('\\.', ''))


### PR DESCRIPTION
This is PR 3 of 3 towards RCS support.
Related PRs: #3359, #3360
Related issue: #2994

#### Description

This PR bumps the spoofed `gmsVersion` to 25.19.31.

By using a script that patches the reported `com.google.android.gms` version in the request payload and performs a binary search, I determined that `mobileconfiguration-pa.googleapis.com` only begins dispatching UPI-enabled configurations when the reported GMS version is ≥ 25.19.00.

25.19.31 was chosen as the smallest bump above this threshold that corresponds to an actual released version.