### PR TITLE
Fido: Disable screen sign-in without local registration

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivity.kt
@@ -170,6 +170,10 @@ class AuthenticatorActivity : AppCompatActivity(), TransportHandlerCallback {
                 this.privilegedCallerName = callerName.takeIf { options is BrowserRequestOptions }
                 this.requiresPrivilege = requiresPrivilege
                 this.supportedTransports = transportHandlers.filter { it.isSupported }.map { it.transport }.toSet()
+                // To sign-in with screen-lock, there must be a local user.
+                if (options.type == RequestOptionsType.SIGN && noLocalUserForSignInstantBlock) {
+                    this.implementedTransports = this.implementedTransports.filter { it != SCREEN_LOCK }.toSet()
+                }
             }.arguments
             val next = if (!requiresPrivilege) {
                 val knownRegistrationTransports = mutableSetOf<Transport>()

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivityFragmentData.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/ui/AuthenticatorActivityFragmentData.kt
@@ -22,8 +22,10 @@ class AuthenticatorActivityFragmentData(val arguments: Bundle = Bundle()) {
         get() = arguments.getStringArrayList(KEY_SUPPORTED_TRANSPORTS)?.map { Transport.valueOf(it) }?.toSet().orEmpty()
         set(value) = arguments.putStringArrayList(KEY_SUPPORTED_TRANSPORTS, ArrayList(value.map { it.name }))
 
-    val implementedTransports: Set<Transport>
-        get() = AuthenticatorActivity.IMPLEMENTED_TRANSPORTS
+    var implementedTransports: Set<Transport>
+        get() = arguments.getStringArrayList(KEY_IMPLEMENTED_TRANSPORTS)?.map { Transport.valueOf(it) }?.toSet()
+            ?: AuthenticatorActivity.IMPLEMENTED_TRANSPORTS
+        set(value) = arguments.putStringArrayList(KEY_IMPLEMENTED_TRANSPORTS, ArrayList(value.map { it.name }))
 
     var privilegedCallerName: String?
         get() = arguments.getString(KEY_PRIVILEGED_CALLER_NAME)
@@ -37,6 +39,7 @@ class AuthenticatorActivityFragmentData(val arguments: Bundle = Bundle()) {
         const val KEY_APP_NAME = "appName"
         const val KEY_IS_FIRST = "isFirst"
         const val KEY_SUPPORTED_TRANSPORTS = "supportedTransports"
+        const val KEY_IMPLEMENTED_TRANSPORTS = "implementedTransports"
         const val KEY_REQUIRES_PRIVILEGE = "requiresPrivilege"
         const val KEY_PRIVILEGED_CALLER_NAME = "privilegedCallerName"
     }


### PR DESCRIPTION
Avoid a crash, when the user clicks on screen sign-in and there isn't any local registration

For that, we prevent the user to select the screen sign-in entry in the transport selection view by excluding SCREEN_LOCK from the implemented transports. When a transport isn't implemented, it is grayed out and disabled.

That way the user see there could be an option to login with SCREEN_LOCK but is currently not available