### PR TITLE
Auth: Fix AskPermission consent flow

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/AskPermissionActivity.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AskPermissionActivity.java
@@ -92,7 +92,7 @@ public class AskPermissionActivity extends AccountAuthenticatorActivity {
                     try {
                         consentData = ConsentData.ADAPTER.decode(intent.getByteArrayExtra(EXTRA_CONSENT_DATA));
                     } catch (Exception e) {
-                        // Ignore
+                        Log.w(TAG, "ConsentData decode failed", e);
                     }
                 }
             }
@@ -169,24 +169,34 @@ public class AskPermissionActivity extends AccountAuthenticatorActivity {
         findViewById(R.id.progress_bar).setVisibility(VISIBLE);
         findViewById(R.id.no_progress_bar).setVisibility(GONE);
         new Thread(() -> {
+            Bundle result = null;
             try {
                 AuthResponse response = authManager.requestAuthWithBackgroundResolution(data.fromAccountManager);
-                Bundle result = new Bundle();
+                result = new Bundle();
                 result.putString(KEY_AUTHTOKEN, response.auth);
                 result.putString(KEY_ACCOUNT_NAME, data.accountName);
                 result.putString(KEY_ACCOUNT_TYPE, data.accountType);
                 result.putString(KEY_ANDROID_PACKAGE_NAME, data.packageName);
                 result.putBoolean(AccountManager.KEY_BOOLEAN_RESULT, true);
-                setAccountAuthenticatorResult(result);
             } catch (IOException e) {
                 Log.w(TAG, e);
             }
-            finish();
+            final Bundle finalResult = result;
+            runOnUiThread(() -> {
+                Intent resultIntent = new Intent();
+                if (finalResult != null) {
+                    setAccountAuthenticatorResult(finalResult);
+                    resultIntent.putExtras(finalResult);
+                }
+                setResult(RESULT_OK, resultIntent);
+                finish();
+            });
         }).start();
     }
 
     public void onDeny() {
         authManager.setPermitted(false);
+        setResult(RESULT_CANCELED);
         finish();
     }
 
@@ -204,12 +214,9 @@ public class AskPermissionActivity extends AccountAuthenticatorActivity {
     }
 
     private String getScopeLabel(String scope) {
-        if (data.consentData != null) {
-            for (ConsentData.ScopeDetails scopeDetails : data.consentData.scopes) {
-                if (scope.equals(scopeDetails.id)) {
-                    return scopeDetails.title;
-                }
-            }
+        ConsentData.ScopeDetails matched = findScopeDetails(scope);
+        if (matched != null && matched.title != null) {
+            return matched.title;
         }
         String labelResourceId = "permission_scope_";
         String escapedScope = scope.replace("/", "_").replace("-", "_");
@@ -226,14 +233,29 @@ public class AskPermissionActivity extends AccountAuthenticatorActivity {
     }
 
     private String getScopeDescription(String scope) {
-        if (data.consentData != null) {
-            for (ConsentData.ScopeDetails scopeDetails : data.consentData.scopes) {
-                if (scope.equals(scopeDetails.id)) {
-                    return scopeDetails.description;
-                }
-            }
+        ConsentData.ScopeDetails matched = findScopeDetails(scope);
+        return matched != null ? matched.description : null;
+    }
+
+    private ConsentData.ScopeDetails findScopeDetails(String scope) {
+        if (data.consentData == null || scope == null) return null;
+        String aliasFull = canonicalOidcScope(scope);
+        for (ConsentData.ScopeDetails sd : data.consentData.scopes) {
+            if (scope.equals(sd.id)) return sd;
+            if (aliasFull != null && aliasFull.equals(sd.id)) return sd;
         }
         return null;
+    }
+
+    private static String canonicalOidcScope(String scope) {
+        switch (scope) {
+            case "email":
+                return "https://www.googleapis.com/auth/userinfo.email";
+            case "profile":
+                return "https://www.googleapis.com/auth/userinfo.profile";
+            default:
+                return null;
+        }
     }
 
     private String getServiceLabel(String service) {

--- a/play-services-core/src/main/res/layout/ask_permission.xml
+++ b/play-services-core/src/main/res/layout/ask_permission.xml
@@ -24,7 +24,7 @@
         android:gravity="center_horizontal"
         android:paddingTop="10dp"
         android:text="@string/account_manager_title"
-        android:textColor="?attr/colorPrimary"
+        android:textColor="?android:attr/textColorPrimary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
@@ -88,7 +88,7 @@
         android:padding="15dp"
         android:gravity="center_horizontal"
         android:textSize="18sp"
-        android:textColor="?attr/colorAccent"
+        android:textColor="?android:attr/textColorPrimary"
         android:text="@string/ask_scope_permission_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
@@ -102,7 +102,7 @@
 
     <TextView
         android:padding="10dp"
-        android:textColor="?attr/colorPrimary"
+        android:textColor="?android:attr/textColorSecondary"
         android:textSize="12sp"
         android:text="@string/ask_permission_tos"
         android:layout_width="match_parent"

--- a/play-services-core/src/main/res/layout/ask_permission_list_entry.xml
+++ b/play-services-core/src/main/res/layout/ask_permission_list_entry.xml
@@ -34,12 +34,14 @@
 
         <TextView
             android:textSize="16sp"
+            android:textColor="?android:attr/textColorPrimary"
             android:id="@android:id/text1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
         <TextView
             android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
             android:visibility="gone"
             android:id="@android:id/text2"
             android:layout_width="wrap_content"


### PR DESCRIPTION
After clicking Allow, callers using startActivityForResult got RESULT_CANCELED and kept retrying getToken in a tight loop                                                                      
 (e.g. Wongnai sign-in stuck looping). 
onAllow/onDeny now call setResult on the UI thread before finish.                    

Also fixes short OIDC scopes (email, profile) showing as "unknown" instead of the ConsentData title, and the consent screen text being unreadable in dark mode.
