### PR TITLE
Fido: Fix PIN requirement for USB plugged after navigating to USB view

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -155,7 +155,7 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
                 throw e
             } catch (e: WrongPinException) {
                 throw e
-            }  catch (e: Exception) {
+            } catch (e: Exception) {
                 Log.w(TAG, e)
             }
         }
@@ -166,6 +166,10 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
             try {
                 return handle(options, callerPackage, device, iface, pinRequested, pin)
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: MissingPinException) {
+                throw e
+            } catch (e: WrongPinException) {
                 throw e
             } catch (e: Exception) {
                 Log.w(TAG, e)

--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/usb/UsbTransportHandler.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import org.microg.gms.fido.core.*
 import org.microg.gms.fido.core.transport.AuthenticatorResponseWithUser
+import org.microg.gms.fido.core.transport.Ctap2StatusException
 import org.microg.gms.fido.core.transport.Transport
 import org.microg.gms.fido.core.transport.TransportHandler
 import org.microg.gms.fido.core.transport.TransportHandlerCallback
@@ -155,6 +156,8 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
                 throw e
             } catch (e: WrongPinException) {
                 throw e
+            } catch (e: Ctap2StatusException) {
+                throw e
             } catch (e: Exception) {
                 Log.w(TAG, e)
             }
@@ -170,6 +173,8 @@ class UsbTransportHandler(private val context: Context, callback: TransportHandl
             } catch (e: MissingPinException) {
                 throw e
             } catch (e: WrongPinException) {
+                throw e
+            } catch (e: Ctap2StatusException) {
                 throw e
             } catch (e: Exception) {
                 Log.w(TAG, e)


### PR DESCRIPTION
When the USB key is plugged after navigating to the USB transport view, and the authenticator requires a PIN, it was simply logged, as caught with other exceptions.

The AuthenticatorActivity shows the PIN entry view only if it catch a MissingPinException, which wasn't possible in this case.

The user had to navigate back to the transport selection, then to the USB entry to finally be able to login

Fix #2888