### PR TITLE
[codex] maps: reuse selected module context in mapbox

### DIFF
--- a/play-services-maps/core/mapbox/src/main/java/com/google/android/gms/maps/internal/CreatorImpl.java
+++ b/play-services-maps/core/mapbox/src/main/java/com/google/android/gms/maps/internal/CreatorImpl.java
@@ -40,6 +40,15 @@ import org.microg.gms.maps.mapbox.model.BitmapDescriptorFactoryImpl;
 @Keep
 public class CreatorImpl extends ICreator.Stub {
     private static final String TAG = "GmsMapCreator";
+    private final Context mapsContext;
+
+    public CreatorImpl() {
+        this(null);
+    }
+
+    public CreatorImpl(Context mapsContext) {
+        this.mapsContext = mapsContext;
+    }
 
     @Override
     public void init(IObjectWrapper resources) {
@@ -48,12 +57,12 @@ public class CreatorImpl extends ICreator.Stub {
 
     @Override
     public IMapFragmentDelegate newMapFragmentDelegate(IObjectWrapper activity) {
-        return new MapFragmentImpl(ObjectWrapper.unwrapTyped(activity, Activity.class));
+        return new MapFragmentImpl(ObjectWrapper.unwrapTyped(activity, Activity.class), mapsContext);
     }
 
     @Override
     public IMapViewDelegate newMapViewDelegate(IObjectWrapper context, GoogleMapOptions options) {
-        return new MapViewImpl(ObjectWrapper.unwrapTyped(context, Context.class), options);
+        return new MapViewImpl(ObjectWrapper.unwrapTyped(context, Context.class), mapsContext, options);
     }
 
     @Override

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/AbstractGoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/AbstractGoogleMap.kt
@@ -15,9 +15,9 @@ import org.microg.gms.maps.mapbox.model.DefaultInfoWindowAdapter
 import org.microg.gms.maps.mapbox.model.InfoWindow
 import org.microg.gms.maps.mapbox.utils.MapContext
 
-abstract class AbstractGoogleMap(context: Context) : IGoogleMapDelegate.Stub() {
+abstract class AbstractGoogleMap(context: Context, mapsContext: Context?) : IGoogleMapDelegate.Stub() {
 
-    internal val mapContext = MapContext(context)
+    internal val mapContext = MapContext(context, mapsContext)
 
     val dpiFactor: Float
         get() = mapContext.resources.displayMetrics.densityDpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -77,7 +77,7 @@ fun runOnMainLooper(forceQueue: Boolean = false, method: () -> Unit) {
     }
 }
 
-class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractGoogleMap(context) {
+class GoogleMapImpl(context: Context, mapsContext: Context?, var options: GoogleMapOptions) : AbstractGoogleMap(context, mapsContext) {
 
     val view: FrameLayout
     var map: MapboxMap? = null

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/LiteGoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/LiteGoogleMap.kt
@@ -66,7 +66,7 @@ class MetaSnapshot(
     )
 }
 
-class LiteGoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractGoogleMap(context) {
+class LiteGoogleMapImpl(context: Context, mapsContext: Context?, var options: GoogleMapOptions) : AbstractGoogleMap(context, mapsContext) {
 
     internal val view: FrameLayout = FrameLayout(mapContext)
     val map: ImageView

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapFragment.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapFragment.kt
@@ -17,6 +17,7 @@
 package org.microg.gms.maps.mapbox
 
 import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.os.Parcel
 import android.util.Base64
@@ -30,7 +31,7 @@ import com.google.android.gms.maps.internal.IGoogleMapDelegate
 import com.google.android.gms.maps.internal.IMapFragmentDelegate
 import com.google.android.gms.maps.internal.IOnMapReadyCallback
 
-class MapFragmentImpl(private val activity: Activity) : IMapFragmentDelegate.Stub() {
+class MapFragmentImpl(private val activity: Activity, private val mapsContext: Context?) : IMapFragmentDelegate.Stub() {
 
     private var map: IGoogleMapDelegate? = null
     private var options: GoogleMapOptions? = null
@@ -54,9 +55,9 @@ class MapFragmentImpl(private val activity: Activity) : IMapFragmentDelegate.Stu
             options = GoogleMapOptions()
         }
         if (options?.liteMode == true) {
-            map = LiteGoogleMapImpl(activity, options ?: GoogleMapOptions())
+            map = LiteGoogleMapImpl(activity, mapsContext, options ?: GoogleMapOptions())
         } else {
-            map = GoogleMapImpl(activity, options ?: GoogleMapOptions())
+            map = GoogleMapImpl(activity, mapsContext, options ?: GoogleMapOptions())
         }
     }
 
@@ -67,9 +68,9 @@ class MapFragmentImpl(private val activity: Activity) : IMapFragmentDelegate.Stu
         Log.d(TAG, "onCreateView: ${options?.camera?.target}")
         if (map == null) {
             map = if (options?.liteMode == true) {
-                LiteGoogleMapImpl(activity, options ?: GoogleMapOptions())
+                LiteGoogleMapImpl(activity, mapsContext, options ?: GoogleMapOptions())
             } else {
-                GoogleMapImpl(activity, options ?: GoogleMapOptions())
+                GoogleMapImpl(activity, mapsContext, options ?: GoogleMapOptions())
             }
         }
         map!!.apply {

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapView.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/MapView.kt
@@ -27,7 +27,7 @@ import com.google.android.gms.maps.internal.IGoogleMapDelegate
 import com.google.android.gms.maps.internal.IMapViewDelegate
 import com.google.android.gms.maps.internal.IOnMapReadyCallback
 
-class MapViewImpl(private val context: Context, options: GoogleMapOptions?) : IMapViewDelegate.Stub() {
+class MapViewImpl(private val context: Context, private val mapsContext: Context?, options: GoogleMapOptions?) : IMapViewDelegate.Stub() {
 
     private val options: GoogleMapOptions = options ?: GoogleMapOptions()
     private var map: IGoogleMapDelegate? = null
@@ -35,9 +35,9 @@ class MapViewImpl(private val context: Context, options: GoogleMapOptions?) : IM
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate: ${options?.camera?.target}")
         map = if (options.liteMode) {
-            LiteGoogleMapImpl(context, options)
+            LiteGoogleMapImpl(context, mapsContext, options)
         } else {
-            GoogleMapImpl(context, options)
+            GoogleMapImpl(context, mapsContext, options)
         }.apply {
             this.onCreate(savedInstanceState)
         }

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MapContext.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MapContext.kt
@@ -24,7 +24,12 @@ import android.view.LayoutInflater
 import org.microg.gms.common.Constants
 import java.io.File
 
-class MapContext(private val context: Context) : ContextWrapper(context.createPackageContext(Constants.GMS_PACKAGE_NAME, Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY)) {
+class MapContext(private val context: Context, mapsContext: Context?) : ContextWrapper(
+    mapsContext ?: context.createPackageContext(
+        Constants.GMS_PACKAGE_NAME,
+        Context.CONTEXT_INCLUDE_CODE or Context.CONTEXT_IGNORE_SECURITY
+    )
+) {
     private var layoutInflater: LayoutInflater? = null
     private val appContext: Context
         get() = context.applicationContext ?: context

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MultiArchLoader.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/utils/MultiArchLoader.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.util.Log
 import com.mapbox.mapboxsdk.LibraryLoader
-import org.microg.gms.common.Constants
 import org.microg.gms.common.PackageUtils
 import java.io.*
 import java.util.zip.ZipFile
@@ -42,7 +41,7 @@ class MultiArchLoader(private val mapContext: Context, private val appContext: C
                 val cacheFileStamp = File("${appContext.cacheDir.absolutePath}/.gmscore/$path.stamp")
                 val cacheVersion = kotlin.runCatching { cacheFileStamp.readText() }.getOrNull()
                 // TODO: Use better version indicator
-                val mapVersion = PackageUtils.versionName(mapContext, Constants.GMS_PACKAGE_NAME)
+                val mapVersion = PackageUtils.versionName(mapContext, mapContext.applicationInfo.packageName)
                 val apkFile = File(mapContext.packageCodePath)
                 if (!cacheFile.exists() || cacheVersion == null || cacheVersion != mapVersion) {
                     val zipFile = ZipFile(apkFile)

--- a/play-services-maps/src/main/java/org/microg/gms/maps/MapsContextLoader.java
+++ b/play-services-maps/src/main/java/org/microg/gms/maps/MapsContextLoader.java
@@ -18,6 +18,8 @@ import com.google.android.gms.maps.internal.ICreator;
 import com.google.android.gms.maps.model.RuntimeRemoteException;
 import org.microg.gms.common.Constants;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class MapsContextLoader {
     private static final String TAG = "MapsContextLoader";
     private static final String DYNAMITE_MODULE_DEFAULT = "com.google.android.gms.maps_dynamite";
@@ -68,14 +70,20 @@ public class MapsContextLoader {
             try {
                 Context mapsContext = getMapsContext(context, preferredRenderer);
                 Class<?> clazz = mapsContext.getClassLoader().loadClass("com.google.android.gms.maps.internal.CreatorImpl");
-                creator = ICreator.Stub.asInterface((IBinder) clazz.newInstance());
+                try {
+                    creator = ICreator.Stub.asInterface((IBinder) clazz.getConstructor(Context.class).newInstance(mapsContext));
+                } catch (NoSuchMethodException e) {
+                    creator = ICreator.Stub.asInterface((IBinder) clazz.newInstance());
+                }
                 creator.initV2(ObjectWrapper.wrap(mapsContext.getResources()), Constants.GMS_VERSION_CODE);
             } catch (ClassNotFoundException e) {
                 throw new IllegalStateException("Unable to find dynamic class com.google.android.gms.maps.internal.CreatorImpl");
             } catch (IllegalAccessException e) {
-                throw new IllegalStateException("Unable to call the default constructor of com.google.android.gms.maps.internal.CreatorImpl");
+                throw new IllegalStateException("Unable to call a constructor of com.google.android.gms.maps.internal.CreatorImpl");
             } catch (InstantiationException e) {
                 throw new IllegalStateException("Unable to instantiate the dynamic class com.google.android.gms.maps.internal.CreatorImpl");
+            } catch (InvocationTargetException e) {
+                throw new IllegalStateException("Unable to invoke the constructor of com.google.android.gms.maps.internal.CreatorImpl", e);
             } catch (RemoteException e) {
                 throw new RuntimeRemoteException(e);
             }


### PR DESCRIPTION
## Summary
- pass the selected maps/module context from `MapsContextLoader` into the mapbox creator and map delegates
- make mapbox `MapContext` reuse that provided maps context instead of reconstructing one from a package string
- keep compatibility with older loaders by retaining a no-arg `CreatorImpl` constructor and falling back to legacy `createPackageContext(...)` behavior when no maps context is supplied
- resolve `MultiArchLoader` package/version metadata from the wrapped maps context instead of a hardcoded GmsCore package name

## Why
Mapbox can observe the embedding app context, so `context.getPackageName()` is not a reliable way to reconstruct the GmsCore-side maps context. `MapsContextLoader` already selects the correct maps/module context; this change reuses that context directly when available.