### PR TITLE
fix: avoid ConcurrentModificationException in SmsRetrieverCore onDestroy

### DIFF
--- a/play-services-auth-api-phone/core/src/main/kotlin/org/microg/gms/auth/phone/SmsRetrieverCore.kt
+++ b/play-services-auth-api-phone/core/src/main/kotlin/org/microg/gms/auth/phone/SmsRetrieverCore.kt
@@ -234,7 +234,7 @@ class SmsRetrieverCore(private val context: Context, override val lifecycle: Lif
         if (this::smsBroadcastReceiver.isInitialized) context.unregisterReceiver(smsBroadcastReceiver)
         if (this::timeoutBroadcastReceiver.isInitialized) context.unregisterReceiver(timeoutBroadcastReceiver)
 
-        for (request in requests.values) {
+        for (request in requests.values.toList()) {
             sendReply(request, Status(CommonStatusCodes.TIMEOUT))
         }
 


### PR DESCRIPTION
We now iterate over a copy of instead of the live value.

This fixes the following crash:
```
--------- beginning of crash
07-10 12:54:48.454  5623  5623 E AndroidRuntime: FATAL EXCEPTION: main
07-10 12:54:48.454  5623  5623 E AndroidRuntime: Process: com.google.android.gms, PID: 5623
07-10 12:54:48.454  5623  5623 E AndroidRuntime: java.util.ConcurrentModificationException
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1603)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at java.util.HashMap$ValueIterator.next(HashMap.java:1631)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at org.microg.gms.auth.phone.SmsRetrieverCore.onDestroy(SmsRetrieverCore.kt:237)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.DefaultLifecycleObserverAdapter.onStateChanged(DefaultLifecycleObserverAdapter.kt:29)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.kt:322)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.LifecycleRegistry.backwardPass(LifecycleRegistry.kt:273)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.kt:290)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.kt:143)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.kt:126)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at androidx.lifecycle.ServiceLifecycleDispatcher$DispatchRunnable.run(ServiceLifecycleDispatcher.kt:92)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:995)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:103)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:248)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:338)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:9067)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
07-10 12:54:48.454  5623  5623 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
```