### PR TITLE
Fido: accept lowercase hybrid QR URI scheme

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/hybrid/model/QrCodeData.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/hybrid/model/QrCodeData.kt
@@ -39,7 +39,10 @@ data class QrCodeData(
         private val PADDING_TABLE = intArrayOf(0, 3, 5, 8, 10, 13, 15)
 
         fun parse(data: String): QrCodeData? {
-            val encoded = data.substringAfter(PREFIX_FIDO, "")
+            if (!data.startsWith(PREFIX_FIDO, ignoreCase = true)) {
+                return null
+            }
+            val encoded = data.substring(PREFIX_FIDO.length)
             Log.d(TAG, "encoded: $encoded")
             val qrCodeDataByte = resolveQrCodeData(encoded)
             Log.d(TAG, "qrCodeDataByte: $qrCodeDataByte")


### PR DESCRIPTION
## Summary

Accept hybrid QR URI schemes case-insensitively in `QrCodeData.parse()`.

`HybridAuthenticateActivity` currently accepts the `FIDO:/` prefix with `ignoreCase = true`, but `QrCodeData.parse()` extracts the payload using the case-sensitive expression:

```kotlin
data.substringAfter(PREFIX_FIDO, "")
```

Android delivered a valid hybrid registration URI using a lowercase scheme:

```text
fido:/...
```

The activity accepted the URI, but the parser failed to find the uppercase `FIDO:/` prefix, decoded an empty payload, and returned `null`.

## Fix

Validate the prefix case-insensitively and remove it by length:

```kotlin
if (!data.startsWith(PREFIX_FIDO, ignoreCase = true)) return null
val encoded = data.substring(PREFIX_FIDO.length)
```

This keeps the encoded payload unchanged while accepting valid casing variations.