### PR TITLE
Click listeners on polylines and polygons

### DIFF
--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/AbstractGoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/AbstractGoogleMap.kt
@@ -32,6 +32,8 @@ abstract class AbstractGoogleMap(context: Context) : IGoogleMapDelegate.Stub() {
     internal var mapLongClickListener: IOnMapLongClickListener? = null
     internal var markerClickListener: IOnMarkerClickListener? = null
     internal var circleClickListener: IOnCircleClickListener? = null
+    internal var polygonClickListener : IOnPolygonClickListener? = null
+    internal var polylineClickListener : IOnPolylineClickListener? = null
 
     internal var myLocationChangeListener: IOnMyLocationChangeListener? = null
 
@@ -87,11 +89,11 @@ abstract class AbstractGoogleMap(context: Context) : IGoogleMapDelegate.Stub() {
     }
 
     override fun setOnPolygonClickListener(listener: IOnPolygonClickListener?) {
-        Log.d(TAG, "Not yet implemented: setOnPolygonClickListener")
+        polygonClickListener = listener
     }
 
     override fun setOnPolylineClickListener(listener: IOnPolylineClickListener?) {
-        Log.d(TAG, "Not yet implemented: setOnPolylineClickListener")
+        polylineClickListener = listener
     }
 
     override fun setOnGroundOverlayClickListener(listener: IOnGroundOverlayClickListener?) {

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -101,10 +101,12 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
 
     var lineManager: LineManager? = null
     val pendingLines = mutableSetOf<Markup<Line, LineOptions>>()
+    val lines = mutableMapOf<Long, PolylineImpl>()
     var lineId = 0L
 
     var fillManager: FillManager? = null
     val pendingFills = mutableSetOf<Markup<Fill, FillOptions>>()
+    val polygons = mutableMapOf<Long, PolygonImpl>()
     val circles = mutableMapOf<Long, CircleImpl>()
     var fillId = 0L
 
@@ -760,10 +762,36 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
                 })
                 fillManager.addClickListener { fill ->
                     try {
+                        /* IDs are assigned consecutively across all types of fill, so no ID
+                         * corresponds to both circle and polygon.
+                         */
                         circles[fill.id]?.let { circle ->
                             if (circle.isClickable) {
                                 circleClickListener?.let {
                                     it.onCircleClick(circle)
+                                    return@addClickListener true
+                                }
+                            }
+                        }
+                        polygons[fill.id]?.let { polygon ->
+                            if (polygon.isClickable) {
+                                polygonClickListener?.let {
+                                    it.onPolygonClick(polygon)
+                                    return@addClickListener true
+                                }
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Log.w(TAG, e)
+                    }
+                    false
+                }
+                lineManager.addClickListener { line ->
+                    try {
+                        lines[line.id]?.let { polyline ->
+                            if (polyline.isClickable) {
+                                polylineClickListener?.let {
+                                    it.onPolylineClick(polyline)
                                     return@addClickListener true
                                 }
                             }
@@ -860,8 +888,10 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
         userOnInitializedCallbackList.clear()
         lineManager?.onDestroy()
         lineManager = null
+        lines.clear()
         fillManager?.onDestroy()
         fillManager = null
+        polygons.clear()
         circles.clear()
         symbolManager?.onDestroy()
         symbolManager = null

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/model/Polygon.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/model/Polygon.kt
@@ -15,6 +15,7 @@ import com.google.android.gms.maps.model.PatternItem
 import com.google.android.gms.maps.model.PolygonOptions
 import com.google.android.gms.maps.model.PolylineOptions
 import com.google.android.gms.maps.model.internal.IPolygonDelegate
+import com.mapbox.mapboxsdk.plugins.annotation.AnnotationManager
 import com.mapbox.mapboxsdk.plugins.annotation.Fill
 import com.mapbox.mapboxsdk.plugins.annotation.FillOptions
 import com.mapbox.mapboxsdk.utils.ColorUtils
@@ -224,6 +225,20 @@ class PolygonImpl(private val map: GoogleMapImpl, id: String, options: PolygonOp
 
     override fun addPolyline(id: String, options: PolylineOptions) {
         strokes.add(PolylineImpl(map, id, options))
+    }
+
+    override fun update(manager: AnnotationManager<*, Fill, FillOptions, *, *, *>) {
+        synchronized(this) {
+            val id = annotation?.id
+            if (removed && id != null) {
+                map.polygons.remove(id)
+            }
+            super.update(manager)
+            val annotation = annotation
+            if (annotation != null && id == null) {
+                map.polygons[annotation.id] = this
+            }
+        }
     }
 
     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean = warnOnTransactionIssues(code, reply, flags) { super.onTransact(code, data, reply, flags) }

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/model/Polyline.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/model/Polyline.kt
@@ -12,6 +12,9 @@ import com.google.android.gms.maps.model.Cap
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.PatternItem
 import com.google.android.gms.maps.model.internal.IPolylineDelegate
+import com.mapbox.mapboxsdk.plugins.annotation.AnnotationManager
+import com.mapbox.mapboxsdk.plugins.annotation.Fill
+import com.mapbox.mapboxsdk.plugins.annotation.FillOptions
 import com.mapbox.mapboxsdk.plugins.annotation.Line
 import com.mapbox.mapboxsdk.plugins.annotation.LineOptions
 import com.mapbox.mapboxsdk.utils.ColorUtils
@@ -167,6 +170,20 @@ class PolylineImpl(private val map: GoogleMapImpl, id: String, options: GmsLineO
             lineOpacity = if (visible) 1f else 0f
         }
         map.lineManager?.let { update(it) }
+    }
+
+    override fun update(manager: AnnotationManager<*, Line, LineOptions, *, *, *>) {
+        synchronized(this) {
+            val id = annotation?.id
+            if (removed && id != null) {
+                map.lines.remove(id)
+            }
+            super.update(manager)
+            val annotation = annotation
+            if (annotation != null && id == null) {
+                map.lines[annotation.id] = this
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
Mirrors click listener functionality on circles to polylines and polygons.

I did not implement click listeners in lite mode maps because I think that is very rarely used, but requires a lot of code for us to compute the hitbox of the objects.

Tested against: https://github.com/googlemaps-samples/android-samples  
ref. https://gitlab.e.foundation/e/os/backlog/-/work_items/3533