### PR TITLE
Cast: return a no-op ReconnectionService instead of null

### DIFF
--- a/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/CastDynamiteModuleImpl.java
+++ b/play-services-cast-framework/core/src/main/java/com/google/android/gms/cast/framework/internal/CastDynamiteModuleImpl.java
@@ -17,6 +17,8 @@
 package com.google.android.gms.cast.framework.internal;
 
 import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
 import android.os.RemoteException;
 import android.util.Log;
 
@@ -65,8 +67,27 @@ public class CastDynamiteModuleImpl extends ICastDynamiteModule.Stub {
 
     @Override
     public IReconnectionService newReconnectionServiceImpl(IObjectWrapper service, IObjectWrapper sessionManager, IObjectWrapper discoveryManager) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: newReconnectionServiceImpl");
-        return null;
+        // Return a minimal no-op service rather than null: the Cast SDK's ReconnectionService calls
+        // onCreate() on this delegate without a null check, so returning null crashes the client app
+        // (NPE in ReconnectionService.onCreate). microG doesn't drive reconnection itself, so a no-op
+        // delegate is sufficient and keeps connectionless Cast sessions stable.
+        return new IReconnectionService.Stub() {
+            @Override
+            public void onCreate() {}
+
+            @Override
+            public int onStartCommand(Intent intent, int flags, int startId) {
+                return android.app.Service.START_NOT_STICKY;
+            }
+
+            @Override
+            public IBinder onBind(Intent intent) {
+                return null;
+            }
+
+            @Override
+            public void onDestroy() {}
+        };
     }
 
     @Override


### PR DESCRIPTION
# Cast: return a no-op ReconnectionService instead of null

## Summary

`CastDynamiteModuleImpl.newReconnectionServiceImpl` currently returns `null`. But the
Cast SDK's `ReconnectionService` calls `onCreate()` on the returned delegate **without a
null check**, so any client that starts the `ReconnectionService` crashes with:

```
java.lang.RuntimeException: Unable to create service
  com.google.android.gms.cast.framework.ReconnectionService:
  java.lang.NullPointerException: Attempt to invoke interface method
  'void com.google.android.gms.cast.framework.zzq.onCreate()' on a null object reference
    at com.google.android.gms.cast.framework.ReconnectionService.onCreate(...play-services-cast-framework@@19.0.0:8)
```

The `ReconnectionService` is started on the connectionless (`Cast.API_CXLESS`) path that
modern first-party apps (Prime Video, YouTube, …) use, so in practice this crash-loops the
sender process during a cast session. The churn also surfaces downstream as a stream of
`RemoteException`s on the device-controller callbacks (`onSendMessageSuccess` /
`onTextMessageReceived`) — those are just callbacks landing on the listener of a process
that's being killed and restarted.

## Fix

Return a minimal no-op `IReconnectionService` instead of `null`:

```java
return new IReconnectionService.Stub() {
    @Override public void onCreate() {}
    @Override public int onStartCommand(Intent intent, int flags, int startId) {
        return android.app.Service.START_NOT_STICKY;
    }
    @Override public IBinder onBind(Intent intent) { return null; }
    @Override public void onDestroy() {}
};
```

microG doesn't implement Cast reconnection itself, so a no-op delegate is sufficient: it
satisfies the SDK's unconditional `onCreate()`/`onStartCommand()` calls without doing
anything, which keeps the session stable. (`START_NOT_STICKY` so the empty service isn't
re-created after being killed.)

## Testing

On a Pixel 2 + a real Chromecast, casting a clip through the connectionless path:

- **Before:** the sender NPE-loops on `ReconnectionService.onCreate`; the device-controller
  callbacks throw `RemoteException` (dead listener); the session is unstable.
- **After:** no crash, no `RemoteException`s, the cast plays cleanly and the sender stays
  alive.

## Notes

This is a microG-level gap independent of any single Cast PR — it affects every
connectionless Cast flow that wires up the `ReconnectionService`. Surfaced while
hardware-testing the open Cast PRs (#3377 in particular); with this fix in place those
connectionless implementations cast cleanly rather than crash-looping.
