### PR TITLE
 Fix ConcurrentModificationException in MultiConnectionKeeper

### DIFF
--- a/play-services-base/src/main/java/org/microg/gms/common/MultiConnectionKeeper.java
+++ b/play-services-base/src/main/java/org/microg/gms/common/MultiConnectionKeeper.java
@@ -33,13 +33,14 @@ import android.util.Log;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static org.microg.gms.common.Constants.GMS_PACKAGE_NAME;
@@ -201,11 +202,11 @@ public class MultiConnectionKeeper {
     public class Connection {
         private final String actionString;
         private final boolean requireMicrog;
-        private final Set<ServiceConnection> connectionForwards = new HashSet<ServiceConnection>();
-        private boolean bound = false;
-        private boolean connected = false;
-        private IBinder binder;
-        private ComponentName component;
+        private final Set<ServiceConnection> connectionForwards =  Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private volatile boolean bound = false;
+        private volatile boolean connected = false;
+        private volatile IBinder binder;
+        private volatile ComponentName component;
         private ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName componentName, IBinder iBinder) {

--- a/play-services-base/src/main/java/org/microg/gms/common/MultiConnectionKeeper.java
+++ b/play-services-base/src/main/java/org/microg/gms/common/MultiConnectionKeeper.java
@@ -202,7 +202,7 @@ public class MultiConnectionKeeper {
     public class Connection {
         private final String actionString;
         private final boolean requireMicrog;
-        private final Set<ServiceConnection> connectionForwards =  Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private final Set<ServiceConnection> connectionForwards = Collections.newSetFromMap(new ConcurrentHashMap<>());
         private volatile boolean bound = false;
         private volatile boolean connected = false;
         private volatile IBinder binder;


### PR DESCRIPTION
06-10 11:38:00.115 E/AndroidRuntime(28150): FATAL EXCEPTION: main
06-10 11:38:00.115 E/AndroidRuntime(28150): Process: com.google.android.gms, PID: 28150
06-10 11:38:00.115 E/AndroidRuntime(28150): java.util.ConcurrentModificationException
06-10 11:38:00.115 E/AndroidRuntime(28150):     at java.util.HashMap$HashIterator.nextNode(HashMap.java:1454)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at java.util.HashMap$KeyIterator.next(HashMap.java:1478)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at org.microg.gms.common.MultiConnectionKeeper$Connection$1.onServiceConnected(MultiConnectionKeeper.java:216)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.app.LoadedApk$ServiceDispatcher.doConnected(LoadedApk.java:2340)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.app.LoadedApk$ServiceDispatcher$RunConnection.run(LoadedApk.java:2373)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.os.Handler.handleCallback(Handler.java:966)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.os.Handler.dispatchMessage(Handler.java:110)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.os.Looper.loopOnce(Looper.java:205)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.os.Looper.loop(Looper.java:293)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.app.ActivityThread.processInnerLoop(ActivityThread.java:10272)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.app.ActivityThread.loopProcess(ActivityThread.java:10264)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at android.app.ActivityThread.main(ActivityThread.java:10255)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at java.lang.reflect.Method.invoke(Native Method)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
06-10 11:38:00.115 E/AndroidRuntime(28150):     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1366)