### PR TITLE
AdMob: Add ChimeraCreator Impl

### DIFF
--- a/play-services-ads-lite/build.gradle
+++ b/play-services-ads-lite/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     api 'androidx.work:work-runtime:2.7.0'
     api project(':play-services-ads-base')
     api project(':play-services-basement')
+    annotationProcessor project(':safe-parcel-processor')
 //    api project(':play-services-measurement-sdk-api')
 //    api project(':user-messaging-platform')
 }

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/AdLoaderBuilderCreatorImpl.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/AdLoaderBuilderCreatorImpl.kt
@@ -16,10 +16,10 @@ import org.microg.gms.utils.warnOnTransactionIssues
 private const val TAG = "AdLoaderBuilder"
 
 @Keep
-class AdLoaderBuilderCreatorImpl : IAdLoaderBuilderCreator.Stub() {
+open class AdLoaderBuilderCreatorImpl : IAdLoaderBuilderCreator.Stub() {
     override fun newAdLoaderBuilder(context: IObjectWrapper?, adUnitId: String, adapterCreator: IAdapterCreator?, clientVersion: Int): IBinder? {
         Log.d(TAG, "newAdLoaderBuilder: adUnitId=$adUnitId clientVersion=$clientVersion")
-        return null
+        return LegacyAdLoaderBuilder()
     }
 
     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean = warnOnTransactionIssues(code, reply, flags, TAG) { super.onTransact(code, data, reply, flags) }

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/AdManagerCreatorImpl.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/AdManagerCreatorImpl.kt
@@ -4,14 +4,32 @@
  */
 package com.google.android.gms.ads
 
+import android.content.Context
+import android.os.IBinder
 import android.os.Parcel
+import android.util.Log
 import androidx.annotation.Keep
+import com.google.android.gms.ads.internal.client.AdSizeParcel
+import com.google.android.gms.ads.internal.client.IAdManagerCreator
+import com.google.android.gms.ads.internal.mediation.client.IAdapterCreator
+import com.google.android.gms.dynamic.IObjectWrapper
+import com.google.android.gms.dynamic.ObjectWrapper
 import org.microg.gms.utils.warnOnTransactionIssues
 
-private const val TAG = "AdManager"
+private const val TAG = "AdManagerCreator"
 
 @Keep
-class AdManagerCreatorImpl : AdManagerCreator.Stub() {
+open class AdManagerCreatorImpl : IAdManagerCreator.Stub() {
+    override fun newAdManager(context: IObjectWrapper?, adSize: AdSizeParcel?, adUnitId: String?, adapterCreator: IAdapterCreator?, clientVersion: Int): IBinder {
+        Log.d(TAG, "newAdManager: adUnitId=$adUnitId clientVersion=$clientVersion")
+        return LegacyAdManager(ObjectWrapper.unwrap(context) as? Context)
+    }
+
+    override fun newAdManagerByType(context: IObjectWrapper?, adSize: AdSizeParcel?, adUnitId: String?, adapterCreator: IAdapterCreator?, clientVersion: Int, type: Int): IBinder {
+        Log.d(TAG, "newAdManagerByType: adUnitId=$adUnitId clientVersion=$clientVersion type=$type")
+        return LegacyAdManager(ObjectWrapper.unwrap(context) as? Context)
+    }
+
     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean =
         warnOnTransactionIssues(code, reply, flags, TAG) { super.onTransact(code, data, reply, flags) }
 }

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/ChimeraAdLoaderBuilderCreatorImpl.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/ChimeraAdLoaderBuilderCreatorImpl.kt
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.google.android.gms.ads
+
+import androidx.annotation.Keep
+
+/**
+ * Dynamite entry point for the native-ad (AdLoader) path.
+ *
+ * The AdMob SDK loads this class from the ads dynamite module by its fully-qualified name, so it must
+ * exist under this exact FQCN and implement `IAdLoaderBuilderCreator`. Behaviour is identical to
+ * [AdLoaderBuilderCreatorImpl], which is kept under its own name for SDKs that request the un-prefixed
+ * class.
+ */
+@Keep
+class ChimeraAdLoaderBuilderCreatorImpl : AdLoaderBuilderCreatorImpl()

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/ChimeraAdManagerCreatorImpl.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/ChimeraAdManagerCreatorImpl.kt
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.google.android.gms.ads
+
+import androidx.annotation.Keep
+
+/**
+ * Dynamite entry point for the banner/interstitial (AdManager) path.
+ *
+ * The AdMob SDK loads this class from the ads dynamite module by its fully-qualified name, so it must
+ * exist under this exact FQCN and implement `IAdManagerCreator`. Behaviour is identical to
+ * [AdManagerCreatorImpl], which is kept under its own name for SDKs that request the un-prefixed class.
+ */
+@Keep
+class ChimeraAdManagerCreatorImpl : AdManagerCreatorImpl()

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/ChimeraMobileAdsSettingManagerCreatorImpl.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/ChimeraMobileAdsSettingManagerCreatorImpl.kt
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.google.android.gms.ads
+
+import androidx.annotation.Keep
+
+/**
+ * Dynamite entry point for the Mobile Ads initialization / settings path.
+ *
+ * The AdMob SDK loads this class from the ads dynamite module by its fully-qualified name, so it must
+ * exist under this exact FQCN and implement `IMobileAdsSettingManagerCreator`. This is the entry point
+ * that gates ad initialization. Behaviour is identical to [MobileAdsSettingManagerCreatorImpl], which is
+ * kept under its own name for SDKs that request the un-prefixed class.
+ */
+@Keep
+class ChimeraMobileAdsSettingManagerCreatorImpl : MobileAdsSettingManagerCreatorImpl()

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/LegacyAdLoaderBuilder.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/LegacyAdLoaderBuilder.kt
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.google.android.gms.ads
+
+import android.util.Log
+import com.google.android.gms.ads.formats.AdManagerAdViewOptions
+import com.google.android.gms.ads.formats.PublisherAdViewOptions
+import com.google.android.gms.ads.internal.AdRequestParcel
+import com.google.android.gms.ads.internal.client.AdSizeParcel
+import com.google.android.gms.ads.internal.client.IAdListener
+import com.google.android.gms.ads.internal.client.IAdLoader
+import com.google.android.gms.ads.internal.client.IAdLoaderBuilder
+import com.google.android.gms.ads.internal.client.ICorrelationIdProvider
+import com.google.android.gms.ads.internal.formats.NativeAdOptionsParcel
+import com.google.android.gms.ads.internal.formats.client.IOnAppInstallAdLoadedListener
+import com.google.android.gms.ads.internal.formats.client.IOnContentAdLoadedListener
+import com.google.android.gms.ads.internal.formats.client.IOnCustomClickListener
+import com.google.android.gms.ads.internal.formats.client.IOnCustomTemplateAdLoadedListener
+import com.google.android.gms.ads.internal.formats.client.IOnPublisherAdViewLoadedListener
+import com.google.android.gms.ads.internal.formats.client.IOnUnifiedNativeAdLoadedListener
+import com.google.android.gms.ads.internal.instream.InstreamAdConfigurationParcel
+import com.google.android.gms.ads.internal.instream.client.IInstreamAdLoadCallback
+
+private const val TAG = "LegacyAdLoader"
+
+internal class LegacyAdLoaderBuilder : IAdLoaderBuilder.Stub() {
+    override fun build(): IAdLoader = LegacyAdLoader
+    override fun setAdListener(listener: IAdListener?) = Unit
+    override fun setAppInstallAdLoadedListener(listener: IOnAppInstallAdLoadedListener?) = Unit
+    override fun setContentAdLoadedListener(listener: IOnContentAdLoadedListener?) = Unit
+    override fun forCustomFormatAd(templateId: String?, onCustomFormatAdLoadedListener: IOnCustomTemplateAdLoadedListener?, onCustomClickListener: IOnCustomClickListener?) = Unit
+    override fun setNativeAdOptions(options: NativeAdOptionsParcel?) = Unit
+    override fun setCorrelationIdProvider(provider: ICorrelationIdProvider?) = Unit
+    override fun forPublisherAdView(onPublisherAdViewLoadedListener: IOnPublisherAdViewLoadedListener?, adSize: AdSizeParcel?) = Unit
+    override fun setPublisherAdViewOptions(options: PublisherAdViewOptions?) = Unit
+    override fun setUnifiedNativeAdLoadedListener(listener: IOnUnifiedNativeAdLoadedListener?) = Unit
+    override fun forInstreamAd(config: InstreamAdConfigurationParcel?) = Unit
+    override fun setInstreamAdLoadCallback(callback: IInstreamAdLoadCallback?) = Unit
+    override fun setAdManagerAdViewOptions(options: AdManagerAdViewOptions?) = Unit
+}
+
+private object LegacyAdLoader : IAdLoader.Stub() {
+    override fun load(request: AdRequestParcel?) {
+        Log.w(TAG, "load")
+    }
+    override fun getMediationAdapterClassName(): String? = null
+    override fun isLoading(): Boolean = false
+    override fun getAdManagerAdapterClassName(): String? = null
+    override fun loadAds(request: AdRequestParcel?, count: Int) {
+        Log.w(TAG, "loadAds")
+    }
+}

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/LegacyAdManager.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/LegacyAdManager.kt
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.google.android.gms.ads
+
+import android.content.Context
+import android.util.Log
+import android.widget.FrameLayout
+import com.google.android.gms.ads.internal.AdRequestParcel
+import com.google.android.gms.ads.internal.client.AdSizeParcel
+import com.google.android.gms.ads.internal.client.IAdClickListener
+import com.google.android.gms.ads.internal.client.IAdListener
+import com.google.android.gms.ads.internal.client.IAdLoadCallback
+import com.google.android.gms.ads.internal.client.IAdManager
+import com.google.android.gms.ads.internal.client.IAppEventListener
+import com.google.android.gms.ads.internal.client.IFullScreenContentCallback
+import com.google.android.gms.ads.internal.client.IOnPaidEventListener
+import com.google.android.gms.ads.internal.client.IVideoController
+import com.google.android.gms.dynamic.IObjectWrapper
+import com.google.android.gms.dynamic.ObjectWrapper
+
+private const val TAG = "LegacyAdManager"
+
+/**
+ * Minimal [IAdManager] returned by [AdManagerCreatorImpl] for the banner/interstitial path.
+ *
+ * It is a non-null ad manager so the AdMob SDK keeps using microG's remote result. No ad is served:
+ * [getView] returns an empty container, [loadAd] reports "no fill", and the listeners/getters are
+ * accepted but inert.
+ */
+internal class LegacyAdManager(private val context: Context?) : IAdManager.Stub() {
+    private val adView: FrameLayout? by lazy { context?.let { FrameLayout(it) } }
+
+    override fun getView(): IObjectWrapper = ObjectWrapper.wrap(adView)
+    override fun destroy() = Unit
+    override fun loadAd(request: AdRequestParcel?): Boolean {
+        Log.w(TAG, "loadAd")
+        return false
+    }
+    override fun pause() = Unit
+    override fun resume() = Unit
+    override fun setAdListener(listener: IAdListener?) = Unit
+    override fun setAppEventListener(listener: IAppEventListener?) = Unit
+    override fun getAdSize(): AdSizeParcel? = null
+    override fun setAdSize(adSize: AdSizeParcel?) = Unit
+    override fun setAdClickListener(listener: IAdClickListener?) = Unit
+    override fun setManualImpressionFlag(flag: Int) = Unit
+    override fun getVideoController(): IVideoController? = null
+    override fun setManualImpressionsEnabled(enabled: Boolean) = Unit
+    override fun setOnPaidEventListener(listener: IOnPaidEventListener?) = Unit
+    override fun loadAdWithCallback(request: AdRequestParcel?, callback: IAdLoadCallback?) = Unit
+    override fun showInterstitial(activityWrapper: IObjectWrapper?) = Unit
+    override fun setFullScreenContentCallback(callback: IFullScreenContentCallback?) = Unit
+    override fun setStartTimestampMillis(timestampMillis: Long) = Unit
+}

--- a/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/MobileAdsSettingManagerCreatorImpl.kt
+++ b/play-services-ads-lite/core/src/main/kotlin/com/google/android/gms/ads/MobileAdsSettingManagerCreatorImpl.kt
@@ -18,7 +18,7 @@ import org.microg.gms.utils.warnOnTransactionIssues
 private const val TAG = "AdsSettingManager"
 
 @Keep
-class MobileAdsSettingManagerCreatorImpl : IMobileAdsSettingManagerCreator.Stub() {
+open class MobileAdsSettingManagerCreatorImpl : IMobileAdsSettingManagerCreator.Stub() {
     override fun getMobileAdsSettingManager(context: IObjectWrapper?, clientVersion: Int): IBinder {
         Log.d(TAG, "getMobileAdsSettingManager($clientVersion)")
         return MobileAdsSettingManagerImpl(ObjectWrapper.unwrap(context) as Context)

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/formats/AdManagerAdViewOptions.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/formats/AdManagerAdViewOptions.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.formats;
+
+parcelable AdManagerAdViewOptions;

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/formats/PublisherAdViewOptions.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/formats/PublisherAdViewOptions.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.formats;
+
+parcelable PublisherAdViewOptions;

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/AdSizeParcel.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/AdSizeParcel.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+parcelable AdSizeParcel;

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/AdValueParcel.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/AdValueParcel.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+parcelable AdValueParcel;

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdClickListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdClickListener.aidl
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+interface IAdClickListener {
+    void onAdClicked() = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdListener.aidl
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.AdErrorParcel;
+
+interface IAdListener {
+    void onAdClosed() = 0;
+    void onAdFailedToLoad(int errorCode) = 1;
+    void onAdLeftApplication() = 2;
+    void onAdOpened() = 3;
+    void onAdLoaded() = 4;
+    void onAdClicked() = 5;
+    void onAdImpression() = 6;
+    void onAdFailedToLoadWithAdError(in AdErrorParcel error) = 7;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdLoadCallback.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdLoadCallback.aidl
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.AdErrorParcel;
+
+interface IAdLoadCallback {
+    void onAdLoaded() = 0;
+    void onAdFailedToLoad(in AdErrorParcel error) = 1;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdLoader.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdLoader.aidl
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.AdRequestParcel;
+
+interface IAdLoader {
+    void load(in AdRequestParcel request) = 0;
+    String getMediationAdapterClassName() = 1;
+    boolean isLoading() = 2;
+    String getAdManagerAdapterClassName() = 3;
+    void loadAds(in AdRequestParcel request, int count) = 4;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdLoaderBuilder.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdLoaderBuilder.aidl
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.client.IAdLoader;
+import com.google.android.gms.ads.internal.client.IAdListener;
+import com.google.android.gms.ads.internal.client.ICorrelationIdProvider;
+import com.google.android.gms.ads.internal.client.AdSizeParcel;
+import com.google.android.gms.ads.internal.formats.NativeAdOptionsParcel;
+import com.google.android.gms.ads.internal.formats.client.IOnAppInstallAdLoadedListener;
+import com.google.android.gms.ads.internal.formats.client.IOnContentAdLoadedListener;
+import com.google.android.gms.ads.internal.formats.client.IOnCustomTemplateAdLoadedListener;
+import com.google.android.gms.ads.internal.formats.client.IOnCustomClickListener;
+import com.google.android.gms.ads.internal.formats.client.IOnUnifiedNativeAdLoadedListener;
+import com.google.android.gms.ads.internal.formats.client.IOnPublisherAdViewLoadedListener;
+import com.google.android.gms.ads.internal.instream.InstreamAdConfigurationParcel;
+import com.google.android.gms.ads.internal.instream.client.IInstreamAdLoadCallback;
+import com.google.android.gms.ads.formats.PublisherAdViewOptions;
+import com.google.android.gms.ads.formats.AdManagerAdViewOptions;
+
+interface IAdLoaderBuilder {
+    IAdLoader build() = 0;
+    void setAdListener(IAdListener listener) = 1;
+    void setAppInstallAdLoadedListener(IOnAppInstallAdLoadedListener listener) = 2;
+    void setContentAdLoadedListener(IOnContentAdLoadedListener listener) = 3;
+    void forCustomFormatAd(String templateId, IOnCustomTemplateAdLoadedListener onCustomFormatAdLoadedListener, IOnCustomClickListener onCustomClickListener) = 4;
+    void setNativeAdOptions(in NativeAdOptionsParcel options) = 5;
+    void setCorrelationIdProvider(ICorrelationIdProvider provider) = 6;
+    void forPublisherAdView(IOnPublisherAdViewLoadedListener onPublisherAdViewLoadedListener, in AdSizeParcel adSize) = 7;
+    void setPublisherAdViewOptions(in PublisherAdViewOptions options) = 8;
+    void setUnifiedNativeAdLoadedListener(IOnUnifiedNativeAdLoadedListener listener) = 9;
+    void forInstreamAd(in InstreamAdConfigurationParcel config) = 12;
+    void setInstreamAdLoadCallback(IInstreamAdLoadCallback callback) = 13;
+    void setAdManagerAdViewOptions(in AdManagerAdViewOptions options) = 14;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdManager.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdManager.aidl
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.AdRequestParcel;
+import com.google.android.gms.ads.internal.client.AdSizeParcel;
+import com.google.android.gms.ads.internal.client.IAdListener;
+import com.google.android.gms.ads.internal.client.IAppEventListener;
+import com.google.android.gms.ads.internal.client.IAdClickListener;
+import com.google.android.gms.ads.internal.client.IVideoController;
+import com.google.android.gms.ads.internal.client.IOnPaidEventListener;
+import com.google.android.gms.ads.internal.client.IAdLoadCallback;
+import com.google.android.gms.ads.internal.client.IFullScreenContentCallback;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface IAdManager {
+    IObjectWrapper getView() = 0;
+    void destroy() = 1;
+    boolean loadAd(in AdRequestParcel request) = 3;
+    void pause() = 4;
+    void resume() = 5;
+    void setAdListener(IAdListener listener) = 6;
+    void setAppEventListener(IAppEventListener listener) = 7;
+    AdSizeParcel getAdSize() = 11;
+    void setAdSize(in AdSizeParcel adSize) = 12;
+    void setAdClickListener(IAdClickListener listener) = 19;
+    void setManualImpressionFlag(int flag) = 21;
+    IVideoController getVideoController() = 25;
+    void setManualImpressionsEnabled(boolean enabled) = 33;
+    void setOnPaidEventListener(IOnPaidEventListener listener) = 41;
+    void loadAdWithCallback(in AdRequestParcel request, IAdLoadCallback callback) = 42;
+    void showInterstitial(IObjectWrapper activityWrapper) = 43;
+    void setFullScreenContentCallback(IFullScreenContentCallback callback) = 44;
+    void setStartTimestampMillis(long timestampMillis) = 47;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdManagerCreator.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAdManagerCreator.aidl
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.client.AdSizeParcel;
+import com.google.android.gms.ads.internal.mediation.client.IAdapterCreator;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface IAdManagerCreator {
+    IBinder newAdManager(IObjectWrapper context, in AdSizeParcel adSize, String adUnitId, IAdapterCreator adapterCreator, int clientVersion) = 0;
+    IBinder newAdManagerByType(IObjectWrapper context, in AdSizeParcel adSize, String adUnitId, IAdapterCreator adapterCreator, int clientVersion, int type) = 1;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAppEventListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IAppEventListener.aidl
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+interface IAppEventListener {
+    void onAppEvent(String name, String info) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/ICorrelationIdProvider.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/ICorrelationIdProvider.aidl
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+interface ICorrelationIdProvider {
+    String getCorrelationId() = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IFullScreenContentCallback.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IFullScreenContentCallback.aidl
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.AdErrorParcel;
+
+interface IFullScreenContentCallback {
+    void onAdFailedToShowFullScreenContent(in AdErrorParcel error) = 0;
+    void onAdShowedFullScreenContent() = 1;
+    void onAdDismissedFullScreenContent() = 2;
+    void onAdImpression() = 3;
+    void onAdClicked() = 4;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IOnPaidEventListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IOnPaidEventListener.aidl
@@ -1,6 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.google.android.gms.ads.internal.client;
 
-import com.google.android.gms.ads.internal.AdErrorParcel;
+import com.google.android.gms.ads.internal.client.AdValueParcel;
 
 interface IOnPaidEventListener {
+    void onPaidEvent(in AdValueParcel adValue) = 0;
+    boolean isLoggingLimitedToImpressionEvents() = 1;
 }

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IVideoController.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IVideoController.aidl
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import com.google.android.gms.ads.internal.client.IVideoLifecycleCallbacks;
+
+interface IVideoController {
+    float getAspectRatio() = 0;
+    float getCurrentTime() = 1;
+    float getDuration() = 2;
+    int getPlaybackState() = 3;
+    void play() = 4;
+    void pause() = 5;
+    void stop() = 6;
+    IVideoLifecycleCallbacks getVideoLifecycleCallbacks() = 7;
+    void setVideoLifecycleCallbacks(IVideoLifecycleCallbacks callbacks) = 8;
+    boolean isClickToExpandEnabled() = 9;
+    boolean isCustomControlsEnabled() = 10;
+    boolean isMuted() = 11;
+    void mute(boolean mute) = 12;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IVideoLifecycleCallbacks.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/client/IVideoLifecycleCallbacks.aidl
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+interface IVideoLifecycleCallbacks {
+    void onVideoStart() = 0;
+    void onVideoPlay() = 1;
+    void onVideoPause() = 2;
+    void onVideoEnd() = 3;
+    void onVideoMute(boolean muted) = 4;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/NativeAdOptionsParcel.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/NativeAdOptionsParcel.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats;
+
+parcelable NativeAdOptionsParcel;

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IAttributionInfo.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IAttributionInfo.aidl
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.formats.client.INativeAdImage;
+
+interface IAttributionInfo {
+    String getText() = 0;
+    INativeAdImage getImage() = 1;
+    IAttributionInfo getNextAttributionInfo() = 2;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeAdImage.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeAdImage.aidl
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import android.net.Uri;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface INativeAdImage {
+    IObjectWrapper getDrawable() = 0;
+    Uri getUri() = 1;
+    double getScale() = 2;
+    int getWidth() = 3;
+    int getHeight() = 4;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeAppInstallAd.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeAppInstallAd.aidl
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import android.os.Bundle;
+import com.google.android.gms.ads.internal.client.IVideoController;
+import com.google.android.gms.ads.internal.formats.client.INativeAdImage;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface INativeAppInstallAd {
+    String getHeadline() = 0;
+    List getImages() = 1;
+    String getBody() = 2;
+    INativeAdImage getIcon() = 3;
+    String getCallToAction() = 4;
+    double getStarRating() = 5;
+    String getStore() = 6;
+    String getPrice() = 7;
+    Bundle getExtras() = 8;
+    void recordImpression() = 9;
+    void performClick(in Bundle clickData) = 10;
+    void reportTouchEvent(in Bundle touchData) = 11;
+    IVideoController getVideoController() = 12;
+    IObjectWrapper getMediaContent() = 13;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeContentAd.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeContentAd.aidl
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import android.os.Bundle;
+import com.google.android.gms.ads.internal.client.IVideoController;
+import com.google.android.gms.ads.internal.formats.client.INativeAdImage;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface INativeContentAd {
+    String getHeadline() = 0;
+    List getImages() = 1;
+    String getBody() = 2;
+    String getCallToAction() = 3;
+    String getAdvertiser() = 4;
+    INativeAdImage getLogo() = 5;
+    Bundle getExtras() = 6;
+    void recordImpression() = 7;
+    void performClick(in Bundle clickData) = 8;
+    void reportTouchEvent(in Bundle touchData) = 9;
+    IVideoController getVideoController() = 10;
+    IObjectWrapper getMediaContent() = 11;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeCustomTemplateAd.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/INativeCustomTemplateAd.aidl
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.client.IVideoController;
+import com.google.android.gms.ads.internal.formats.client.INativeAdImage;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface INativeCustomTemplateAd {
+    List<String> getAvailableAssetNames() = 0;
+    String getCustomTemplateId() = 1;
+    String getText(String assetName) = 2;
+    INativeAdImage getImage(String assetName) = 3;
+    void performClick(String assetName) = 4;
+    void recordImpression() = 5;
+    IVideoController getVideoController() = 6;
+    IObjectWrapper getMediaContent() = 7;
+    IObjectWrapper getDisplayOpenMeasurement() = 8;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnAppInstallAdLoadedListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnAppInstallAdLoadedListener.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.formats.client.INativeAppInstallAd;
+
+interface IOnAppInstallAdLoadedListener {
+    void onAppInstallAdLoaded(INativeAppInstallAd ad) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnContentAdLoadedListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnContentAdLoadedListener.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.formats.client.INativeContentAd;
+
+interface IOnContentAdLoadedListener {
+    void onContentAdLoaded(INativeContentAd ad) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnCustomClickListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnCustomClickListener.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.formats.client.INativeCustomTemplateAd;
+
+interface IOnCustomClickListener {
+    void onCustomClick(INativeCustomTemplateAd ad, String assetName) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnCustomTemplateAdLoadedListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnCustomTemplateAdLoadedListener.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.formats.client.INativeCustomTemplateAd;
+
+interface IOnCustomTemplateAdLoadedListener {
+    void onCustomTemplateAdLoaded(INativeCustomTemplateAd ad) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnPublisherAdViewLoadedListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnPublisherAdViewLoadedListener.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface IOnPublisherAdViewLoadedListener {
+    void onPublisherAdViewLoaded(IObjectWrapper view) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnUnifiedNativeAdLoadedListener.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IOnUnifiedNativeAdLoadedListener.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import com.google.android.gms.ads.internal.formats.client.IUnifiedNativeAd;
+
+interface IOnUnifiedNativeAdLoadedListener {
+    void onUnifiedNativeAdLoaded(IUnifiedNativeAd ad) = 0;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IUnifiedNativeAd.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/formats/client/IUnifiedNativeAd.aidl
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats.client;
+
+import android.os.Bundle;
+import com.google.android.gms.ads.internal.client.IVideoController;
+import com.google.android.gms.ads.internal.client.IResponseInfo;
+import com.google.android.gms.ads.internal.formats.client.INativeAdImage;
+import com.google.android.gms.ads.internal.formats.client.IAttributionInfo;
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface IUnifiedNativeAd {
+    String getHeadline() = 0;
+    List getImages() = 1;
+    String getBody() = 2;
+    INativeAdImage getIcon() = 3;
+    String getCallToAction() = 4;
+    double getStarRating() = 5;
+    String getStore() = 6;
+    String getPrice() = 7;
+    String getAdvertiser() = 8;
+    Bundle getExtras() = 9;
+    IVideoController getVideoController() = 10;
+    float getMediaContentAspectRatio() = 11;
+    IResponseInfo getResponseInfo() = 12;
+    IAttributionInfo getAttributionInfo() = 13;
+    void recordImpression() = 14;
+    void performClick(in Bundle clickData) = 15;
+    void reportTouchEvent(in Bundle touchData) = 16;
+    void cancelUnconfirmedClick() = 17;
+    void recordCustomClickGesture() = 18;
+    IObjectWrapper getMediaContent() = 19;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/instream/InstreamAdConfigurationParcel.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/instream/InstreamAdConfigurationParcel.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.instream;
+
+parcelable InstreamAdConfigurationParcel;

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/instream/client/IInstreamAd.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/instream/client/IInstreamAd.aidl
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.instream.client;
+
+import com.google.android.gms.dynamic.IObjectWrapper;
+
+interface IInstreamAd {
+    void destroy() = 0;
+    IObjectWrapper getMediaContent() = 1;
+    float getAspectRatio() = 2;
+}

--- a/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/instream/client/IInstreamAdLoadCallback.aidl
+++ b/play-services-ads-lite/src/main/aidl/com/google/android/gms/ads/internal/instream/client/IInstreamAdLoadCallback.aidl
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.instream.client;
+
+import com.google.android.gms.ads.internal.instream.client.IInstreamAd;
+
+interface IInstreamAdLoadCallback {
+    void onInstreamAdLoaded(IInstreamAd ad) = 0;
+    void onInstreamAdFailedToLoad(int errorCode) = 1;
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/formats/AdManagerAdViewOptions.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/formats/AdManagerAdViewOptions.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.formats;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Ad Manager ad view options passed to {@code IAdLoaderBuilder.setAdManagerAdViewOptions}.
+ */
+@SafeParcelable.Class
+public final class AdManagerAdViewOptions extends AbstractSafeParcelable {
+    @Field(1)
+    public boolean manualImpressionsEnabled;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<AdManagerAdViewOptions> CREATOR = findCreator(AdManagerAdViewOptions.class);
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/formats/PublisherAdViewOptions.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/formats/PublisherAdViewOptions.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.formats;
+
+import android.os.IBinder;
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Ad Manager publisher ad view options passed to {@code IAdLoaderBuilder.setPublisherAdViewOptions}.
+ */
+@Deprecated
+@SafeParcelable.Class
+public final class PublisherAdViewOptions extends AbstractSafeParcelable {
+    @Field(1)
+    public boolean manualImpressionsEnabled;
+    @Field(2)
+    public IBinder appEventListener;
+    @Field(3)
+    public IBinder delayedBannerAdListener;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<PublisherAdViewOptions> CREATOR = findCreator(PublisherAdViewOptions.class);
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/client/AdSizeParcel.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/client/AdSizeParcel.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Ad size (AdMob {@code AdSize}) passed to {@code IAdLoaderBuilder.forPublisherAdView} and used by the
+ * banner ad manager.
+ */
+@SafeParcelable.Class
+public class AdSizeParcel extends AbstractSafeParcelable {
+    @Field(2)
+    public String formatString;
+    @Field(3)
+    public int height;
+    @Field(4)
+    public int heightPixels;
+    @Field(5)
+    public boolean autoHeight;
+    @Field(6)
+    public int width;
+    @Field(7)
+    public int widthPixels;
+    @Field(8)
+    public AdSizeParcel[] shortcuts;
+    @Field(9)
+    public boolean isFluid;
+    @Field(10)
+    public boolean isAutoHeightSmartBanner;
+    @Field(11)
+    public boolean isDynamicBanner;
+    @Field(12)
+    public boolean isFullWidth;
+    @Field(13)
+    public boolean isAutoMediation;
+    @Field(14)
+    public boolean isParcelStateValid;
+    @Field(15)
+    public boolean isAdaptiveBanner;
+    @Field(16)
+    public boolean isInlineAdaptiveBanner;
+    @Field(17)
+    public boolean isCollapsible;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<AdSizeParcel> CREATOR = findCreator(AdSizeParcel.class);
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/client/AdValueParcel.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/client/AdValueParcel.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Ad value (AdMob {@code AdValue}) delivered to {@code IOnPaidEventListener.onPaidEvent}.
+ */
+@SafeParcelable.Class
+public class AdValueParcel extends AbstractSafeParcelable {
+    @Field(1)
+    public int adType;
+    @Field(2)
+    public int precisionType;
+    @Field(3)
+    public String currencyCode;
+    @Field(4)
+    public long valueMicros;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<AdValueParcel> CREATOR = findCreator(AdValueParcel.class);
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/client/VideoOptionsParcel.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/client/VideoOptionsParcel.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.client;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Video options (AdMob {@code VideoOptions}) nested inside {@link NativeAdOptionsParcel}.
+ */
+@SafeParcelable.Class
+public class VideoOptionsParcel extends AbstractSafeParcelable {
+    @Field(2)
+    public boolean startMuted;
+    @Field(3)
+    public boolean customControlsRequested;
+    @Field(4)
+    public boolean clickToExpandRequested;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<VideoOptionsParcel> CREATOR = findCreator(VideoOptionsParcel.class);
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/formats/NativeAdOptionsParcel.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/formats/NativeAdOptionsParcel.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.formats;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.ads.internal.client.VideoOptionsParcel;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Native ad options (AdMob {@code NativeAdOptions}) passed to {@code IAdLoaderBuilder.setNativeAdOptions}.
+ */
+@SafeParcelable.Class
+public class NativeAdOptionsParcel extends AbstractSafeParcelable {
+    @Field(1)
+    public int versionCode = 6;
+    @Field(2)
+    public boolean returnUrlsForImageAssets;
+    @Field(3)
+    public int imageOrientation;
+    @Field(4)
+    public boolean requestMultipleImages;
+    @Field(5)
+    public int adChoicesPlacement;
+    @Field(6)
+    public VideoOptionsParcel videoOptions;
+    @Field(7)
+    public boolean requestCustomMuteThisAd;
+    @Field(8)
+    public int mediaAspectRatio;
+    @Field(9)
+    public int swipeGestureDirection;
+    @Field(10)
+    public boolean customClickGestureEnabled;
+    @Field(11)
+    public int customClickGestureDirection;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<NativeAdOptionsParcel> CREATOR = findCreator(NativeAdOptionsParcel.class);
+}

--- a/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/instream/InstreamAdConfigurationParcel.java
+++ b/play-services-ads-lite/src/main/java/com/google/android/gms/ads/internal/instream/InstreamAdConfigurationParcel.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.ads.internal.instream;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Instream ad configuration passed to {@code IAdLoaderBuilder.forInstreamAd}.
+ */
+@SafeParcelable.Class
+public class InstreamAdConfigurationParcel extends AbstractSafeParcelable {
+    @Field(1000)
+    public int versionCode;
+    @Field(1)
+    public int instreamAdType;
+    @Field(2)
+    public String adTagUrl;
+    @Field(3)
+    public int timeoutMillis;
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<InstreamAdConfigurationParcel> CREATOR = findCreator(InstreamAdConfigurationParcel.class);
+}


### PR DESCRIPTION
Fixed crashes occurring on AOSP 16 with the ad-enabled versions used by some apps.
Some code is included from: https://github.com/microg/GmsCore/pull/3330

e.g.
cn.museedu.handwriting, com.telenor.pakistan.mytelenor, com.bianf.avatars.couple.animals.cats, com.nwff.firstferry
, com.app.graphicsDesign, com.sx.flutuante, com.vwa.rythmapp, com.dxg.singaporemrtmapdetail