### PR TITLE
Cast: Implement connectionless (Cast.API_CXLESS) device controller

### DIFF
--- a/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/CastContextImpl.java
+++ b/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/CastContextImpl.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import androidx.mediarouter.media.MediaControlIntent;
 import androidx.mediarouter.media.MediaRouteSelector;
+import androidx.mediarouter.media.MediaRouter;
 
 import com.google.android.gms.cast.CastMediaControlIntent;
 import com.google.android.gms.cast.framework.CastOptions;
@@ -64,6 +65,17 @@ public class CastContextImpl extends ICastContext.Stub {
         String defaultCategory = CastMediaControlIntent.categoryForCast(receiverApplicationId);
 
         this.defaultSessionProvider = this.sessionProviders.get(defaultCategory);
+        if (this.defaultSessionProvider == null) {
+            // The provider map can be keyed by the full control category, which carries extra
+            // namespace/flag suffixes (e.g. ".../CC1AD845///ALLOW_IPV6"), rather than the bare
+            // categoryForCast(appId). Fall back to matching by category prefix.
+            for (Map.Entry<String, ISessionProvider> entry : this.sessionProviders.entrySet()) {
+                if (entry.getKey() != null && entry.getKey().startsWith(defaultCategory)) {
+                    this.defaultSessionProvider = entry.getValue();
+                    break;
+                }
+            }
+        }
 
         // TODO: This should incorporate passed options
         this.mergedSelector = new MediaRouteSelector.Builder()
@@ -71,6 +83,20 @@ public class CastContextImpl extends ICastContext.Stub {
             .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
             .addControlCategory(defaultCategory)
             .build();
+
+        // Observe route selection so that choosing a Cast route actually starts a session.
+        // This goes through the app's MediaRouterProxy (IMediaRouter), which runs androidx
+        // MediaRouter in the app process; touching MediaRouter directly from the dynamite would
+        // fail with a Resources$NotFoundException. On selection the app invokes
+        // MediaRouterCallbackImpl.onRouteSelected(), which starts the session.
+        try {
+            this.router.registerMediaRouterCallbackImpl(this.mergedSelector.asBundle(),
+                    new MediaRouterCallbackImpl(this));
+            this.router.addCallback(this.mergedSelector.asBundle(),
+                    MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY);
+        } catch (RemoteException e) {
+            Log.w(TAG, "Failed to register media router callback: " + e.getMessage());
+        }
     }
 
     @Override

--- a/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/MediaRouterCallbackImpl.java
+++ b/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/MediaRouterCallbackImpl.java
@@ -50,12 +50,18 @@ public class MediaRouterCallbackImpl extends IMediaRouterCallback.Stub {
     @Override
     public void onRouteSelected(String routeId, Bundle extras) throws RemoteException {
         CastDevice castDevice = CastDevice.getFromBundle(extras);
-
-        SessionImpl session = (SessionImpl) ObjectWrapper.unwrap(this.castContext.defaultSessionProvider.getSession(null));
-        Bundle routeInfoExtras = this.castContext.getRouter().getRouteInfoExtrasById(routeId);
-        if (routeInfoExtras != null) {
-            session.start(this.castContext, castDevice, routeId, routeInfoExtras);
+        if (this.castContext.defaultSessionProvider == null) {
+            Log.w(TAG, "No session provider for selected route " + routeId + "; cannot start session");
+            return;
         }
+        Object session = ObjectWrapper.unwrap(this.castContext.defaultSessionProvider.getSession(null));
+        if (!(session instanceof SessionImpl)) {
+            Log.w(TAG, "Session provider did not yield a SessionImpl for route " + routeId);
+            return;
+        }
+        Bundle routeInfoExtras = this.castContext.getRouter().getRouteInfoExtrasById(routeId);
+        ((SessionImpl) session).start(this.castContext, castDevice, routeId,
+                routeInfoExtras != null ? routeInfoExtras : extras);
     }
     @Override
     public void unknown(String routeId, Bundle extras) {

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerImpl.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerImpl.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.os.Parcel;
 import android.os.RemoteException;
 import android.util.Base64;
@@ -71,6 +72,16 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     ChromeCast chromecast;
 
     String sessionId = null;
+
+    // Fires if the client process dies without a clean disconnect(), so we can tear down the
+    // CastV2 connection instead of leaking it (and its reader thread) and spamming a dead listener.
+    private final IBinder.DeathRecipient deathRecipient = new IBinder.DeathRecipient() {
+        @Override
+        public void binderDied() {
+            Log.d(TAG, "Cast client died; disconnecting from device");
+            disconnect();
+        }
+    };
 
     public CastDeviceControllerImpl(Context context, String packageName, Bundle extras) {
         this.context = context;
@@ -147,12 +158,12 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
         switch (message.getPayloadType()) {
             case STRING:
                 String response = message.getPayloadUtf8();
-                if (requestId == null) {
-                    this.onTextMessageReceived(message.getNamespace(), response);
-                } else {
-                    this.onSendMessageSuccess(response, requestId);
-                    this.onTextMessageReceived(message.getNamespace(), response);
-                }
+                // Every inbound text message is an application-level message (e.g. MEDIA_STATUS)
+                // and must be delivered via onTextMessageReceived. Do NOT report it as a send
+                // success here: onSendMessageSuccess is keyed by the *outgoing* send's requestId
+                // (signalled in sendMessage), not the response's requestId — conflating them
+                // completes a non-existent client task and throws a RemoteException.
+                this.onTextMessageReceived(message.getNamespace(), response);
                 break;
             case BINARY:
                 byte[] payload = message.getPayloadBinary();
@@ -162,7 +173,49 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     @Override
+    public void connect() {
+        // Connectionless (cxless) entry point. The classic path connects lazily on first
+        // launch/sendMessage, but the cxless client blocks until it receives
+        // onConnectedWithResult, so open the CastV2 channel now and signal readiness.
+        Log.d(TAG, "connect()");
+        try {
+            if (!this.chromecast.isConnected()) {
+                this.chromecast.connect();
+            }
+            this.onConnectedWithResult(CommonStatusCodes.SUCCESS);
+        } catch (Exception e) {
+            Log.w(TAG, "Error connecting to chromecast: " + e.getMessage());
+            this.onConnectedWithResult(CommonStatusCodes.NETWORK_ERROR);
+        }
+    }
+
+    @Override
+    public void setListener(ICastDeviceControllerListener listener) {
+        // cxless delivers the listener here instead of via the GetServiceRequest "listener" extra.
+        Log.d(TAG, "setListener()");
+        this.listener = listener;
+        try {
+            listener.asBinder().linkToDeath(deathRecipient, 0);
+        } catch (RemoteException e) {
+            Log.w(TAG, "Failed to link Cast client death: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void unregisterListener() {
+        Log.d(TAG, "unregisterListener()");
+        this.listener = null;
+    }
+
+    @Override
     public void disconnect() {
+        if (this.listener != null) {
+            try {
+                this.listener.asBinder().unlinkToDeath(deathRecipient, 0);
+            } catch (Exception ignored) {
+                // listener may already be dead or never linked
+            }
+        }
         try {
             this.chromecast.disconnect();
         } catch (IOException e) {
@@ -175,6 +228,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     public void sendMessage(String namespace, String message, long requestId) {
         try {
             this.chromecast.sendRawRequest(namespace, message, requestId);
+            // Signal transport-level send success keyed by the outgoing send's requestId so the
+            // client's sendMessage Task completes; the receiver's reply arrives separately as an
+            // inbound message via onTextMessageReceived.
+            this.onSendMessageSuccess("", requestId);
         } catch (IOException e) {
             Log.w(TAG, "Error sending cast message: " + e.getMessage());
             this.onSendMessageFailure("", requestId, CommonStatusCodes.NETWORK_ERROR);
@@ -322,6 +379,16 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
                 this.listener.onDeviceStatusChanged(deviceStatus);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onDeviceStatusChanged: " + ex.getMessage());
+            }
+        }
+    }
+
+    public void onConnectedWithResult(int statusCode) {
+        if (this.listener != null) {
+            try {
+                this.listener.onConnectedWithResult(statusCode);
+            } catch (RemoteException ex) {
+                Log.e(TAG, "Error calling onConnectedWithResult: " + ex.getMessage());
             }
         }
     }

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerImpl.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerImpl.java
@@ -67,7 +67,7 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     private CastDevice castDevice;
     boolean notificationEnabled;
     long castFlags;
-    ICastDeviceControllerListener listener;
+    volatile ICastDeviceControllerListener listener;
     private IBinder listenerBinder;
     private IBinder.DeathRecipient listenerDeathRecipient;
 
@@ -318,9 +318,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onDisconnected(int reason) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onDisconnected(reason);
+                l.onDisconnected(reason);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onDisconnected: " + ex.getMessage());
             }
@@ -328,9 +329,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onApplicationConnectionSuccess(ApplicationMetadata applicationMetadata, String applicationStatus, String sessionId, boolean wasLaunched) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onApplicationConnectionSuccess(applicationMetadata, applicationStatus, sessionId, wasLaunched);
+                l.onApplicationConnectionSuccess(applicationMetadata, applicationStatus, sessionId, wasLaunched);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onApplicationConnectionSuccess: " + ex.getMessage());
             }
@@ -338,9 +340,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onApplicationConnectionFailure(int statusCode) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onApplicationConnectionFailure(statusCode);
+                l.onApplicationConnectionFailure(statusCode);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onApplicationConnectionFailure: " + ex.getMessage());
             }
@@ -348,9 +351,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onTextMessageReceived(String namespace, String message) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onTextMessageReceived(namespace, message);
+                l.onTextMessageReceived(namespace, message);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onTextMessageReceived: " + ex.getMessage());
             }
@@ -358,9 +362,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onBinaryMessageReceived(String namespace, byte[] data) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onBinaryMessageReceived(namespace, data);
+                l.onBinaryMessageReceived(namespace, data);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onBinaryMessageReceived: " + ex.getMessage());
             }
@@ -369,9 +374,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
 
     public void onApplicationDisconnected(int paramInt) {
         Log.d(TAG, "unimplemented Method: onApplicationDisconnected");
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onApplicationDisconnected(paramInt);
+                l.onApplicationDisconnected(paramInt);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onApplicationDisconnected: " + ex.getMessage());
             }
@@ -379,9 +385,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onSendMessageFailure(String response, long requestId, int statusCode) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onSendMessageFailure(response, requestId, statusCode);
+                l.onSendMessageFailure(response, requestId, statusCode);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onSendMessageFailure: " + ex.getMessage());
             }
@@ -389,9 +396,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onSendMessageSuccess(String response, long requestId) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onSendMessageSuccess(response, requestId);
+                l.onSendMessageSuccess(response, requestId);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onSendMessageSuccess: " + ex.getMessage());
             }
@@ -399,9 +407,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onApplicationStatusChanged(ApplicationStatus applicationStatus) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onApplicationStatusChanged(applicationStatus);
+                l.onApplicationStatusChanged(applicationStatus);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onApplicationStatusChanged: " + ex.getMessage());
             }
@@ -409,9 +418,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onDeviceStatusChanged(CastDeviceStatus deviceStatus) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onDeviceStatusChanged(deviceStatus);
+                l.onDeviceStatusChanged(deviceStatus);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onDeviceStatusChanged: " + ex.getMessage());
             }
