### PR TITLE
Fido: Fix request with FidoAppIdExtension

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/JsonExtensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/JsonExtensions.kt
@@ -181,7 +181,7 @@ fun JSONObject.parseTokenBinding() = when (TokenBindingStatus.fromString(getStri
 
 fun JSONObject.parseAuthenticationExtensions(): AuthenticationExtensions {
     val builder = AuthenticationExtensions.Builder()
-    if (has("fidoAppIdExtension")) builder.setFido2Extension(FidoAppIdExtension(getJSONObject("fidoAppIdExtension").getString("appId")))
+    if (has("fidoAppIdExtension")) builder.setFido2Extension(FidoAppIdExtension(getJSONObject("fidoAppIdExtension").getString("appid")))
     if (has("appid")) builder.setFido2Extension(FidoAppIdExtension(getString("appid")))
     // TODO: Add support for other extensions
     return builder.build()

--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/JsonExtensions.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/credentials/provider/JsonExtensions.kt
@@ -182,7 +182,7 @@ fun JSONObject.parseTokenBinding() = when (TokenBindingStatus.fromString(getStri
 fun JSONObject.parseAuthenticationExtensions(): AuthenticationExtensions {
     val builder = AuthenticationExtensions.Builder()
     if (has("fidoAppIdExtension")) builder.setFido2Extension(FidoAppIdExtension(getJSONObject("fidoAppIdExtension").getString("appId")))
-    if (has("appid")) builder.setFido2Extension(FidoAppIdExtension(getString("appId")))
+    if (has("appid")) builder.setFido2Extension(FidoAppIdExtension(getString("appid")))
     // TODO: Add support for other extensions
     return builder.build()
 }


### PR DESCRIPTION
The JSON key is `appid`, and if it was present we were trying to get `appId` which always failed with an exception "No value for appId"

It caused a crash with Gitlab for example