### PR TITLE
Auth: add package override support to getTokenWithAccount (#3278)

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -121,9 +121,6 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
             packageName = extras.getString(KEY_CLIENT_PACKAGE_NAME);
         packageName = PackageUtils.getAndCheckCallingPackage(context, packageName, extras.getInt(KEY_CALLER_UID, 0), extras.getInt(KEY_CALLER_PID, 0));
         boolean notify = extras.getBoolean(KEY_HANDLE_NOTIFICATION, false);
-        String effectivePackageName = packageName;
-        boolean isOverrideAllowed = false;
-        CertData overrideCert = null;
 
         scope = Objects.equals(AuthConstants.SCOPE_OAUTH2, scope) ? AuthConstants.SCOPE_EM_OP_PRO : scope;
 
@@ -138,45 +135,80 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
          */
         scope = scope.replace("https://www.googleapis.com/auth/identity.plus.page.impersonation ", "");
 
-        if (extras.containsKey(AccountAuthenticator.KEY_OVERRIDE_PACKAGE) || extras.containsKey(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE)) {
-            String overridePackage = extras.getString(AccountAuthenticator.KEY_OVERRIDE_PACKAGE, packageName);
-            CertData requestingCert = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName).get(0);
-            byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
-            if (overrideCertificateBytes != null) {
-                overrideCert = new CertData(overrideCertificateBytes);
-            } else {
-                overrideCert = requestingCert;
-            }
-            if (packageName.equals(context.getPackageName())) {
-                isOverrideAllowed = true;
-            } else {
-                String requestingDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(requestingCert, "SHA-256"), "");
-                String overrideCertificateDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-256"), "");
-                String overrideUserDataKey = "override." + packageName + ":" + requestingDigestString + ":" + overridePackage + ":" + overrideCertificateDigestString;
-                String hasOverride = AccountManager.get(context).getUserData(account, overrideUserDataKey);
-                isOverrideAllowed = "1".equals(hasOverride);
-            }
-            if (isOverrideAllowed) {
-                effectivePackageName = overridePackage;
-                Log.d(TAG, "getTokenWithAccount: using package override " + packageName + " -> " + effectivePackageName);
-            } else {
-                Bundle result = new Bundle();
-                result.putString(KEY_ERROR, "NeedPermission");
-                Intent i = new Intent(context, AskPackageOverrideActivity.class);
-                i.putExtras(extras);
-                i.putExtra(KEY_ANDROID_PACKAGE_NAME, packageName);
-                i.putExtra(KEY_ACCOUNT_TYPE, account.type);
-                i.putExtra(KEY_ACCOUNT_NAME, account.name);
-                i.putExtra(AccountAuthenticator.KEY_OVERRIDE_PACKAGE, overridePackage);
-                i.putExtra(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE, overrideCert.getBytes());
-                result.putParcelable(KEY_USER_RECOVERY_INTENT, i);
-                return result;
+        // Issue #4: Only check KEY_OVERRIDE_PACKAGE (not OR with certificate key)
+        String effectivePackageName = packageName;
+        if (extras.containsKey(AccountAuthenticator.KEY_OVERRIDE_PACKAGE)) {
+            // Issue #1: Don't use packageName as fallback default
+            String overridePackage = extras.getString(AccountAuthenticator.KEY_OVERRIDE_PACKAGE);
+            if (overridePackage != null && !overridePackage.isEmpty()) {
+                // Issue #2: Safely get requesting cert with bounds check
+                List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
+                if (certs.isEmpty()) {
+                    Log.w(TAG, "getTokenWithAccount: no certificates found for requesting package " + packageName);
+                    Bundle result = new Bundle();
+                    result.putString(KEY_ERROR, "NeedPermission");
+                    return result;
+                }
+                CertData requestingCert = certs.get(0);
+                
+                // Get override cert from extras or use requesting cert
+                byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
+                CertData overrideCert = (overrideCertificateBytes != null) 
+                    ? new CertData(overrideCertificateBytes) 
+                    : requestingCert;
+                
+                boolean isOverrideAllowed;
+                if (packageName.equals(context.getPackageName())) {
+                    isOverrideAllowed = true;
+                } else {
+                    String requestingDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(requestingCert, "SHA-256"), "");
+                    String overrideCertificateDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-256"), "");
+                    String overrideUserDataKey = "override." + packageName + ":" + requestingDigestString + ":" + overridePackage + ":" + overrideCertificateDigestString;
+                    String hasOverride = AccountManager.get(context).getUserData(account, overrideUserDataKey);
+                    isOverrideAllowed = "1".equals(hasOverride);
+                }
+                
+                if (isOverrideAllowed) {
+                    effectivePackageName = overridePackage;
+                    Log.d(TAG, "getTokenWithAccount: using package override " + packageName + " -> " + effectivePackageName);
+                    // Will set signature below after AuthManager creation
+                } else {
+                    // Issue #3: Add KEY_ACCOUNT_NAME and KEY_ACCOUNT_TYPE to result
+                    Bundle result = new Bundle();
+                    result.putString(KEY_ERROR, "NeedPermission");
+                    result.putString(KEY_ACCOUNT_NAME, account.name);
+                    result.putString(KEY_ACCOUNT_TYPE, account.type);
+                    
+                    // Issue #6: Only pass necessary keys to AskPackageOverrideActivity, not full extras
+                    Intent i = new Intent(context, AskPackageOverrideActivity.class);
+                    i.putExtra(KEY_ANDROID_PACKAGE_NAME, packageName);
+                    i.putExtra(KEY_ACCOUNT_TYPE, account.type);
+                    i.putExtra(KEY_ACCOUNT_NAME, account.name);
+                    i.putExtra(AccountAuthenticator.KEY_OVERRIDE_PACKAGE, overridePackage);
+                    i.putExtra(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE, overrideCert.getBytes());
+                    result.putParcelable(KEY_USER_RECOVERY_INTENT, i);
+                    return result;
+                }
             }
         }
 
         AuthManager authManager = new AuthManager(context, account.name, effectivePackageName, scope);