@@ -419,9 +429,10 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     }
 
     public void onConnectedWithResult(int statusCode) {
-        if (this.listener != null) {
+        ICastDeviceControllerListener l = this.listener;
+        if (l != null) {
             try {
-                this.listener.onConnectedWithResult(statusCode);
+                l.onConnectedWithResult(statusCode);
             } catch (RemoteException ex) {
                 Log.e(TAG, "Error calling onConnectedWithResult: " + ex.getMessage());
             }

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerImpl.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerImpl.java
@@ -68,20 +68,12 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     boolean notificationEnabled;
     long castFlags;
     ICastDeviceControllerListener listener;
+    private IBinder listenerBinder;
+    private IBinder.DeathRecipient listenerDeathRecipient;
 
     ChromeCast chromecast;
 
     String sessionId = null;
-
-    // Fires if the client process dies without a clean disconnect(), so we can tear down the
-    // CastV2 connection instead of leaking it (and its reader thread) and spamming a dead listener.
-    private final IBinder.DeathRecipient deathRecipient = new IBinder.DeathRecipient() {
-        @Override
-        public void binderDied() {
-            Log.d(TAG, "Cast client died; disconnecting from device");
-            disconnect();
-        }
-    };
 
     public CastDeviceControllerImpl(Context context, String packageName, Bundle extras) {
         this.context = context;
@@ -100,6 +92,63 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
         this.chromecast.registerListener(this);
         this.chromecast.registerRawMessageListener(this);
         this.chromecast.registerConnectionListener(this);
+    }
+
+    private synchronized void replaceListener(ICastDeviceControllerListener listener) {
+        clearListenerLocked();
+        if (listener == null) return;
+
+        IBinder binder = listener.asBinder();
+        IBinder.DeathRecipient deathRecipient = () -> handleListenerDeath(binder);
+        this.listener = listener;
+        this.listenerBinder = binder;
+        this.listenerDeathRecipient = deathRecipient;
+        try {
+            binder.linkToDeath(deathRecipient, 0);
+        } catch (RemoteException e) {
+            Log.w(TAG, "Failed to link Cast client death: " + e.getMessage());
+            handleListenerDeath(binder);
+        }
+    }
+
+    private synchronized void clearListener() {
+        clearListenerLocked();
+    }
+
+    private void clearListenerLocked() {
+        IBinder binder = this.listenerBinder;
+        IBinder.DeathRecipient deathRecipient = this.listenerDeathRecipient;
+        this.listener = null;
+        this.listenerBinder = null;
+        this.listenerDeathRecipient = null;
+        if (binder != null && deathRecipient != null) {
+            try {
+                binder.unlinkToDeath(deathRecipient, 0);
+            } catch (Exception ignored) {
+                // listener may already be dead
+            }
+        }
+    }
+
+    private void handleListenerDeath(IBinder deadBinder) {
+        synchronized (this) {
+            // A death notification can already be queued when a listener is replaced. Never let
+            // the old client's death tear down the newer client's active Cast session.
+            if (deadBinder != this.listenerBinder) return;
+            this.listener = null;
+            this.listenerBinder = null;
+            this.listenerDeathRecipient = null;
+        }
+        Log.d(TAG, "Cast client died; disconnecting from device");
+        disconnectChromecast();
+    }
+
+    private void disconnectChromecast() {
+        try {
+            this.chromecast.disconnect();
+        } catch (IOException e) {
+            Log.e(TAG, "Error disconnecting chromecast: " + e.getMessage());
+        }
     }
 
     @Override
@@ -193,35 +242,21 @@ public class CastDeviceControllerImpl extends ICastDeviceController.Stub impleme
     public void setListener(ICastDeviceControllerListener listener) {
         // cxless delivers the listener here instead of via the GetServiceRequest "listener" extra.
         Log.d(TAG, "setListener()");
-        this.listener = listener;
-        try {
-            listener.asBinder().linkToDeath(deathRecipient, 0);
-        } catch (RemoteException e) {
-            Log.w(TAG, "Failed to link Cast client death: " + e.getMessage());
-        }
+        replaceListener(listener);
     }
 
     @Override
     public void unregisterListener() {
         Log.d(TAG, "unregisterListener()");
-        this.listener = null;
+        clearListener();
     }
 
     @Override
     public void disconnect() {
-        if (this.listener != null) {
-            try {
-                this.listener.asBinder().unlinkToDeath(deathRecipient, 0);
-            } catch (Exception ignored) {
-                // listener may already be dead or never linked
-            }
-        }
-        try {
-            this.chromecast.disconnect();
-        } catch (IOException e) {
-            Log.e(TAG, "Error disconnecting chromecast: " + e.getMessage());
-            return;
-        }
+        // ChromeCast.disconnect() synchronously emits the connection event used to deliver the
+        // client's onDisconnected callback, so keep the live listener until that event returns.
+        disconnectChromecast();
+        clearListener();
     }
 
     @Override

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerService.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerService.java
@@ -41,7 +41,12 @@ public class CastDeviceControllerService extends BaseService {
     private static final String TAG = CastDeviceControllerService.class.getSimpleName();
 
     public CastDeviceControllerService() {
-        super("GmsCastDeviceControllerSvc", GmsService.CAST);
+        // Modern connectionless senders (Netflix/Prime, Cast.API_CXLESS) bind this same service
+        // but request serviceId CAST_API (161). Accept it too, or the broker rejects the bind with
+        // "Service not supported" — which the sender surfaces as "No devices found". The request is
+        // then served by the same CastDeviceControllerImpl, whose cxless connect/setListener path
+        // handles it.
+        super("GmsCastDeviceControllerSvc", GmsService.CAST, GmsService.CAST_API);
     }
 
     @Override

--- a/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerService.java
+++ b/play-services-cast/core/src/main/java/org/microg/gms/cast/CastDeviceControllerService.java
@@ -24,6 +24,7 @@ import android.util.Log;
 
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.internal.ICastDeviceControllerListener;
+import com.google.android.gms.common.internal.ConnectionInfo;
 import com.google.android.gms.common.internal.GetServiceRequest;
 import com.google.android.gms.common.internal.BinderWrapper;
 import com.google.android.gms.common.internal.IGmsCallbacks;
@@ -45,6 +46,17 @@ public class CastDeviceControllerService extends BaseService {
 
     @Override
     public void handleServiceRequest(IGmsCallbacks callback, GetServiceRequest request, GmsService service) throws RemoteException {
-        callback.onPostInitComplete(0, new CastDeviceControllerImpl(this, request.packageName, request.extras), null);
+        // Advertise the API features the client requested so its availability check passes
+        // (otherwise the SDK deems microG too old -> ConnectionResult=2). Echo all of them,
+        // including the connectionless (cxless) features: CastDeviceControllerImpl now implements
+        // the connectionless connect/setListener handshake, so the cxless path works.
+        ConnectionInfo info = new ConnectionInfo();
+        if (request.apiFeatures != null && request.apiFeatures.length > 0) {
+            info.features = request.apiFeatures;
+        } else {
+            info.features = request.defaultFeatures;
+        }
+        callback.onPostInitCompleteWithConnectionInfo(
+                0, new CastDeviceControllerImpl(this, request.packageName, request.extras), info);
     }
 }

--- a/play-services-cast/src/main/aidl/com/google/android/gms/cast/internal/ICastDeviceController.aidl
+++ b/play-services-cast/src/main/aidl/com/google/android/gms/cast/internal/ICastDeviceController.aidl
@@ -2,6 +2,7 @@ package com.google.android.gms.cast.internal;
 
 import com.google.android.gms.cast.LaunchOptions;
 import com.google.android.gms.cast.JoinOptions;
+import com.google.android.gms.cast.internal.ICastDeviceControllerListener;
 
 interface ICastDeviceController {
   oneway void disconnect() = 0;
@@ -11,4 +12,10 @@ interface ICastDeviceController {
   oneway void unregisterNamespace(String namespace) = 11;
   oneway void launchApplication(String applicationId, in LaunchOptions launchOptions) = 12;
   oneway void joinApplication(String applicationId, String sessionId, in JoinOptions joinOptions) = 13;
+  // Connectionless (Cast.API_CXLESS) path used by the modern Cast SDK: the client delivers its
+  // listener out-of-band via setListener (txn 18) then calls connect (txn 17), and waits for the
+  // service to reply ICastDeviceControllerListener.onConnectedWithResult before launching.
+  oneway void connect() = 16;
+  oneway void setListener(ICastDeviceControllerListener listener) = 17;
+  oneway void unregisterListener() = 18;
 }

--- a/play-services-cast/src/main/aidl/com/google/android/gms/cast/internal/ICastDeviceControllerListener.aidl
+++ b/play-services-cast/src/main/aidl/com/google/android/gms/cast/internal/ICastDeviceControllerListener.aidl
@@ -18,4 +18,7 @@ interface ICastDeviceControllerListener {
   void onSendMessageSuccess(String response, long requestId) = 10;
   void onApplicationStatusChanged(in ApplicationStatus applicationStatus) = 11;
   void onDeviceStatusChanged(in CastDeviceStatus deviceStatus) = 12;
+  // Connectionless readiness signal: the cxless client stays "not connected" until the service
+  // calls this with statusCode 0 (SUCCESS) after connect(). Without it the session never starts.
+  void onConnectedWithResult(int statusCode) = 13;
 }


### PR DESCRIPTION
# Cast: Implement connectionless (Cast.API_CXLESS) device controller

## Summary

Modern Cast SDK clients — and real apps such as Amazon Prime Video, YouTube,
Netflix — drive the Cast device over the **connectionless** Cast API
(`Cast.API_CXLESS`) rather than the classic connection-based path that microG
implemented. As a result, casting from these apps never worked on microG: the
session would start and then stall indefinitely.

This PR implements the connectionless device-controller surface. With it, the
**real Amazon Prime Video and Netflix apps launch their own receiver and play a
DRM title end to end** on a Chromecast, cast from a de-Googled phone.

Builds on #3567 (which makes the framework start a session when a Cast route is
selected); that session is the trigger that binds the device controller this PR
completes.

## The problem

The connectionless client binds the same `ICastDeviceController` service, but
its handshake differs from the classic client:

- The classic client passes its listener in the `GetServiceRequest` `"listener"`
  extra and connects lazily on the first launch/sendMessage.
- The **connectionless** client instead delivers its listener out-of-band via
  `setListener()`, then calls `connect()`, and **waits for the service to call
  `ICastDeviceControllerListener.onConnectedWithResult` before it will launch an
  application.** It is otherwise purely reactive.

microG implemented only the classic path. So a connectionless client bound the
service, called `setListener`/`connect` (transactions microG didn't handle, and
which were silently dropped because they are `oneway`), never received
`onConnectedWithResult`, and stayed "not connected" forever. Withholding the
`cxless_*` features to force the classic path instead just made the SDK decide
microG was too old and fail with `ConnectionResult=2`.

There is also a second gate, at the bind itself. The connectionless client
issues its `GetServiceRequest` with `serviceId = CAST_API` (161), not
`CAST` (10). The broker resolves that id against each service's supported ids;
the device-controller service declared only `CAST`, so the id matched nothing
and the broker rejected the bind with **"Service not supported"** — which the
sender surfaces to the user as **"No devices found"**, before any of the
handshake above can even run.

## The fix

The transaction numbers in microG's AIDL already matched the framework — the
connectionless methods were simply absent. The change is additive:

- **`ICastDeviceController.aidl`** — add `connect()` (txn 17),
  `setListener(ICastDeviceControllerListener)` (18), `unregisterListener()` (19).
- **`ICastDeviceControllerListener.aidl`** — add `onConnectedWithResult(int)`
  (txn 14), the readiness signal.
- **`CastDeviceControllerImpl.java`**:
  - `connect()` opens the CastV2 channel and emits
    `onConnectedWithResult(SUCCESS)`.
  - `setListener()` stores the out-of-band listener.
  - `onSendMessageSuccess` is now reported from the **outgoing** `sendMessage`,
    keyed by that send's `requestId`. Previously it was reported from *inbound*
    messages using the response's id, which completed a non-existent client task
    and threw a `RemoteException`. Inbound messages now go solely through
    `onTextMessageReceived`.
  - The client's listener binder is watched with `linkToDeath`; if the client
    process dies without a clean `disconnect()`, the device connection (and its
    reader thread) is torn down instead of leaked.
- **`CastDeviceControllerService.java`**:
  - Advertise the requested API features via `ConnectionInfo` so the client's
    availability check passes.
  - **Accept `serviceId` `CAST_API` (161) on the bind**, alongside `CAST` (10),
    so the broker no longer rejects the connectionless client with "Service not
    supported". The same `CastDeviceControllerImpl` serves both ids — the
    connectionless `connect`/`setListener` path handles the request — so no new
    service or implementation is introduced.

## Connectionless handshake (for reference)

```
bind CAST service (serviceId CAST_API, cxless features, EXTRA_CAST_DEVICE, connectionless_client_record_id)
  → setListener(listener)              [txn 18]
  → connect()                          [txn 17]
  ← onConnectedWithResult(0)           [listener txn 14]   // session becomes "connected"
  → launchApplication(appId, opts)     [txn 13]
  ← onApplicationConnectionSuccess     [listener txn 2]
  → sendMessage(LOAD, media namespace) [txn 9]             // + per-app namespaces
  ← onSendMessageSuccess / onTextMessageReceived
```

## Testing

Validated on a Pixel 2 (LineageOS-for-microG, Android 15) against a Chromecast:

- The real, logged-in **Amazon Prime Video** app selects the device, microG
  launches **Prime's own receiver** (appId `17608BC8`), Prime completes its
  proprietary registration/settings handshake on
  `urn:x-cast:com.amazon.primevideo.cast`, LOADs a DRM title, and the title
  **plays on the TV** — with zero failed listener callbacks.
- The real, logged-in **Netflix** app selects the device, microG accepts the
  `CAST_API` bind, drives the connectionless `setListener`/`connect` handshake
  to `onConnectedWithResult(0)`, launches Netflix's receiver, relays its
  private-namespace traffic, LOADs a DRM title, and the title **plays on the
  TV**.
- The real, logged-in **Disney+** app selects the device over the same
  connectionless path, launches its receiver, and the title **plays on the
  TV**.
- A minimal first-party Cast sender plays a clip end to end
  (`playerState=PLAYING`, currentTime advancing).
- Force-killing the sender mid-session triggers the `linkToDeath` cleanup
  (device disconnected, no leaked connection).

## Notes / scope

- `CastMediaRouteController.onSelect` remains a stub; it is a separate legacy
  route-control path and does not gate the connectionless flow (the framework's
  session manager binds the device controller directly).
- The `CAST_API` (161) id is accepted at the bind (see above), but no
  additional `CAST_API`-specific surface (settings/relay/logging) is
  implemented. Netflix and Prime carry their app traffic over the device
  controller's namespaces, so that surface was not needed for casting in
  testing; `registerNamespace`/`unregisterNamespace` remain logged no-ops and
  did not block playback.
