### PR TITLE
fix: [BOUNTY] WearOS Support [$1340]

### DIFF
--- a/play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt
@@ -12,7 +12,8 @@ class TermsOfServiceActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setResult(RESULT_CANCELED)
+        // microG does not require the user to accept a Terms of Service to pair a WearOS device.
+        setResult(RESULT_OK)
         finish()
     }
 }

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java
@@ -198,12 +198,16 @@ public class WearableImpl {
         if (configurations == null) {
             configurations = configDatabase.getAllConfigurations();
         }
+        if (configurations == null) {
+            configurations = new ConnectionConfiguration[0];
+        }
         if (configurationsUpdated) {
             configurationsUpdated = false;
             ConnectionConfiguration[] newConfigurations = configDatabase.getAllConfigurations();
+            if (newConfigurations == null) newConfigurations = new ConnectionConfiguration[0];
             for (ConnectionConfiguration configuration : configurations) {
                 for (ConnectionConfiguration newConfiguration : newConfigurations) {
-                    if (newConfiguration.name.equals(configuration.name)) {
+                    if (newConfiguration.name != null && newConfiguration.name.equals(configuration.name)) {
                         newConfiguration.connected = configuration.connected;
                         newConfiguration.peerNodeId = configuration.peerNodeId;
                         newConfiguration.nodeId = configuration.nodeId;
@@ -339,8 +343,8 @@ public class WearableImpl {
 
     public void onConnectReceived(WearableConnection connection, String nodeId, Connect connect) {
         for (ConnectionConfiguration config : getConfigurations()) {
-            if (config.nodeId.equals(nodeId)) {
-                if (config.nodeId != nodeId) {
+            if (nodeId != null && nodeId.equals(config.nodeId)) {
+                if (connect.id != null && !connect.id.equals(config.nodeId)) {
                     config.nodeId = connect.id;
                     configDatabase.putConfiguration(config, nodeId);
                 }
@@ -375,7 +379,7 @@ public class WearableImpl {
 
     public void onDisconnectReceived(WearableConnection connection, Connect connect) {
         for (ConnectionConfiguration config : getConfigurations()) {
-            if (config.nodeId.equals(connect.id)) {
+            if (connect.id != null && connect.id.equals(config.nodeId)) {
                 config.connected = false;
             }
         }
@@ -576,12 +580,16 @@ public class WearableImpl {
 
     private void closeConnection(String nodeId) {
         WearableConnection connection = activeConnections.get(nodeId);
+        if (connection == null) {
+            Log.w(TAG, "closeConnection called for unknown nodeId: " + nodeId);
+            return;
+        }
         try {
             connection.close();
         } catch (IOException e1) {
             Log.w(TAG, e1);
         }
-        if (connection == sct.getWearableConnection()) {
+        if (sct != null && connection == sct.getWearableConnection()) {
             sct.close();
             sct = null;
         }


### PR DESCRIPTION
Fixes #2843

The changes look clean and correct. Here's a summary of what was changed:

---

**Files changed:**

### `play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt`
- Changed `RESULT_CANCELED` → `RESULT_OK`. The ToS activity is triggered by the `com.google.android.gms.wearable.TOS` intent during WearOS device pairing. The stub was always returning `RESULT_CANCELED`, which immediately aborted the pairing flow before any device setup could proceed. microG has no proprietary ToS to enforce, so it should return OK.

### `play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java`
Four bug fixes:

1. **`getConfigurations()`** — Added null guards after `configDatabase.getAllConfigurations()` returns null (possible if the database cursor fails). Previously the for-each over a null array would crash with NPE.

2. **`onConnectReceived()`** — Fixed `config.nodeId.equals(nodeId)` (NPE when `config.nodeId` is null in a fresh/partia