### PR TITLE
Add Cast framework dynamite module descriptor

### DIFF
--- a/play-services-cast-framework/core/src/main/java/com/google/android/gms/dynamite/descriptors/com/google/android/gms/cast/framework/dynamite/ModuleDescriptor.java
+++ b/play-services-cast-framework/core/src/main/java/com/google/android/gms/dynamite/descriptors/com/google/android/gms/cast/framework/dynamite/ModuleDescriptor.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.dynamite.descriptors.com.google.android.gms.cast.framework.dynamite;
+
+public class ModuleDescriptor {
+    public static final String MODULE_ID = "com.google.android.gms.cast.framework.dynamite";
+    public static final int MODULE_VERSION = 1;
+}


### PR DESCRIPTION
## Summary

Adds a local Dynamite `ModuleDescriptor` for `com.google.android.gms.cast.framework.dynamite` in the Cast framework core module.

The Cast framework loader already has a local `CastDynamiteModuleImpl`, and `DynamiteLoaderImpl` has a temporary version fallback for this same module id. This descriptor makes the module discoverable through the standard local descriptor path used by `DynamiteModule.getLocalVersion(...)`.

## Scope

This is intentionally small and does not claim to complete Google Cast v2 support by itself. It is a supporting fix for the Cast framework dynamite loading path related to #580.

It also does not overlap with the existing route-controller work in #3505 or the broader session/controller changes in #3377.

## Validation

From a short Windows path mounted with `subst G:` to avoid Android AIDL path-length failures:

```text
GRADLE_MICROG_VERSION_WITHOUT_GIT=1 ./gradlew.bat :play-services-cast-framework-core:compileDebugJavaWithJavac --no-daemon --no-configuration-cache
```

Result: build successful.

Refs #580