### PR TITLE
Fido: Fix authentication with websites looking at user handle

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
@@ -515,9 +515,9 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                 clientData,
                 response.authData,
                 response.signature,
-                null
+                response.user?.id
             ),
-            null
+            response.user
         )
     }
 


### PR DESCRIPTION
By returning the user handle when known

Testing on Discourse (eg. https://discuss.privacyguides.net/)