### PR TITLE
DroidGuard: Fix native library conflict on concurrent handle requests

### DIFF
--- a/play-services-droidguard/src/main/kotlin/org/microg/gms/droidguard/HandleProxyFactory.kt
+++ b/play-services-droidguard/src/main/kotlin/org/microg/gms/droidguard/HandleProxyFactory.kt
@@ -89,7 +89,9 @@ open class HandleProxyFactory(private val context: Context) {
                 getCacheDir(vmKey).deleteRecursively()
                 throw ClassNotFoundException("APK signature verification failed")
             }
-            val loader = DexClassLoader(getTheApkFile(vmKey).absolutePath, getOptDir(vmKey).absolutePath, null, context.classLoader)
+            val loader = LOADER_MAP.getOrPut(vmKey) {
+                DexClassLoader(getTheApkFile(vmKey).absolutePath, getOptDir(vmKey).absolutePath, null, context.classLoader)
+            }
             val clazz = loader.loadClass(CLASS_NAME)
             CLASS_MAP[vmKey] = clazz
             return clazz
@@ -100,6 +102,7 @@ open class HandleProxyFactory(private val context: Context) {
         const val CLASS_NAME = "com.google.ccc.abuse.droidguard.DroidGuard"
         const val CACHE_FOLDER_NAME = "cache_dg"
         private val CLASS_MAP = hashMapOf<String, Class<*>>()
+        private val LOADER_MAP = hashMapOf<String, DexClassLoader>()
         val PROD_CERT_HASH = byteArrayOf(61, 122, 18, 35, 1, -102, -93, -99, -98, -96, -29, 67, 106, -73, -64, -119, 107, -5, 79, -74, 121, -12, -34, 95, -25, -62, 63, 50, 108, -113, -103, 74)
     }
 }


### PR DESCRIPTION
Cache the DexClassLoader instance statically so that concurrent DroidGuard handle requests for the same VM key reuse the same classloader instead of creating a new one that conflicts on the native library.

Without this fix, dual-SIM devices crash with UnsatisfiedLinkError when both SIMs trigger DroidGuard simultaneously (e.g. during RCS provisioning), because Android doesn't allow the same .so to be loaded by two different classloaders.

The loadClass() method does have synchronization and caching, but it doesn't quite cover this case.
classMap is per-instance, so a fresh HandleProxyFactory starts with an empty cache and won't find anything. 
weakClassMap is static but it's a WeakHashMap, so the entry can get garbage collected between calls if nothing else holds a strong reference to the class
When both miss, a new DexClassLoader gets created for the same APK, and that's when Android complains about the native lib already being loaded. So the synchronization prevents them from running truly in parallel inside loadClass(), but the second caller still ends up creating a new classloader because neither cache reliably had the entry.