### PR TITLE
Fixed an issue where certain device models could not navigate to the old-style "Gemini Live" page for authorization.

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
@@ -89,6 +89,7 @@ private val CONFIGURATION_OPTIONS = mapOf(
         Flag("45766419", 8.0, 0), // bar animation
         Flag("45772982", 0L, 0), // pure black render (without it the bars are blue/gray)
         Flag("45750622", true, 0), // Fix "Conversation requires an update"
+        Flag("45763529", true, 0), // Make Gemini Live first-use consent open immediately from the Live button
     ),
     "com.google.android.libraries.search.googleapp.user#com.google.android.googlequicksearchbox" to arrayOf(
         // Allow the "Saved" tab in the Google app to appear as "Activity."


### PR DESCRIPTION
Make Gemini Live first-use consent open immediately from the Live button.