-        if (isOverrideAllowed && overrideCert != null) {
-            authManager.setPackageSignature(PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA1"), ""));
+        // Set override signature if override was approved
+        if (!effectivePackageName.equals(packageName)) {
+            // Override is in effect; set signature from override cert
+            try {
+                List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
+                if (!certs.isEmpty()) {
+                    byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
+                    CertData overrideCert = (overrideCertificateBytes != null) 
+                        ? new CertData(overrideCertificateBytes) 
+                        : certs.get(0);
+                    // Issue #5: Use "SHA-1" (with hyphen) for consistency with Java MessageDigest
+                    authManager.setPackageSignature(PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-1"), ""));
+                }
+            } catch (Exception e) {
+                Log.w(TAG, "getTokenWithAccount: error setting override signature", e);
+            }
         }
         if (extras.containsKey(KEY_DELEGATION_TYPE) && extras.getInt(KEY_DELEGATION_TYPE) != 0 ) {
             authManager.setDelegation(extras.getInt(KEY_DELEGATION_TYPE), extras.getString("delegatee_user_id"));

--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -135,13 +135,10 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
          */
         scope = scope.replace("https://www.googleapis.com/auth/identity.plus.page.impersonation ", "");
 
-        // Issue #4: Only check KEY_OVERRIDE_PACKAGE (not OR with certificate key)
         String effectivePackageName = packageName;
         if (extras.containsKey(AccountAuthenticator.KEY_OVERRIDE_PACKAGE)) {
-            // Issue #1: Don't use packageName as fallback default
             String overridePackage = extras.getString(AccountAuthenticator.KEY_OVERRIDE_PACKAGE);
             if (overridePackage != null && !overridePackage.isEmpty()) {
-                // Issue #2: Safely get requesting cert with bounds check
                 List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
                 if (certs.isEmpty()) {
                     Log.w(TAG, "getTokenWithAccount: no certificates found for requesting package " + packageName);
@@ -151,7 +148,6 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                 }
                 CertData requestingCert = certs.get(0);
                 
-                // Get override cert from extras or use requesting cert
                 byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
                 CertData overrideCert = (overrideCertificateBytes != null) 
                     ? new CertData(overrideCertificateBytes) 
@@ -171,15 +167,12 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                 if (isOverrideAllowed) {
                     effectivePackageName = overridePackage;
                     Log.d(TAG, "getTokenWithAccount: using package override " + packageName + " -> " + effectivePackageName);
-                    // Will set signature below after AuthManager creation
                 } else {
-                    // Issue #3: Add KEY_ACCOUNT_NAME and KEY_ACCOUNT_TYPE to result
                     Bundle result = new Bundle();
                     result.putString(KEY_ERROR, "NeedPermission");
                     result.putString(KEY_ACCOUNT_NAME, account.name);
                     result.putString(KEY_ACCOUNT_TYPE, account.type);
                     
-                    // Issue #6: Only pass necessary keys to AskPackageOverrideActivity, not full extras
                     Intent i = new Intent(context, AskPackageOverrideActivity.class);
                     i.putExtra(KEY_ANDROID_PACKAGE_NAME, packageName);
                     i.putExtra(KEY_ACCOUNT_TYPE, account.type);
@@ -193,22 +186,18 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
         }
 
         AuthManager authManager = new AuthManager(context, account.name, effectivePackageName, scope);
-        // Set override signature if override was approved
+
         if (!effectivePackageName.equals(packageName)) {
-            // Override is in effect; set signature from override cert
             try {
                 byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
                 CertData overrideCert;
                 if (overrideCertificateBytes != null) {
                     overrideCert = new CertData(overrideCertificateBytes);
                 } else {
-                    // Explicitly null-safe: getCertificates may return empty list
                     List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
                     overrideCert = certs.isEmpty() ? null : certs.get(0);
                 }
-                // Only set signature if overrideCert is non-null
                 if (overrideCert != null) {
-                    // Use "SHA-1" (with hyphen) for consistency with Java MessageDigest standard
                     authManager.setPackageSignature(PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-1"), ""));
                 }
             } catch (Exception e) {

--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -34,6 +34,7 @@ import androidx.core.app.PendingIntentCompat;
 
 import com.google.android.auth.IAuthManagerService;
 import com.google.android.gms.R;
+import com.google.android.gms.common.internal.CertData;
 import com.google.android.gms.auth.AccountChangeEventsRequest;
 import com.google.android.gms.auth.AccountChangeEventsResponse;
 import com.google.android.gms.auth.GetHubTokenInternalResponse;
@@ -42,8 +43,10 @@ import com.google.android.gms.auth.HasCapabilitiesRequest;
 import com.google.android.gms.auth.TokenData;
 import com.google.android.gms.common.api.Scope;
 
+import org.microg.gms.auth.loginservice.AccountAuthenticator;
 import org.microg.gms.common.GooglePackagePermission;
 import org.microg.gms.common.PackageUtils;
+import org.microg.gms.utils.PackageManagerUtilsKt;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -118,6 +121,9 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
             packageName = extras.getString(KEY_CLIENT_PACKAGE_NAME);
         packageName = PackageUtils.getAndCheckCallingPackage(context, packageName, extras.getInt(KEY_CALLER_UID, 0), extras.getInt(KEY_CALLER_PID, 0));
         boolean notify = extras.getBoolean(KEY_HANDLE_NOTIFICATION, false);
+        String effectivePackageName = packageName;
+        boolean isOverrideAllowed = false;
+        CertData overrideCert = null;
 
         scope = Objects.equals(AuthConstants.SCOPE_OAUTH2, scope) ? AuthConstants.SCOPE_EM_OP_PRO : scope;
 
@@ -132,7 +138,46 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
          */
         scope = scope.replace("https://www.googleapis.com/auth/identity.plus.page.impersonation ", "");
 
-        AuthManager authManager = new AuthManager(context, account.name, packageName, scope);
+        if (extras.containsKey(AccountAuthenticator.KEY_OVERRIDE_PACKAGE) || extras.containsKey(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE)) {
+            String overridePackage = extras.getString(AccountAuthenticator.KEY_OVERRIDE_PACKAGE, packageName);
+            CertData requestingCert = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName).get(0);
+            byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
+            if (overrideCertificateBytes != null) {
+                overrideCert = new CertData(overrideCertificateBytes);
+            } else {
+                overrideCert = requestingCert;
+            }
+            if (packageName.equals(context.getPackageName())) {
+                isOverrideAllowed = true;
+            } else {
+                String requestingDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(requestingCert, "SHA-256"), "");
+                String overrideCertificateDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-256"), "");
+                String overrideUserDataKey = "override." + packageName + ":" + requestingDigestString + ":" + overridePackage + ":" + overrideCertificateDigestString;
+                String hasOverride = AccountManager.get(context).getUserData(account, overrideUserDataKey);
+                isOverrideAllowed = "1".equals(hasOverride);
+            }
+            if (isOverrideAllowed) {
+                effectivePackageName = overridePackage;
+                Log.d(TAG, "getTokenWithAccount: using package override " + packageName + " -> " + effectivePackageName);
+            } else {
+                Bundle result = new Bundle();
+                result.putString(KEY_ERROR, "NeedPermission");
+                Intent i = new Intent(context, AskPackageOverrideActivity.class);
+                i.putExtras(extras);
+                i.putExtra(KEY_ANDROID_PACKAGE_NAME, packageName);
+                i.putExtra(KEY_ACCOUNT_TYPE, account.type);
+                i.putExtra(KEY_ACCOUNT_NAME, account.name);
+                i.putExtra(AccountAuthenticator.KEY_OVERRIDE_PACKAGE, overridePackage);
+                i.putExtra(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE, overrideCert.getBytes());
+                result.putParcelable(KEY_USER_RECOVERY_INTENT, i);
+                return result;
+            }
+        }
+
+        AuthManager authManager = new AuthManager(context, account.name, effectivePackageName, scope);
+        if (isOverrideAllowed && overrideCert != null) {
+            authManager.setPackageSignature(PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA1"), ""));
+        }
         if (extras.containsKey(KEY_DELEGATION_TYPE) && extras.getInt(KEY_DELEGATION_TYPE) != 0 ) {
             authManager.setDelegation(extras.getInt(KEY_DELEGATION_TYPE), extras.getString("delegatee_user_id"));
         }

--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -197,13 +197,18 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
         if (!effectivePackageName.equals(packageName)) {
             // Override is in effect; set signature from override cert
             try {
-                List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
-                if (!certs.isEmpty()) {
-                    byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
-                    CertData overrideCert = (overrideCertificateBytes != null) 
-                        ? new CertData(overrideCertificateBytes) 
-                        : certs.get(0);
-                    // Issue #5: Use "SHA-1" (with hyphen) for consistency with Java MessageDigest
+                byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
+                CertData overrideCert;
+                if (overrideCertificateBytes != null) {
+                    overrideCert = new CertData(overrideCertificateBytes);
+                } else {
+                    // Explicitly null-safe: getCertificates may return empty list
+                    List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
+                    overrideCert = certs.isEmpty() ? null : certs.get(0);
+                }
+                // Only set signature if overrideCert is non-null
+                if (overrideCert != null) {
+                    // Use "SHA-1" (with hyphen) for consistency with Java MessageDigest standard
                     authManager.setPackageSignature(PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-1"), ""));
                 }
             } catch (Exception e) {

--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -80,6 +80,14 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
     public static final String KEY_ERROR = "Error";
     public static final String KEY_USER_RECOVERY_INTENT = "userRecoveryIntent";
 
+    // Error value constants — extracted to avoid magic strings and typos
+    private static final String ERROR_NEED_PERMISSION = "NeedPermission";
+    private static final String ERROR_NETWORK_ERROR = "NetworkError";
+    private static final String ERROR_OK = "OK";
+
+    // The value stored in account userData when a package override has been granted
+    private static final String OVERRIDE_ALLOWED_VALUE = "1";
+
     private final Context context;
 
     public AuthManagerServiceImpl(Context context) {
@@ -143,16 +151,22 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                 if (certs.isEmpty()) {
                     Log.w(TAG, "getTokenWithAccount: no certificates found for requesting package " + packageName);
                     Bundle result = new Bundle();
-                    result.putString(KEY_ERROR, "NeedPermission");
+                    result.putString(KEY_ERROR, ERROR_NEED_PERMISSION);
                     return result;
                 }
+                // Use certs.get(0) — the oldest (leaf) signing certificate — as the stable identity
+                // for the requesting package. With APK Signature Scheme v3 key rotation, newer
+                // certificates may be present but the original cert is what was recorded when the
+                // override permission was granted (stored in account userData using this digest),
+                // so we must use the same cert to reproduce the matching key. This is consistent
+                // with how AccountAuthenticator.getAuthToken resolves the requesting certificate.
                 CertData requestingCert = certs.get(0);
-                
+
                 byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
-                CertData overrideCert = (overrideCertificateBytes != null) 
-                    ? new CertData(overrideCertificateBytes) 
+                CertData overrideCert = (overrideCertificateBytes != null)
+                    ? new CertData(overrideCertificateBytes)
                     : requestingCert;
-                
+
                 boolean isOverrideAllowed;
                 if (packageName.equals(context.getPackageName())) {
                     isOverrideAllowed = true;
@@ -161,18 +175,18 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                     String overrideCertificateDigestString = PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-256"), "");
                     String overrideUserDataKey = "override." + packageName + ":" + requestingDigestString + ":" + overridePackage + ":" + overrideCertificateDigestString;
                     String hasOverride = AccountManager.get(context).getUserData(account, overrideUserDataKey);
-                    isOverrideAllowed = "1".equals(hasOverride);
+                    isOverrideAllowed = OVERRIDE_ALLOWED_VALUE.equals(hasOverride);
                 }
-                
+
                 if (isOverrideAllowed) {
                     effectivePackageName = overridePackage;
                     Log.d(TAG, "getTokenWithAccount: using package override " + packageName + " -> " + effectivePackageName);
                 } else {
                     Bundle result = new Bundle();
-                    result.putString(KEY_ERROR, "NeedPermission");
+                    result.putString(KEY_ERROR, ERROR_NEED_PERMISSION);
                     result.putString(KEY_ACCOUNT_NAME, account.name);
                     result.putString(KEY_ACCOUNT_TYPE, account.type);
-                    
+
                     Intent i = new Intent(context, AskPackageOverrideActivity.class);
                     i.putExtra(KEY_ANDROID_PACKAGE_NAME, packageName);
                     i.putExtra(KEY_ACCOUNT_TYPE, account.type);
@@ -188,31 +202,35 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
         AuthManager authManager = new AuthManager(context, account.name, effectivePackageName, scope);
 
         if (!effectivePackageName.equals(packageName)) {
+            // SHA-1 is used here intentionally: Google's Auth servers require the package
+            // signature in SHA-1 hex form for legacy compatibility. This is not used for
+            // security decisions — the authorization check above uses SHA-256.
             try {
                 byte[] overrideCertificateBytes = extras.getByteArray(AccountAuthenticator.KEY_OVERRIDE_CERTIFICATE);
                 CertData overrideCert;
                 if (overrideCertificateBytes != null) {
                     overrideCert = new CertData(overrideCertificateBytes);
                 } else {
+                    // See comment above about certs.get(0) and APK Signature Scheme v3
                     List<CertData> certs = PackageManagerUtilsKt.getCertificates(context.getPackageManager(), packageName);
                     overrideCert = certs.isEmpty() ? null : certs.get(0);
                 }
                 if (overrideCert != null) {
                     authManager.setPackageSignature(PackageManagerUtilsKt.toHexString(PackageManagerUtilsKt.digest(overrideCert, "SHA-1"), ""));
                 }
-            } catch (Exception e) {
-                Log.w(TAG, "getTokenWithAccount: error setting override signature", e);
+            } catch (java.security.NoSuchAlgorithmException e) {
+                Log.w(TAG, "getTokenWithAccount: unsupported digest algorithm when setting override signature", e);
             }
         }
-        if (extras.containsKey(KEY_DELEGATION_TYPE) && extras.getInt(KEY_DELEGATION_TYPE) != 0 ) {
-            authManager.setDelegation(extras.getInt(KEY_DELEGATION_TYPE), extras.getString("delegatee_user_id"));
+        if (extras.containsKey(KEY_DELEGATION_TYPE) && extras.getInt(KEY_DELEGATION_TYPE) != 0) {
+            authManager.setDelegation(extras.getInt(KEY_DELEGATION_TYPE), extras.getString(KEY_DELEGATEE_USER_ID));
         }
         authManager.setOauth2Foreground(notify ? "0" : "1");
         Bundle result = new Bundle();
         result.putString(KEY_ACCOUNT_NAME, account.name);
         result.putString(KEY_ACCOUNT_TYPE, authManager.getAccountType());
         if (!authManager.accountExists()) {
-            result.putString(KEY_ERROR, "NetworkError");
+            result.putString(KEY_ERROR, ERROR_NETWORK_ERROR);
             return result;
         }
         try {
@@ -224,9 +242,9 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                 Bundle details = new Bundle();
                 details.putParcelable("TokenData", new TokenData(res.auth, res.expiry, scope.startsWith("oauth2:"), getScopes(res.grantedScopes != null ? res.grantedScopes : scope)));
                 result.putBundle("tokenDetails", details);
-                result.putString(KEY_ERROR, "OK");
+                result.putString(KEY_ERROR, ERROR_OK);
             } else {
-                result.putString(KEY_ERROR, "NeedPermission");
+                result.putString(KEY_ERROR, ERROR_NEED_PERMISSION);
                 Intent i = new Intent(context, AskPermissionActivity.class);
                 i.putExtras(extras);
                 i.putExtra(KEY_ANDROID_PACKAGE_NAME, packageName);
@@ -254,7 +272,7 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
             }
         } catch (IOException e) {
             Log.w(TAG, e);
-            result.putString(KEY_ERROR, "NetworkError");
+            result.putString(KEY_ERROR, ERROR_NETWORK_ERROR);
         }
         return result;
     }


### PR DESCRIPTION
Mirrors the override logic from AccountAuthenticator.getAuthToken into AuthManagerServiceImpl.getTokenWithAccount so that apps calling this path directly (e.g. patched YouTube flavors) also benefit from package overrides, fixing UNREGISTERED_ON_API_CONSOLE errors.