### PR TITLE
Fix "Something went wrong" error in Google Passwords

### DIFF
--- a/play-services-base/core/src/main/kotlin/org/microg/gms/common/KnownGooglePackages.kt
+++ b/play-services-base/core/src/main/kotlin/org/microg/gms/common/KnownGooglePackages.kt
@@ -216,6 +216,13 @@ private val KNOWN_GOOGLE_PACKAGES = mapOf(
         PackageAndCertHash("com.google.android.apps.youtube.producer", SHA256, "5faeab9198730e9ef1f2312f742d66095632bffa7cc74f5d5c8280cb0b184e9d"),
         setOf(ACCOUNT, AUTH, OWNER)
     ),
+
+    // Google Password Manager
+    Pair(
+        PackageAndCertHash("com.google.android.apps.credentialmanager", SHA256, "15fc750bc4ed1f8fcf7319ec7dd60571391755db80eedfd1b93bca54e3768d6e"),
+        setOf(ACCOUNT, AUTH, OWNER, CREDENTIALS)
+    ),
+
 )
 
 fun isGooglePackage(pkg: PackageAndCertHash): Boolean {

--- a/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/credential/CredentialManagerService.kt
@@ -64,7 +64,7 @@ private class CredentialManagerServiceImpl(private val context: Context, overrid
             runCatching {
                 val intent = Intent().apply {
                     setClassName(Constants.GMS_PACKAGE_NAME, PASSWORD_MANAGER_CLASS_NAME)
-                    putExtra(EXTRA_KEY_ACCOUNT_NAME, params.account.name)
+                    params.account?.name?.let { putExtra(EXTRA_KEY_ACCOUNT_NAME, it) }
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
                 val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, 0, false)


### PR DESCRIPTION
An "Something went wrong" error appears when opening Google Passwords on the device.