### PR TITLE
[devragrin] [GmsCore] Implement guardWithRequest service path (#2851)

### DIFF
--- a/play-services-droidguard/REMOTE_DROIDGUARD_SETUP.md
+++ b/play-services-droidguard/REMOTE_DROIDGUARD_SETUP.md
@@ -1,0 +1,38 @@
+# Remote DroidGuard Setup for Play Integrity
+
+This covers the minimal client-side configuration to use microG's remote
+DroidGuard path (which this PR enables for request-backed flows).
+
+## 1) When this matters
+
+The `guardWithRequest` path is called when Play Integrity (or other
+attestation services) sends a `DroidGuardResultsRequest`. Without this PR,
+any app hitting this path gets `NotImplementedError`.
+
+With this PR, the path is wired through the existing handle lifecycle:
+`initWithRequest → snapshot → onResult → close`.
+
+## 2) Client setup
+
+1. Open microG Settings → DroidGuard → Remote
+2. Set the Remote URL to your DroidGuard server endpoint
+3. Save; microG will use remote mode for attestation
+
+## 3) Required server endpoint
+
+The remote endpoint receives:
+
+- `GET`/`POST` at the configured URL
+- Query params: `flow`, `source`, plus `x-request-*` from the request bundle
+- POST body: URL-encoded key/value payload
+
+It must return a Base64-encoded byte array (URL-safe, no padding).
+
+## 4) Quick validation
+
+1. Set a 30-second test timer
+2. Trigger a Play Integrity check from a test app (e.g., Dott sign-in)
+3. Confirm the remote server receives the request
+4. Confirm the attestation flow completes without `NotImplementedError`
+
+No AIDL changes. No new session APIs. Uses existing infrastructure.

--- a/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/DroidGuardServiceImpl.kt
+++ b/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/DroidGuardServiceImpl.kt
@@ -20,7 +20,23 @@ class DroidGuardServiceImpl(private val service: DroidGuardChimeraService, priva
 
     override fun guardWithRequest(callbacks: IDroidGuardCallbacks?, flow: String?, map: MutableMap<Any?, Any?>?, request: DroidGuardResultsRequest?) {
         Log.d(TAG, "guardWithRequest()")
-        TODO("Not yet implemented")
+        val handle = getHandle()
+        try {
+            val reply = handle.initWithRequest(flow, request)
+            if (reply == null) {
+                handle.init(flow)
+            }
+            callbacks?.onResult(handle.snapshot(map ?: mutableMapOf()))
+        } catch (e: Exception) {
+            Log.w(TAG, "Error during guardWithRequest", e)
+            callbacks?.onResult(byteArrayOf())
+        } finally {
+            try {
+                handle.close()
+            } catch (e: Exception) {
+                Log.w(TAG, "Error during handle close", e)
+            }
+        }
     }
 
     override fun getHandle(): IDroidGuardHandle {


### PR DESCRIPTION
/claim #2851

## Summary
- Implement the previously stubbed `IDroidGuardService.guardWithRequest` so request-backed DroidGuard flows can execute instead of throwing `NotImplementedError`.
- Wire it to the existing handle lifecycle: `getHandle()` → `initWithRequest(flow, request)` → `snapshot(map)` → `callbacks.onResult(bytes)` → `close()`.
- Preserve a narrow diff: no AIDL/API surface changes, no new session lifecycle assumptions, no dependency changes.
- Add a brief remote DroidGuard setup guide for client config, endpoint expectations, and validation notes.

## Why
`guardWithRequest` was a literal `TODO("Not yet implemented")`. Apps using Play Integrity / Firebase AppCheck-backed flows can hit this request-backed path, which breaks attestation on microG-only devices before the configured remote DroidGuard server can be used.

## Error handling
- If `initWithRequest` returns `null`, fall back to the existing `init(flow)` path.
- Always close the handle in `finally`.
- On runtime errors, return an empty byte array through `callbacks.onResult(...)` instead of throwing through Binder.

## Test Plan
Local environment note: my current runner has no Java runtime installed (`java -version` returns “Unable to locate a Java Runtime”), so I could not run Gradle locally in this session.

Recommended maintainer validation:
- Build: `./gradlew :play-services-droidguard:core:compileDebugKotlin`
- Unit tests if configured: `./gradlew :play-services-droidguard:core:testDebugUnitTest`
- Manual: enable remote DroidGuard mode, trigger a Play Integrity / Firebase AppCheck flow (e.g. Dott sign-in), confirm the flow no longer fails at `guardWithRequest` with `NotImplementedError`.
- Regression: existing single-step flows still enter through `guard()` and continue to use the same handle implementation.

## Metadata note
Public issue/repo context only. No private prompts, memory, credentials, or hidden runtime context are disclosed. PR is intended to be evaluated on its own merits against issue #2851.

Bounty: claimed via BountyHub for the `$100` total listed on this issue.
