### PR TITLE
Cast: Start a session when a Cast route is selected

### DIFF
--- a/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/CastContextImpl.java
+++ b/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/CastContextImpl.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import androidx.mediarouter.media.MediaControlIntent;
 import androidx.mediarouter.media.MediaRouteSelector;
+import androidx.mediarouter.media.MediaRouter;
 
 import com.google.android.gms.cast.CastMediaControlIntent;
 import com.google.android.gms.cast.framework.CastOptions;
@@ -64,6 +65,17 @@ public class CastContextImpl extends ICastContext.Stub {
         String defaultCategory = CastMediaControlIntent.categoryForCast(receiverApplicationId);
 
         this.defaultSessionProvider = this.sessionProviders.get(defaultCategory);
+        if (this.defaultSessionProvider == null) {
+            // The provider map can be keyed by the full control category, which carries extra
+            // namespace/flag suffixes (e.g. ".../CC1AD845///ALLOW_IPV6"), rather than the bare
+            // categoryForCast(appId). Fall back to matching by category prefix.
+            for (Map.Entry<String, ISessionProvider> entry : this.sessionProviders.entrySet()) {
+                if (entry.getKey() != null && entry.getKey().startsWith(defaultCategory)) {
+                    this.defaultSessionProvider = entry.getValue();
+                    break;
+                }
+            }
+        }
 
         // TODO: This should incorporate passed options
         this.mergedSelector = new MediaRouteSelector.Builder()
@@ -71,6 +83,20 @@ public class CastContextImpl extends ICastContext.Stub {
             .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
             .addControlCategory(defaultCategory)
             .build();
+
+        // Observe route selection so that choosing a Cast route actually starts a session.
+        // This goes through the app's MediaRouterProxy (IMediaRouter), which runs androidx
+        // MediaRouter in the app process; touching MediaRouter directly from the dynamite would
+        // fail with a Resources$NotFoundException. On selection the app invokes
+        // MediaRouterCallbackImpl.onRouteSelected(), which starts the session.
+        try {
+            this.router.registerMediaRouterCallbackImpl(this.mergedSelector.asBundle(),
+                    new MediaRouterCallbackImpl(this));
+            this.router.addCallback(this.mergedSelector.asBundle(),
+                    MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY);
+        } catch (RemoteException e) {
+            Log.w(TAG, "Failed to register media router callback: " + e.getMessage());
+        }
     }
 
     @Override

--- a/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/MediaRouterCallbackImpl.java
+++ b/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/MediaRouterCallbackImpl.java
@@ -50,12 +50,18 @@ public class MediaRouterCallbackImpl extends IMediaRouterCallback.Stub {
     @Override
     public void onRouteSelected(String routeId, Bundle extras) throws RemoteException {
         CastDevice castDevice = CastDevice.getFromBundle(extras);
-
-        SessionImpl session = (SessionImpl) ObjectWrapper.unwrap(this.castContext.defaultSessionProvider.getSession(null));
-        Bundle routeInfoExtras = this.castContext.getRouter().getRouteInfoExtrasById(routeId);
-        if (routeInfoExtras != null) {
-            session.start(this.castContext, castDevice, routeId, routeInfoExtras);
+        if (this.castContext.defaultSessionProvider == null) {
+            Log.w(TAG, "No session provider for selected route " + routeId + "; cannot start session");
+            return;
         }
+        Object session = ObjectWrapper.unwrap(this.castContext.defaultSessionProvider.getSession(null));
+        if (!(session instanceof SessionImpl)) {
+            Log.w(TAG, "Session provider did not yield a SessionImpl for route " + routeId);
+            return;
+        }
+        Bundle routeInfoExtras = this.castContext.getRouter().getRouteInfoExtrasById(routeId);
+        ((SessionImpl) session).start(this.castContext, castDevice, routeId,
+                routeInfoExtras != null ? routeInfoExtras : extras);
     }
     @Override
     public void unknown(String routeId, Bundle extras) {


### PR DESCRIPTION
# Cast: start a session when a Cast route is selected

## Problem

Apps using the modern Cast SDK (`play-services-cast-framework`) — Prime Video, Netflix,
Disney+, YouTube, and any app built on `CastContext`/`SessionManager` — cannot start a
Cast session through microG. The Cast button discovers and lists Chromecasts (route
discovery works), but selecting a device does nothing: no session starts, no connection is
attempted, and the app's `SessionManagerListener` never fires. On the device this looks
like a silent failure (the symptom reported for Prime Video on /e/OS).

## Root cause

`CastContextImpl` builds the merged `MediaRouteSelector` and holds the app's `IMediaRouter`
and its `ISessionProvider`s, but it **never registers a route-selection callback**.
`MediaRouterCallbackImpl` — which already contains the correct "on selection, start the
session" logic — is imported by `CastDynamiteModuleImpl` but never instantiated or
registered with the router. As a result nothing observes route selection, so the session
lifecycle is never driven.

A second, latent bug sits in the provider lookup: `defaultSessionProvider` is fetched with
`sessionProviders.get(categoryForCast(appId))`, but the provider map is keyed by the *full*
control-category string, which carries extra namespace/flag suffixes
(e.g. `…/CC1AD845///ALLOW_IPV6`). The exact-key lookup misses, leaving
`defaultSessionProvider == null`, so even once selection is observed the session can't be
created (and `MediaRouterCallbackImpl.onRouteSelected` would NPE on it).

## Fix

`play-services-cast-framework` only — two files, no API changes:

1. **`CastContextImpl`** — register `MediaRouterCallbackImpl` with the app's
   `IMediaRouter` (`registerMediaRouterCallbackImpl` + `addCallback`) in the constructor, so
   route selection is observed and starts a session. This deliberately goes through the
   `IMediaRouter` binder rather than touching androidx `MediaRouter` directly: the dynamite
   runs with the app's `Resources` but microG's resource IDs, so a direct
   `MediaRouter.getInstance(context)` from the dynamite throws
   `Resources$NotFoundException`. The app's `MediaRouterProxy` already runs androidx
   MediaRouter correctly in-process.
2. **`CastContextImpl`** — fall back to a category-prefix match when the exact
   `categoryForCast(appId)` key isn't present, so the default session provider resolves
   despite the flag suffixes.
3. **`MediaRouterCallbackImpl.onRouteSelected`** — null-safety hardening (skip cleanly if
   there is no provider / the unwrapped object isn't a `SessionImpl`, and fall back to the
   route's own extras when `getRouteInfoExtrasById` returns null).

## Verification

Built into a `vtmDefault` GmsCore APK and tested against Google's real
`play-services-cast-framework` (a minimal sender app) on:
- an AOSP Android 14 emulator, and
- a Pixel 2 on LineageOS 22.2 (Android 15).

Before: selecting the Cast route only logs `unimplemented Method: onSelect`; nothing else
happens.

After: selecting the route drives the full session lifecycle —
```
MediaRouterCallbackImpl.onRouteSelected → SessionImpl.start → SessionManager.onSessionStarting
CastSender: onSessionStarting   (app's SessionManagerListener fires)
castState: NO_DEVICES_AVAILABLE → CONNECTING
```
i.e. the session now starts and proceeds to the device-connection/authentication handshake.

Note: completing the connection to a live device additionally requires microG signature
spoofing to be active on the device (so the app's GMS authenticity check passes) — that is
an existing environmental requirement of microG, independent of this change. On a device
without working signature spoofing the session correctly stalls at `CONNECTING` with a
`SERVICE_INVALID` from the app's `GoogleApiManager`; this patch is what gets the session to
that point in the first place.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
