### PR TITLE
WearOS pairing and data bridging support

### DIFF
--- a/play-services-base/core/src/main/kotlin/org/microg/gms/settings/SettingsContract.kt
+++ b/play-services-base/core/src/main/kotlin/org/microg/gms/settings/SettingsContract.kt
@@ -326,6 +326,18 @@ object SettingsContract {
         )
     }
 
+    object Wearable {
+        const val ID = "wearable"
+        fun getContentUri(context: Context) = Uri.withAppendedPath(getAuthorityUri(context), ID)
+        fun getContentType(context: Context) = "vnd.android.cursor.item/vnd.${getAuthority(context)}.$ID"
+
+        const val AUTO_ACCEPT_TOS = "wearable_auto_accept_tos"
+
+        val PROJECTION = arrayOf(
+            AUTO_ACCEPT_TOS
+        )
+    }
+
     private fun <T> withoutCallingIdentity(f: () -> T): T {
         val identity = Binder.clearCallingIdentity()
         try {

--- a/play-services-base/core/src/main/kotlin/org/microg/gms/settings/SettingsProvider.kt
+++ b/play-services-base/core/src/main/kotlin/org/microg/gms/settings/SettingsProvider.kt
@@ -26,6 +26,7 @@ import org.microg.gms.settings.SettingsContract.Location
 import org.microg.gms.settings.SettingsContract.Profile
 import org.microg.gms.settings.SettingsContract.SafetyNet
 import org.microg.gms.settings.SettingsContract.Vending
+import org.microg.gms.settings.SettingsContract.Wearable
 import org.microg.gms.settings.SettingsContract.WorkProfile
 import org.microg.gms.settings.SettingsContract.getAuthority
 import java.io.File
@@ -85,6 +86,7 @@ class SettingsProvider : ContentProvider() {
         Vending.ID -> queryVending(projection ?: Vending.PROJECTION)
         WorkProfile.ID -> queryWorkProfile(projection ?: WorkProfile.PROJECTION)
         GameProfile.ID -> queryGameProfile(projection ?: GameProfile.PROJECTION)
+        Wearable.ID -> queryWearable(projection ?: Wearable.PROJECTION)
         else -> null
     }
 
@@ -108,6 +110,7 @@ class SettingsProvider : ContentProvider() {
             Vending.ID -> updateVending(values)
             WorkProfile.ID -> updateWorkProfile(values)
             GameProfile.ID -> updateGameProfile(values)
+            Wearable.ID -> updateWearable(values)
             else -> return 0
         }
         return 1
@@ -434,6 +437,25 @@ class SettingsProvider : ContentProvider() {
             when (key) {
                 GameProfile.ALLOW_CREATE_PLAYER -> editor.putBoolean(key, value as Boolean)
                 GameProfile.ALLOW_UPLOAD_GAME_PLAYED -> editor.putBoolean(key, value as Boolean)
+                else -> throw IllegalArgumentException("Unknown key: $key")
+            }
+        }
+        editor.apply()
+    }
+
+    private fun queryWearable(p: Array<out String>): Cursor = MatrixCursor(p).addRow(p) { key ->
+        when (key) {
+            Wearable.AUTO_ACCEPT_TOS -> getSettingsBoolean(key, false)
+            else -> throw IllegalArgumentException("Unknown key: $key")
+        }
+    }
+
+    private fun updateWearable(values: ContentValues) {
+        if (values.size() == 0) return
+        val editor = preferences.edit()
+        values.valueSet().forEach { (key, value) ->
+            when (key) {
+                Wearable.AUTO_ACCEPT_TOS -> editor.putBoolean(key, value as Boolean)
                 else -> throw IllegalArgumentException("Unknown key: $key")
             }
         }

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -138,10 +138,18 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
+    <uses-permission
+        android:name="android.permission.MEDIA_CONTENT_CONTROL"
+        tools:ignore="ProtectedPermissions" />
 
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
@@ -261,7 +269,9 @@
             </intent-filter>
         </service>
 
-        <service android:name="org.microg.gms.wearable.location.WearableLocationService">
+        <service
+            android:name="org.microg.gms.wearable.location.WearableLocationService"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
                 <data
@@ -451,9 +461,20 @@
 
         <!-- Wearable -->
 
-        <service android:name="org.microg.gms.wearable.WearableService">
+        <service
+            android:name="org.microg.gms.wearable.WearableService"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.google.android.gms.wearable.BIND" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name="org.microg.gms.wearable.notification.WearableNotificationService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
 

--- a/play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt
@@ -5,14 +5,40 @@
 
 package com.google.android.gms.wearable.consent
 
+import android.app.AlertDialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.R
+import org.microg.gms.wearable.WearablePreferences
 
 class TermsOfServiceActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setResult(RESULT_CANCELED)
-        finish()
+
+        if (WearablePreferences.isAutoAcceptTosEnabled(this)) {
+            // User has opted-in to auto-accept; proceed immediately.
+            setResult(RESULT_OK)
+            finish()
+            return
+        }
+
+        // Show an explicit dialog so the user can make an informed choice.
+        AlertDialog.Builder(this)
+            .setTitle(R.string.wearable_tos_dialog_title)
+            .setMessage(R.string.wearable_tos_dialog_message)
+            .setPositiveButton(R.string.wearable_tos_accept) { _, _ ->
+                setResult(RESULT_OK)
+                finish()
+            }
+            .setNegativeButton(R.string.wearable_tos_decline) { _, _ ->
+                setResult(RESULT_CANCELED)
+                finish()
+            }
+            .setOnCancelListener {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
+            .show()
     }
 }

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/SettingsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/SettingsFragment.kt
@@ -54,6 +54,10 @@ class SettingsFragment : ResourceSettingsFragment() {
             findNavController().navigate(requireContext(), R.id.openWorkProfileSettings)
             true
         }
+        findPreference<Preference>(PREF_WEARABLE)!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            findNavController().navigate(requireContext(), R.id.openWearableSettings)
+            true
+        }
 
         findPreference<Preference>(PREF_ABOUT)!!.apply {
             onPreferenceClickListener = Preference.OnPreferenceClickListener {
@@ -139,6 +143,7 @@ class SettingsFragment : ResourceSettingsFragment() {
         const val PREF_VENDING = "pref_vending"
         const val PREF_WORK_PROFILE = "pref_work_profile"
         const val PREF_ACCOUNTS = "pref_accounts"
+        const val PREF_WEARABLE = "pref_wearable"
     }
 
     init {

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/WearableFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/WearableFragment.kt
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.ui
+
+import android.os.Bundle
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.TwoStatePreference
+import com.google.android.gms.R
+import kotlinx.coroutines.launch
+import org.microg.gms.wearable.WearablePreferences
+
+class WearableFragment : PreferenceFragmentCompat() {
+    private lateinit var autoAcceptTos: TwoStatePreference
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResource(R.xml.preferences_wearable)
+
+        autoAcceptTos = preferenceScreen.findPreference(PREF_AUTO_ACCEPT_TOS)!!
+        autoAcceptTos.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+            val appContext = requireContext().applicationContext
+            if (newValue is Boolean) {
+                lifecycleScope.launch {
+                    WearablePreferences.setAutoAcceptTosEnabled(appContext, newValue)
+                    updateContent()
+                }
+            }
+            true
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updateContent()
+    }
+
+    private fun updateContent() {
+        val appContext = requireContext().applicationContext
+        lifecycleScope.launch {
+            autoAcceptTos.isChecked = WearablePreferences.isAutoAcceptTosEnabled(appContext)
+        }
+    }
+
+    companion object {
+        const val PREF_AUTO_ACCEPT_TOS = "wearable_auto_accept_tos"
+    }
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/wearable/WearablePreferences.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/wearable/WearablePreferences.kt
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2025 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable
+
+import android.content.Context
+import org.microg.gms.settings.SettingsContract
+
+object WearablePreferences {
+    @JvmStatic
+    fun isAutoAcceptTosEnabled(context: Context): Boolean {
+        val projection = arrayOf(SettingsContract.Wearable.AUTO_ACCEPT_TOS)
+        return SettingsContract.getSettings(context, SettingsContract.Wearable.getContentUri(context), projection) { c ->
+            c.getInt(0) != 0
+        }
+    }
+
+    @JvmStatic
+    fun setAutoAcceptTosEnabled(context: Context, enabled: Boolean) {
+        SettingsContract.setSettings(context, SettingsContract.Wearable.getContentUri(context)) {
+            put(SettingsContract.Wearable.AUTO_ACCEPT_TOS, enabled)
+        }
+    }
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/wearable/notification/WearableNotificationService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/wearable/notification/WearableNotificationService.kt
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.notification
+
+import android.app.Notification
+import android.os.Build
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import org.microg.gms.wearable.NotificationBridge
+import org.microg.gms.wearable.WearableService
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.util.concurrent.atomic.AtomicInteger
+
+private const val TAG = "WearNotificationSvc"
+
+/** Path used for forwarding bridged Android notifications to wearable peers. */
+const val NOTIFICATION_PATH = "/wearable/notification"
+
+/** Monotonic counter used to assign collision-free UIDs to bridged notifications. */
+private val uidCounter = AtomicInteger(1)
+
+/**
+ * [NotificationListenerService] that bridges Android notifications to connected
+ * Wear OS peers via the microG WearableImpl message transport.
+ *
+ * Filters out:
+ * - Notifications originating from this GmsCore package itself.
+ * - Ongoing notifications ([Notification.FLAG_ONGOING_EVENT]).
+ * - Non-clearable notifications ([Notification.FLAG_NO_CLEAR]).
+ */
+class WearableNotificationService : NotificationListenerService() {
+
+    /**
+     * Maps the notification's stable key to the UID we assigned to it, so that we send
+     * the same UID on removal.  The key is derived via [sbnKey] to remain safe on API 19.
+     */
+    private val keyToUid = HashMap<String, Int>()
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        if (shouldSkip(sbn)) return
+
+        // Assign a stable, collision-free UID for this notification.
+        val uid = keyToUid.getOrPut(sbnKey(sbn)) { uidCounter.getAndIncrement() }
+        NotificationBridge.activeNotifications[uid] = sbn
+
+        val payload = encodeNotification(uid, sbn) ?: return
+        sendToWearable(payload)
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification) {
+        val uid = keyToUid.remove(sbnKey(sbn)) ?: return
+        NotificationBridge.activeNotifications.remove(uid)
+
+        // Notify peers that this notification was dismissed
+        val payload = encodeRemoval(uid, sbnKey(sbn)) ?: return
+        sendToWearable(payload)
+    }
+
+    // -------------------------------------------------------------------------
+
+    private fun shouldSkip(sbn: StatusBarNotification): Boolean {
+        if (sbn.packageName == packageName) return true
+        val flags = sbn.notification?.flags ?: return true
+        if (flags and Notification.FLAG_ONGOING_EVENT != 0) return true
+        if (flags and Notification.FLAG_NO_CLEAR != 0) return true
+        return false
+    }
+
+    private fun sendToWearable(payload: ByteArray) {
+        val wearable = WearableService.getInstance() ?: run {
+            Log.d(TAG, "WearableService not running, skipping notification forward")
+            return
+        }
+        val connectedNodes = wearable.allConnectedNodes
+        if (connectedNodes.isEmpty()) {
+            Log.d(TAG, "No connected wearable nodes, skipping notification forward")
+            return
+        }
+        for (nodeId in connectedNodes) {
+            val result = wearable.sendMessage(packageName, nodeId, NOTIFICATION_PATH, payload)
+            if (result < 0) {
+                Log.w(TAG, "sendMessage to $nodeId failed (result=$result)")
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Encoding helpers
+// -------------------------------------------------------------------------
+
+/**
+ * Returns a stable string key for [sbn] that is safe on API 19+.
+ *
+ * [StatusBarNotification.getKey] was added in API 20 (KITKAT_WATCH). On API 19 we fall
+ * back to a composite of `packageName + '|' + id + '|' + tag` which is sufficient for
+ * distinguishing notifications within a single posting session.  Package names are
+ * dot-separated identifiers and cannot contain '|', minimising the risk of collisions.
+ */
+internal fun sbnKey(sbn: StatusBarNotification): String {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+        sbn.key
+    } else {
+        "${sbn.packageName}|${sbn.id}|${sbn.tag ?: ""}"
+    }
+}
+
+/**
+ * Encodes a posted notification as:
+ * - byte type = 1 (posted)
+ * - int uid
+ * - UTF packageName
+ * - UTF key
+ * - UTF title (empty string if absent)
+ * - UTF text  (empty string if absent)
+ * - long timestamp
+ * - int actionCount
+ * - UTF[] action titles
+ */
+internal fun encodeNotification(uid: Int, sbn: StatusBarNotification): ByteArray? {
+    return try {
+        val n = sbn.notification ?: return null
+        val extras = n.extras
+        val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString() ?: ""
+        val text = (extras?.getCharSequence(Notification.EXTRA_BIG_TEXT)
+            ?: extras?.getCharSequence(Notification.EXTRA_TEXT))?.toString() ?: ""
+        val actions: Array<Notification.Action> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            n.actions ?: emptyArray()
+        } else {
+            emptyArray()
+        }
+
+        ByteArrayOutputStream().also { baos ->
+            DataOutputStream(baos).use { dos ->
+                dos.writeByte(1) // type: posted
+                dos.writeInt(uid)
+                dos.writeUTF(sbn.packageName)
+                dos.writeUTF(sbnKey(sbn))
+                dos.writeUTF(title)
+                dos.writeUTF(text)
+                dos.writeLong(sbn.postTime)
+                dos.writeInt(actions.size)
+                for (action in actions) {
+                    dos.writeUTF(action.title?.toString() ?: "")
+                }
+            }
+        }.toByteArray()
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to encode notification", e)
+        null
+    }
+}
+
+/**
+ * Encodes a removal event as:
+ * - byte type = 2 (removed)
+ * - int uid
+ * - UTF key
+ */
+internal fun encodeRemoval(uid: Int, key: String): ByteArray? {
+    return try {
+        ByteArrayOutputStream().also { baos ->
+            DataOutputStream(baos).use { dos ->
+                dos.writeByte(2) // type: removed
+                dos.writeInt(uid)
+                dos.writeUTF(key)
+            }
+        }.toByteArray()
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to encode notification removal", e)
+        null
+    }
+}

--- a/play-services-core/src/main/res/navigation/nav_settings.xml
+++ b/play-services-core/src/main/res/navigation/nav_settings.xml
@@ -30,6 +30,9 @@
             android:id="@+id/openWorkProfileSettings"
             app:destination="@id/workProfileFragment" />
         <action
+            android:id="@+id/openWearableSettings"
+            app:destination="@id/wearableFragment" />
+        <action
             android:id="@+id/openMoreGoogleSettings"
             app:destination="@id/googleMoreFragment" />
         <action
@@ -195,6 +198,13 @@
         android:id="@+id/workProfileFragment"
         android:name="org.microg.gms.ui.WorkProfileFragment"
         android:label="@string/service_name_work_profile" />
+
+    <!-- Wearable -->
+
+    <fragment
+        android:id="@+id/wearableFragment"
+        android:name="org.microg.gms.ui.WearableFragment"
+        android:label="@string/service_name_wearable" />
 
     <!-- More -->
 

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -475,4 +475,13 @@ Please set up a password, PIN, or pattern lock screen."</string>
     <string name="pref_passkey_manager_transport_bluetooth">Bluetooth</string>
     <string name="pref_passkey_manager_transport_hybrid">Hybrid</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <string name="service_name_wearable">Wearable</string>
+    <string name="pref_wearable_tos_category">Terms of Service</string>
+    <string name="pref_wearable_auto_accept_tos_switch">Auto-accept Wearable TOS</string>
+    <string name="pref_wearable_auto_accept_tos_summary">Automatically accept the Wearable Terms of Service when requested. Disabled by default.</string>
+    <string name="wearable_tos_dialog_title">Wearable Terms of Service</string>
+    <string name="wearable_tos_dialog_message">A Wearable device is requesting permission to pair with this phone. Do you accept the Terms of Service?</string>
+    <string name="wearable_tos_accept">Accept</string>
+    <string name="wearable_tos_decline">Decline</string>
 </resources>

--- a/play-services-core/src/main/res/xml/preferences_start.xml
+++ b/play-services-core/src/main/res/xml/preferences_start.xml
@@ -53,6 +53,10 @@
             android:key="pref_work_profile"
             android:title="@string/service_name_work_profile" />
         <Preference
+            android:icon="@drawable/ic_link"
+            android:key="pref_wearable"
+            android:title="@string/service_name_wearable" />
+        <Preference
             android:icon="@drawable/dots_horizontal"
             android:key="pref_google_more"
             android:title="@string/pref_more_settings"

--- a/play-services-core/src/main/res/xml/preferences_wearable.xml
+++ b/play-services-core/src/main/res/xml/preferences_wearable.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ SPDX-FileCopyrightText: 2025 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        android:title="@string/pref_wearable_tos_category"
+        app:iconSpaceReserved="false">
+        <SwitchPreferenceCompat
+            android:title="@string/pref_wearable_auto_accept_tos_switch"
+            android:summary="@string/pref_wearable_auto_accept_tos_summary"
+            android:key="wearable_auto_accept_tos"
+            android:persistent="false"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/play-services-wearable/README.md
+++ b/play-services-wearable/README.md
@@ -1,0 +1,45 @@
+# Google Play Services Wearable
+
+This module implements the Wearable API (`com.google.android.gms.wearable`), enabling microG to communicate with Wear OS devices.
+
+## Features
+
+### Bluetooth RFCOMM Transport (`BluetoothConnectionThread.java`)
+- Uses a **microG experimental** Bluetooth RFCOMM UUID (`a3c87500-8ed3-4bdf-8a39-a01bebede295`) for lab / microG-to-microG transport. This is **not** a documented stock Wear OS companion RFCOMM UUID (the bit pattern is publicly known as Eddystone BLE; microG does not implement Eddystone). Stock Wear interop needs a device-proven UUID from an HCI snoop.
+- Wraps `BluetoothSocket` in a `java.net.Socket` proxy to reuse the existing `SocketWearableConnection` framing code
+- Supports both server (listen) and client (connect) modes
+
+### Phone Call Handling (`CallBridge.java`)
+- Monitors phone call state (idle, ringing, off-hook)
+- Sends call state changes to connected Wear OS devices
+- Handles incoming call actions from the watch: answer, end, silence
+
+### Media Controls (`MediaBridge.java`)
+- Registers as a media session listener to receive playback state updates
+- Forwards play/pause/skip events from the phone to connected Wear OS devices
+
+### Notification Bridging (`WearableNotificationService.kt`)
+- Extends `NotificationListenerService` to intercept phone notifications
+- Forwards clearable, non-ongoing notifications to connected Wear OS devices
+- Supports notification removal events (same UID on removal)
+
+### Wearable Channels API (`ChannelManager.java`)
+- Implements the full `ChannelGetInputStream` / `ChannelGetOutputStream` AIDL interface
+- Supports stream and file transfers between phone and watch
+
+### Settings UI (`play-services-core`)
+- `WearableFragment.kt`: Settings screen with auto-accept TOS toggle
+- `TermsOfServiceActivity.kt`: Shows a dialog on first pairing; auto-accept if enabled
+- `WearablePreferences.kt`: Persistent preference storage
+
+## Permissions Added
+
+- `BLUETOOTH`, `BLUETOOTH_ADMIN` (up to API 30)
+- `BLUETOOTH_CONNECT`, `BLUETOOTH_SCAN`
+- `ANSWER_PHONE_CALLS`
+- `MEDIA_CONTENT_CONTROL`
+
+## Relates to
+
+- Issue [#2843](https://github.com/microg/GmsCore/issues/2843) — WearOS Support bounty
+- PR [#3473](https://github.com/microg/GmsCore/pull/3473)

--- a/play-services-wearable/core/build.gradle
+++ b/play-services-wearable/core/build.gradle
@@ -15,6 +15,22 @@ dependencies {
     implementation project(':play-services-wearable')
 
     implementation "org.microg:wearable:$wearableVersion"
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    // wearable 0.1.1 was compiled against Wire 1.6.1. GmsCore ships Wire 6.x.
+    // Unit tests that construct SocketWearableConnection / ChannelControlRequest
+    // need the 1.x ABI or they die in <clinit> before the real assertions.
+    testImplementation 'com.squareup.wire:wire-runtime:1.6.1'
+}
+
+configurations.configureEach { config ->
+    String n = config.name.toLowerCase()
+    if (n.contains('unittest') || n == 'testcompileclasspath' || n == 'testruntimeclasspath') {
+        config.resolutionStrategy {
+            force 'com.squareup.wire:wire-runtime:1.6.1'
+        }
+    }
 }
 
 android {
@@ -48,6 +64,12 @@ android {
 
     kotlinOptions {
         jvmTarget = 1.8
+    }
+
+    testOptions {
+        unitTests.all {
+            maxHeapSize = '2048m'
+        }
     }
 }
 

--- a/play-services-wearable/core/src/main/AndroidManifest.xml
+++ b/play-services-wearable/core/src/main/AndroidManifest.xml
@@ -6,6 +6,12 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application>
+
     </application>
 </manifest>

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/BluetoothConnectionThread.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/BluetoothConnectionThread.java
@@ -1,0 +1,318 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothServerSocket;
+import android.bluetooth.BluetoothSocket;
+import android.util.Log;
+
+import org.microg.wearable.SocketWearableConnection;
+import org.microg.wearable.WearableConnection;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Transport thread that mirrors {@code SocketConnectionThread} but uses Bluetooth RFCOMM instead
+ * of TCP sockets.
+ *
+ * <p>Internally, each {@link BluetoothSocket} is wrapped in a minimal {@link Socket} proxy so
+ * that the existing {@link SocketWearableConnection} framing code can be reused unchanged.
+ * This avoids any direct dependency on the Wire 1.x API that is otherwise unavailable at
+ * compile time.
+ *
+ * <h3>Server mode</h3>
+ * <pre>
+ *   BluetoothConnectionThread bct =
+ *       BluetoothConnectionThread.serverListen(adapter, messageHandler);
+ *   bct.start();
+ * </pre>
+ * The thread opens a Bluetooth RFCOMM server socket and accepts connections in a loop.
+ * Each accepted connection runs the message loop synchronously before looping back.
+ *
+ * <h3>Client mode</h3>
+ * <pre>
+ *   BluetoothConnectionThread bct =
+ *       BluetoothConnectionThread.clientConnect(remoteDevice, messageHandler);
+ *   bct.start();
+ * </pre>
+ * The thread connects to {@code remoteDevice} using {@link #WEAR_BT_UUID} and runs the
+ * message loop until the connection is closed.
+ */
+public abstract class BluetoothConnectionThread extends Thread {
+
+    private static final String TAG = "GmsWearBtThread";
+
+    /**
+     * RFCOMM service UUID used by microG for the wearable Bluetooth transport.
+     *
+     * <p><b>Important:</b> This is a <em>microG experimental</em> service UUID chosen for
+     * local RFCOMM pairing experiments. It is <b>not</b> a documented Google Wear OS / Play
+     * Services companion RFCOMM UUID. Notably, the same 128-bit value is publicly known as
+     * the Eddystone BLE service UUID; microG reuses the bit pattern only as an RFCOMM SDP
+     * record id and does <b>not</b> implement Eddystone advertising or claim stock Wear
+     * companion interop through this constant.
+     *
+     * <p>Interoperability with factory Wear OS companions requires a device-proven UUID from
+     * an HCI/BT snoop of a real pairing session. Until then, treat this transport as
+     * microG-to-microG / lab-only.
+     */
+    public static final UUID WEAR_BT_UUID =
+            UUID.fromString("a3c87500-8ed3-4bdf-8a39-a01bebede295");
+
+    /** SDP service name advertised alongside {@link #WEAR_BT_UUID}. */
+    static final String WEAR_BT_SERVICE_NAME = "microG Wearable";
+
+    /**
+     * Live peer connections accepted by this thread. Server-listen mode keeps every
+     * accepted peer here; a second {@link #setWearableConnection} must not close the first.
+     */
+    private final Map<Integer, SocketWearableConnection> wearableConnections =
+            new ConcurrentHashMap<Integer, SocketWearableConnection>();
+
+    /** Most recently registered peer; kept for existing single-slot callers. */
+    private volatile SocketWearableConnection wearableConnection;
+
+    // Package-private constructor; concrete subclasses are anonymous inner classes.
+    BluetoothConnectionThread() {}
+
+    /**
+     * Registers a live peer connection without tearing down any other peer.
+     * The previous single-slot setter closed {@code prev}, which dropped the first
+     * RFCOMM socket as soon as a second watch connected.
+     */
+    protected void setWearableConnection(SocketWearableConnection connection) {
+        if (connection == null) {
+            return;
+        }
+        wearableConnections.put(System.identityHashCode(connection), connection);
+        this.wearableConnection = connection;
+    }
+
+    /** Returns the most recently established {@link SocketWearableConnection}, or null. */
+    public SocketWearableConnection getWearableConnection() {
+        return wearableConnection;
+    }
+
+    /** Snapshot of every live peer still registered on this thread. */
+    public Collection<SocketWearableConnection> getWearableConnections() {
+        return Collections.unmodifiableCollection(wearableConnections.values());
+    }
+
+    /**
+     * Drops a disconnected peer from the live set. Does not close other peers.
+     * Package-visible so {@link WearableImpl} can forget one server-accepted socket
+     * without shutting down the RFCOMM listen thread.
+     */
+    public void removeWearableConnection(SocketWearableConnection connection) {
+        if (connection == null) {
+            return;
+        }
+        wearableConnections.remove(System.identityHashCode(connection));
+        if (this.wearableConnection == connection) {
+            this.wearableConnection = null;
+        }
+    }
+
+    /** Closes the underlying Bluetooth server/client socket, unblocking any pending I/O. */
+    public abstract void close();
+
+    // -------------------------------------------------------------------------
+    // Internal helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Wraps a {@link BluetoothSocket} in a minimal {@link Socket} proxy so that
+     * {@link SocketWearableConnection} can use its streams without any Wire-version-specific
+     * framing code in this module.
+     *
+     * <p>{@link SocketWearableConnection} calls {@link #getInputStream()},
+     * {@link #getOutputStream()}, {@link #isConnected()}, {@link #isClosed()}, and {@link #close()}
+     * on the socket object.
+     */
+    private static Socket proxySocket(BluetoothSocket btSocket) {
+        return new Socket() {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return btSocket.getInputStream();
+            }
+
+            @Override
+            public OutputStream getOutputStream() throws IOException {
+                return btSocket.getOutputStream();
+            }
+
+            @Override
+            public boolean isConnected() {
+                return btSocket != null && btSocket.isConnected();
+            }
+
+            @Override
+            public boolean isClosed() {
+                return btSocket == null || !btSocket.isConnected();
+            }
+
+            @Override
+            public synchronized void close() throws IOException {
+                if (btSocket != null) {
+                    btSocket.close();
+                }
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a server-side thread that listens for incoming Bluetooth RFCOMM connections
+     * using the well-known {@link #WEAR_BT_UUID}.
+     *
+     * <p>Requires {@code BLUETOOTH_CONNECT} permission on API 31+.
+     *
+     * @param adapter  the local {@link BluetoothAdapter}; must not be null
+     * @param listener message listener shared across all accepted connections
+     * @return a {@link BluetoothConnectionThread} ready to be {@link #start()}ed
+     */
+    @SuppressLint("MissingPermission")
+    public static BluetoothConnectionThread serverListen(
+            BluetoothAdapter adapter, WearableConnection.Listener listener) {
+        return new BluetoothConnectionThread() {
+            private volatile BluetoothServerSocket serverSocket;
+
+            @Override
+            public void close() {
+                BluetoothServerSocket s = serverSocket;
+                serverSocket = null;
+                if (s != null) {
+                    try {
+                        s.close();
+                    } catch (IOException e) {
+                        Log.w(TAG, "server close: error", e);
+                    }
+                }
+            }
+
+            @Override
+            @SuppressLint("MissingPermission")
+            public void run() {
+                try {
+                    serverSocket = adapter.listenUsingRfcommWithServiceRecord(
+                            WEAR_BT_SERVICE_NAME, WEAR_BT_UUID);
+                    Log.d(TAG, "server: listening for RFCOMM connections");
+                    while (!Thread.interrupted()) {
+                        BluetoothSocket btSocket;
+                        try {
+                            btSocket = serverSocket.accept();
+                        } catch (IOException e) {
+                            // serverSocket was closed via close() – stop the loop
+                            break;
+                        }
+                        if (btSocket == null || Thread.interrupted()) break;
+                        final BluetoothSocket accepted = btSocket;
+                        // Run each peer on its own worker so accept() is not blocked by one client.
+                        new Thread(() -> {
+                            SocketWearableConnection conn = null;
+                            try {
+                                conn = new SocketWearableConnection(proxySocket(accepted), listener);
+                                setWearableConnection(conn);
+                                try {
+                                    conn.run();
+                                } finally {
+                                    removeWearableConnection(conn);
+                                    try {
+                                        accepted.close();
+                                    } catch (IOException e) {
+                                        Log.w(TAG, "server: close error for accepted connection", e);
+                                    }
+                                }
+                            } catch (IOException e) {
+                                Log.w(TAG, "server: error on accepted connection", e);
+                                if (conn != null) {
+                                    removeWearableConnection(conn);
+                                }
+                            }
+                        }, "GmsWearBtPeer").start();
+                    }
+                } catch (IOException e) {
+                    if (!Thread.interrupted()) {
+                        Log.w(TAG, "server: socket error", e);
+                    }
+                } finally {
+                    BluetoothServerSocket s = serverSocket;
+                    serverSocket = null;
+                    if (s != null) {
+                        try { s.close(); } catch (IOException e) { Log.d(TAG, "server: close error in finally", e); }
+                    }
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates a client-side thread that connects to a known Bluetooth {@code device} via
+     * RFCOMM using {@link #WEAR_BT_UUID}.
+     *
+     * <p>Requires {@code BLUETOOTH_CONNECT} permission on API 31+.
+     *
+     * @param device   the remote Bluetooth device (e.g. the wearable)
+     * @param listener message listener for the connection
+     * @return a {@link BluetoothConnectionThread} ready to be {@link #start()}ed
+     */
+    @SuppressLint("MissingPermission")
+    public static BluetoothConnectionThread clientConnect(
+            BluetoothDevice device, WearableConnection.Listener listener) {
+        return new BluetoothConnectionThread() {
+            private volatile BluetoothSocket btSocket;
+
+            @Override
+            public void close() {
+                BluetoothSocket s = btSocket;
+                btSocket = null;
+                if (s != null) {
+                    try {
+                        s.close();
+                    } catch (IOException e) {
+                        Log.w(TAG, "client close: error", e);
+                    }
+                }
+            }
+
+            @Override
+            @SuppressLint("MissingPermission")
+            public void run() {
+                BluetoothSocket s = null;
+                try {
+                    s = device.createRfcommSocketToServiceRecord(WEAR_BT_UUID);
+                    btSocket = s;
+                    s.connect();
+                    SocketWearableConnection conn =
+                            new SocketWearableConnection(proxySocket(s), listener);
+                    setWearableConnection(conn);
+                    conn.run();
+                } catch (IOException e) {
+                    Log.w(TAG, "client: connection error", e);
+                } finally {
+                    btSocket = null;
+                    if (s != null) {
+                        try { s.close(); } catch (IOException e) { Log.d(TAG, "client: close error in finally", e); }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/CallBridge.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/CallBridge.java
@@ -1,0 +1,284 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Build;
+import android.telecom.TelecomManager;
+import android.telephony.PhoneStateListener;
+import android.telephony.TelephonyManager;
+import android.util.Log;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.lang.ref.WeakReference;
+
+/**
+ * Bridges phone call state between the Android phone and connected Wear OS peers.
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Registers a {@link PhoneStateListener} to monitor ringing / off-hook / idle state.
+ *   <li>Sends call-state updates to all connected watch nodes via
+ *       {@link WearableImpl#sendMessage} on path {@value #PHONE_PATH}.
+ *   <li>Handles call-control commands arriving from the watch on path
+ *       {@value #PHONE_COMMAND_PATH}: answer, reject/end, and silence-ringer.
+ * </ul>
+ *
+ * <h3>Phone-state payload format (path {@value #PHONE_PATH})</h3>
+ * <pre>
+ *   byte  type          0 = idle, 1 = ringing, 2 = off-hook
+ *   UTF   phoneNumber   (empty string when unavailable)
+ *   UTF   contactName   (empty string when unavailable)
+ * </pre>
+ *
+ * <h3>Command payload format (path {@value #PHONE_COMMAND_PATH})</h3>
+ * <pre>
+ *   byte  command       1 = answer, 2 = reject/end, 3 = silence ringer
+ * </pre>
+ */
+public class CallBridge {
+
+    private static final String TAG = "GmsWearCallBridge";
+
+    /** Path used to push phone-state updates to connected wearable peers. */
+    public static final String PHONE_PATH = "/wearable/phone";
+
+    /** Path on which the wearable peer sends call-control commands. */
+    public static final String PHONE_COMMAND_PATH = "/wearable/phone/command";
+
+    // Phone-state type constants (sent in the payload to the watch)
+    private static final byte STATE_IDLE     = 0;
+    private static final byte STATE_RINGING  = 1;
+    private static final byte STATE_OFFHOOK  = 2;
+
+    // Command constants (received from the watch)
+    private static final byte CMD_ANSWER  = 1;
+    private static final byte CMD_END     = 2;
+    private static final byte CMD_SILENCE = 3;
+
+    private static PhoneStateListener sPhoneStateListener;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a {@link PhoneStateListener} and begins forwarding call-state changes
+     * to all connected wearable nodes.
+     *
+     * <p>Safe to call multiple times; subsequent calls replace the previous listener.
+     */
+    public static synchronized void start(Context context, WearableImpl wearable) {
+        stop(context);
+        TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        if (tm == null) {
+            Log.w(TAG, "TelephonyManager unavailable, call monitoring disabled");
+            return;
+        }
+        sPhoneStateListener = new WearPhoneStateListener(context, wearable);
+        try {
+            tm.listen(sPhoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
+            Log.d(TAG, "call state listener registered");
+        } catch (SecurityException e) {
+            Log.w(TAG, "Missing READ_PHONE_STATE permission to listen to call state", e);
+        }
+    }
+
+    /**
+     * Unregisters the previously registered {@link PhoneStateListener}.
+     */
+    public static synchronized void stop(Context context) {
+        if (sPhoneStateListener == null) return;
+        TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        if (tm != null) {
+            tm.listen(sPhoneStateListener, PhoneStateListener.LISTEN_NONE);
+        }
+        sPhoneStateListener = null;
+        Log.d(TAG, "call state listener unregistered");
+    }
+
+    // -------------------------------------------------------------------------
+    // Call-control actions (invoked by WearableServiceImpl or command handler)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Answers the current ringing call using {@link TelecomManager}.
+     * Requires {@code android.permission.ANSWER_PHONE_CALLS} on API 26+.
+     */
+    @SuppressLint("MissingPermission")
+    public static void answerCall(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            TelecomManager tm = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
+            if (tm != null) {
+                try {
+                    tm.acceptRingingCall();
+                    Log.d(TAG, "acceptRingingCall() called");
+                } catch (SecurityException e) {
+                    Log.w(TAG, "Missing ANSWER_PHONE_CALLS permission", e);
+                }
+            }
+        } else {
+            Log.d(TAG, "answerCall: requires API 26+, ignoring");
+        }
+    }
+
+    /**
+     * Ends the current call (or rejects an incoming one) using {@link TelecomManager}.
+     * Requires {@code android.permission.ANSWER_PHONE_CALLS} on API 28+ for
+     * ending an active call.
+     */
+    @SuppressLint("MissingPermission")
+    public static void endCall(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            TelecomManager tm = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
+            if (tm != null) {
+                try {
+                    tm.endCall();
+                    Log.d(TAG, "endCall() called");
+                } catch (SecurityException e) {
+                    Log.w(TAG, "Missing ANSWER_PHONE_CALLS permission for endCall", e);
+                }
+            }
+        } else {
+            Log.d(TAG, "endCall: requires API 28+, ignoring");
+        }
+    }
+
+    /**
+     * Silences the ringer for the current incoming call without rejecting it.
+     * Uses {@link TelecomManager#silenceRinger()} on API 23+.
+     */
+    @SuppressLint("MissingPermission")
+    public static void silenceRinger(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            TelecomManager tm = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
+            if (tm != null) {
+                try {
+                    tm.silenceRinger();
+                    Log.d(TAG, "silenceRinger() called");
+                } catch (SecurityException e) {
+                    Log.w(TAG, "Missing permission for silenceRinger", e);
+                }
+            }
+        } else {
+            Log.d(TAG, "silenceRinger: requires API 23+, ignoring");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Incoming command handling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Dispatches a call-control command received from the watch.
+     *
+     * @param context application context
+     * @param data    raw payload bytes from the watch message
+     */
+    public static void handleCommand(Context context, byte[] data) {
+        if (data == null || data.length == 0) {
+            Log.w(TAG, "handleCommand: empty payload");
+            return;
+        }
+        try {
+            DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data));
+            byte command = dis.readByte();
+            Log.d(TAG, "handleCommand: command=" + command);
+            switch (command) {
+                case CMD_ANSWER:
+                    answerCall(context);
+                    break;
+                case CMD_END:
+                    endCall(context);
+                    break;
+                case CMD_SILENCE:
+                    silenceRinger(context);
+                    break;
+                default:
+                    Log.w(TAG, "handleCommand: unknown command=" + command);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "handleCommand: failed to parse payload", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Encoding helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Encodes a phone-state update payload to send to the watch.
+     *
+     * @param stateType   one of {@link #STATE_IDLE}, {@link #STATE_RINGING}, or
+     *                    {@link #STATE_OFFHOOK}
+     * @param phoneNumber incoming phone number, or empty string
+     * @param contactName resolved contact name, or empty string
+     * @return encoded bytes or {@code null} on error
+     */
+    static byte[] encodeState(byte stateType, String phoneNumber, String contactName) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataOutputStream dos = new DataOutputStream(baos);
+            dos.writeByte(stateType);
+            dos.writeUTF(phoneNumber != null ? phoneNumber : "");
+            dos.writeUTF(contactName != null ? contactName : "");
+            dos.flush();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            Log.e(TAG, "encodeState: failed", e);
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // PhoneStateListener inner class
+    // -------------------------------------------------------------------------
+
+    private static final class WearPhoneStateListener extends PhoneStateListener {
+        private final Context context;
+        // WeakReference to avoid preventing WearableImpl GC
+        private final WeakReference<WearableImpl> wearableRef;
+
+        WearPhoneStateListener(Context context, WearableImpl wearable) {
+            this.context = context.getApplicationContext();
+            this.wearableRef = new WeakReference<>(wearable);
+        }
+
+        @Override
+        public void onCallStateChanged(int state, String phoneNumber) {
+            WearableImpl wearable = wearableRef.get();
+            if (wearable == null) return;
+
+            byte type;
+            switch (state) {
+                case TelephonyManager.CALL_STATE_RINGING:
+                    type = STATE_RINGING;
+                    break;
+                case TelephonyManager.CALL_STATE_OFFHOOK:
+                    type = STATE_OFFHOOK;
+                    break;
+                default:
+                    type = STATE_IDLE;
+                    break;
+            }
+
+            Log.d(TAG, "onCallStateChanged: type=" + type + ", number=" + phoneNumber);
+            byte[] payload = encodeState(type, phoneNumber, "");
+            if (payload == null) return;
+
+            for (String nodeId : wearable.getAllConnectedNodes()) {
+                int result = wearable.sendMessage(context.getPackageName(), nodeId, PHONE_PATH, payload);
+                if (result < 0) {
+                    Log.w(TAG, "sendMessage to " + nodeId + " failed (result=" + result + ")");
+                }
+            }
+        }
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/ChannelManager.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/ChannelManager.java
@@ -1,0 +1,745 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import com.google.android.gms.wearable.internal.ChannelEventParcelable;
+import com.google.android.gms.wearable.internal.ChannelParcelable;
+
+import org.microg.wearable.proto.ChannelControlRequest;
+import org.microg.wearable.proto.ChannelDataAckRequest;
+import org.microg.wearable.proto.ChannelDataHeader;
+import org.microg.wearable.proto.ChannelDataRequest;
+import org.microg.wearable.proto.ChannelRequest;
+import org.microg.wearable.proto.Request;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import okio.ByteString;
+
+/**
+ * Manages the lifecycle and I/O for Wearable Channel API channels.
+ * <p>
+ * Uses the {@link ChannelControlRequest}, {@link ChannelDataRequest}, and
+ * {@link ChannelDataAckRequest} protocol messages to open, transfer data through,
+ * and close channels with peer WearOS nodes.
+ *
+ * <h3>ParcelFileDescriptor ownership</h3>
+ * <ul>
+ *   <li>{@link ChannelState} owns the canonical pipe ends created via
+ *       {@link ParcelFileDescriptor#createPipe()}.</li>
+ *   <li>AIDL callers receive {@link ParcelFileDescriptor#dup() duplicated} ends from
+ *       {@link #getInputStream}/{@link #getOutputStream}; closing those dups must not
+ *       tear down the canonical ends still used by the network path.</li>
+ *   <li>{@link #writeInputToFd} / {@link #readOutputFromFd} operate on dups of the
+ *       canonical ends so AutoClose streams cannot invalidate app-facing PFDs.</li>
+ *   <li>The output forwarder owns the read end of the output pipe for the lifetime of
+ *       the channel (or until EOF).</li>
+ * </ul>
+ */
+public class ChannelManager {
+    private static final String TAG = "GmsWearChannelMgr";
+
+    /** ChannelControlRequest.type values */
+    private static final int CONTROL_TYPE_OPEN = 1;
+    private static final int CONTROL_TYPE_CLOSE = 2;
+
+    /** ChannelEventParcelable.eventType values */
+    private static final int EVENT_TYPE_OPENED = 1;
+    private static final int EVENT_TYPE_CLOSED = 2;
+    private static final int EVENT_TYPE_INPUT_CLOSED = 3;
+    private static final int EVENT_TYPE_OUTPUT_CLOSED = 4;
+
+    private static final int CHUNK_SIZE = 8192;
+
+    /** Maps channelId (Long) to ChannelState */
+    private final Map<Long, ChannelState> channels = new ConcurrentHashMap<>();
+    /** Maps String token (= Long.toString(channelId)) to channelId for the public API */
+    private final Map<String, Long> tokenToId = new ConcurrentHashMap<>();
+
+    private final WearableImpl wearable;
+    private final AtomicLong nextChannelId = new AtomicLong(1);
+
+    public ChannelManager(WearableImpl wearable) {
+        this.wearable = wearable;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API called from WearableServiceImpl
+    // -------------------------------------------------------------------------
+
+    /**
+     * Opens a new channel to the given node on the given path.
+     * Sends a {@link ChannelControlRequest} OPEN message to the peer and returns a
+     * {@link ChannelParcelable} token the caller can use for subsequent operations.
+     *
+     * @param targetNodeId    the peer node to open the channel to
+     * @param path            the application-specific channel path
+     * @param packageName     calling app's package name (included in the protocol message)
+     * @param signatureDigest SHA-1 digest of the calling app's signing certificate
+     * @return a {@link ChannelParcelable}, or {@code null} on failure
+     */
+    public ChannelParcelable openChannel(String targetNodeId, String path,
+            String packageName, String signatureDigest) {
+        if (!wearable.hasActiveConnection(targetNodeId)) {
+            Log.w(TAG, "openChannel: node " + targetNodeId + " is not connected");
+            return null;
+        }
+
+        long channelId = nextChannelId.getAndIncrement();
+        String token = Long.toString(channelId);
+
+        ChannelState state = new ChannelState(token, channelId, targetNodeId, path);
+        channels.put(channelId, state);
+        tokenToId.put(token, channelId);
+
+        try {
+            sendChannelControl(targetNodeId, new ChannelControlRequest.Builder()
+                    .type(CONTROL_TYPE_OPEN)
+                    .channelId(channelId)
+                    .fromChannelOperator(true)
+                    .packageName(packageName)
+                    .signatureDigest(signatureDigest)
+                    .path(path)
+                    .build());
+        } catch (IOException e) {
+            Log.e(TAG, "openChannel: failed to send OPEN for channel " + channelId, e);
+            channels.remove(channelId);
+            tokenToId.remove(token);
+            return null;
+        }
+
+        Log.d(TAG, "Opened channel: token=" + token + ", node=" + targetNodeId + ", path=" + path);
+        return new ChannelParcelable(token, targetNodeId, path);
+    }
+
+    /**
+     * Closes the channel identified by {@code token}.
+     * Sends a {@link ChannelControlRequest} CLOSE message to the peer and notifies
+     * registered listeners with a {@link ChannelEventParcelable} CLOSED event.
+     *
+     * @param token     the channel token returned from {@link #openChannel}
+     * @param errorCode 0 for a normal close, non-zero for an error close
+     * @return {@code true} if the channel was found and closed
+     */
+    public boolean closeChannel(String token, int errorCode) {
+        Long channelId = tokenToId.remove(token);
+        if (channelId == null) {
+            Log.w(TAG, "closeChannel: unknown token " + token);
+            return false;
+        }
+        ChannelState state = channels.remove(channelId);
+        if (state == null) {
+            Log.w(TAG, "closeChannel: no state for channelId " + channelId);
+            return false;
+        }
+
+        // Null wearable is normal in unit tests; production always has WearableImpl.
+        if (wearable != null) {
+            try {
+                sendChannelControl(state.nodeId, new ChannelControlRequest.Builder()
+                        .type(CONTROL_TYPE_CLOSE)
+                        .channelId(channelId)
+                        .fromChannelOperator(true)
+                        .closeErrorCode(errorCode)
+                        .build());
+            } catch (IOException e) {
+                Log.w(TAG, "closeChannel: failed to send CLOSE for channel " + channelId, e);
+            }
+        }
+
+        synchronized (state) {
+            state.close();
+        }
+        dispatchChannelEvent(state, EVENT_TYPE_CLOSED, errorCode, 0);
+        Log.d(TAG, "Closed channel: token=" + token + ", errorCode=" + errorCode);
+        return true;
+    }
+
+    /**
+     * Returns the read-end {@link ParcelFileDescriptor} for the channel's input stream.
+     * The caller reads data from it; incoming data from the peer is written to the
+     * write-end by {@link #handleIncomingData}.
+     *
+     * @param token the channel token
+     * @return the read-end PFD, or {@code null} if the channel does not exist
+     */
+    public ParcelFileDescriptor getInputStream(String token) {
+        ChannelState state = stateForToken(token);
+        if (state == null) {
+            Log.w(TAG, "getInputStream: unknown channel " + token);
+            return null;
+        }
+        try {
+            synchronized (state) {
+                if (state.inputPipe == null) {
+                    state.inputPipe = ParcelFileDescriptor.createPipe();
+                    // Keep a long-lived writer over the write-end for incoming network data.
+                    state.inputPipeWriter = new ParcelFileDescriptor.AutoCloseOutputStream(
+                            state.inputPipe[1]);
+                }
+                // Return a dup so the caller's close (or Binder FD handoff) cannot destroy
+                // the canonical read end still owned by ChannelState.
+                return state.inputPipe[0].dup();
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "getInputStream: failed to create pipe for channel " + token, e);
+            return null;
+        }
+    }
+
+    /**
+     * Returns the write-end {@link ParcelFileDescriptor} for the channel's output stream
+     * and starts a background forwarder thread that reads from the pipe and sends
+     * {@link ChannelDataRequest} messages to the peer.
+     *
+     * @param token the channel token
+     * @return the write-end PFD, or {@code null} if the channel does not exist
+     */
+    public ParcelFileDescriptor getOutputStream(String token) {
+        ChannelState state = stateForToken(token);
+        if (state == null) {
+            Log.w(TAG, "getOutputStream: unknown channel " + token);
+            return null;
+        }
+        try {
+            synchronized (state) {
+                if (state.outputPipe == null) {
+                    state.outputPipe = ParcelFileDescriptor.createPipe();
+                    startOutputForwarder(state);
+                }
+                // Dup the write end for the AIDL caller; ChannelState keeps the canonical end.
+                return state.outputPipe[1].dup();
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "getOutputStream: failed to create pipe for channel " + token, e);
+            return null;
+        }
+    }
+
+    /**
+     * Pipes data from the channel's input stream into the given file descriptor.
+     * A background thread copies data written to the input pipe (by the peer) into {@code fd}.
+     *
+     * @param token the channel token
+     * @param fd    the destination file descriptor
+     * @return {@code true} if the background copy was started
+     */
+    public boolean writeInputToFd(String token, ParcelFileDescriptor fd) {
+        ChannelState state = stateForToken(token);
+        if (state == null) {
+            Log.w(TAG, "writeInputToFd: unknown channel " + token);
+            if (fd != null) {
+                try {
+                    fd.close();
+                } catch (IOException ignored) {
+                }
+            }
+            return false;
+        }
+        try {
+            final ParcelFileDescriptor readEndDup;
+            synchronized (state) {
+                if (state.inputPipe == null) {
+                    state.inputPipe = ParcelFileDescriptor.createPipe();
+                    state.inputPipeWriter = new ParcelFileDescriptor.AutoCloseOutputStream(
+                            state.inputPipe[1]);
+                }
+                // Dup so AutoCloseInputStream cannot close the canonical app/network read end.
+                readEndDup = state.inputPipe[0].dup();
+            }
+            new Thread(() -> {
+                try (InputStream in = new ParcelFileDescriptor.AutoCloseInputStream(readEndDup);
+                     OutputStream out = new ParcelFileDescriptor.AutoCloseOutputStream(fd)) {
+                    byte[] buf = new byte[CHUNK_SIZE];
+                    int n;
+                    while ((n = in.read(buf)) != -1) {
+                        out.write(buf, 0, n);
+                    }
+                } catch (IOException e) {
+                    Log.e(TAG, "writeInputToFd error for channel " + token, e);
+                }
+            }, "WearChanIn-" + token).start();
+            return true;
+        } catch (IOException e) {
+            Log.e(TAG, "writeInputToFd: failed to create pipe", e);
+            if (fd != null) {
+                try {
+                    fd.close();
+                } catch (IOException ignored) {
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Reads from the given file descriptor (with optional offset/length) and sends the
+     * data through the channel's output stream to the peer.
+     *
+     * @param token       the channel token
+     * @param fd          the source file descriptor
+     * @param startOffset byte offset to start reading from (0 = beginning)
+     * @param length      maximum bytes to send (-1 or 0 = until EOF)
+     * @return {@code true} if the background send was started
+     */
+    public boolean readOutputFromFd(String token, ParcelFileDescriptor fd,
+            long startOffset, long length) {
+        ChannelState state = stateForToken(token);
+        if (state == null) {
+            Log.w(TAG, "readOutputFromFd: unknown channel " + token);
+            if (fd != null) {
+                try {
+                    fd.close();
+                } catch (IOException ignored) {
+                }
+            }
+            return false;
+        }
+        try {
+            final ParcelFileDescriptor writeEndDup;
+            synchronized (state) {
+                if (state.outputPipe == null) {
+                    state.outputPipe = ParcelFileDescriptor.createPipe();
+                    startOutputForwarder(state);
+                }
+                // Dup so AutoCloseOutputStream cannot close the canonical app write end.
+                writeEndDup = state.outputPipe[1].dup();
+            }
+            new Thread(() -> {
+                try (InputStream in = new ParcelFileDescriptor.AutoCloseInputStream(fd);
+                     OutputStream out = new ParcelFileDescriptor.AutoCloseOutputStream(writeEndDup)) {
+                    if (startOffset > 0) {
+                        long remaining = startOffset;
+                        while (remaining > 0) {
+                            long skipped = in.skip(remaining);
+                            if (skipped <= 0) {
+                                // Fall back to read-and-discard; pure skip may return 0 before EOF.
+                                byte[] discard = new byte[(int) Math.min(remaining, CHUNK_SIZE)];
+                                int r = in.read(discard);
+                                if (r < 0) {
+                                    Log.w(TAG, "readOutputFromFd: EOF after skipping "
+                                            + (startOffset - remaining) + "/" + startOffset
+                                            + " for channel " + token);
+                                    return;
+                                }
+                                remaining -= r;
+                            } else {
+                                remaining -= skipped;
+                            }
+                        }
+                    }
+                    byte[] buf = new byte[CHUNK_SIZE];
+                    long total = 0;
+                    int n;
+                    while ((n = in.read(buf)) != -1) {
+                        if (length > 0 && total + n > length) {
+                            out.write(buf, 0, (int) (length - total));
+                            break;
+                        }
+                        out.write(buf, 0, n);
+                        total += n;
+                    }
+                } catch (IOException e) {
+                    Log.e(TAG, "readOutputFromFd error for channel " + token, e);
+                }
+            }, "WearChanOut-" + token).start();
+            return true;
+        } catch (IOException e) {
+            Log.e(TAG, "readOutputFromFd: failed to create pipe", e);
+            if (fd != null) {
+                try {
+                    fd.close();
+                } catch (IOException ignored) {
+                }
+            }
+            return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Incoming message handling (called from MessageHandler)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Dispatches an incoming {@link Request} from the peer that was received on the
+     * {@code channelRequest} field of a {@link org.microg.wearable.proto.RootMessage}.
+     * <p>
+     * Handles channel open, close, data, and data-ack sub-messages.
+     *
+     * @param sourceNodeId the peer node that sent the message
+     * @param request      the channel request proto
+     */
+    public void handleIncomingChannelMessage(String sourceNodeId, Request request) {
+        if (request == null || request.request == null) {
+            Log.w(TAG, "handleIncomingChannelMessage: null or empty request from " + sourceNodeId);
+            return;
+        }
+        ChannelRequest cr = request.request;
+        if (cr.channelControlRequest != null) {
+            handleIncomingControl(sourceNodeId, request.path, cr.channelControlRequest);
+        } else if (cr.channelDataRequest != null) {
+            handleIncomingData(cr.channelDataRequest);
+        } else if (cr.channelDataAckRequest != null) {
+            handleIncomingDataAck(cr.channelDataAckRequest);
+        } else {
+            Log.w(TAG, "handleIncomingChannelMessage: unrecognised sub-message from " + sourceNodeId);
+        }
+    }
+
+    /**
+     * Legacy entry point preserved for callers that do not yet pass the full
+     * {@link Request}. Treats every call as a new channel-open request from the peer.
+     *
+     * @deprecated Use {@link #handleIncomingChannelMessage(String, Request)} instead.
+     */
+    @Deprecated
+    public void handleIncomingChannelRequest(String sourceNodeId, String path, String token) {
+        long channelId = nextChannelId.getAndIncrement();
+        String newToken = Long.toString(channelId);
+        ChannelState state = new ChannelState(newToken, channelId, sourceNodeId, path);
+        channels.put(channelId, state);
+        tokenToId.put(newToken, channelId);
+        Log.d(TAG, "Accepted incoming channel (legacy) from " + sourceNodeId
+                + ": path=" + path + ", token=" + newToken);
+        dispatchChannelEvent(state, EVENT_TYPE_OPENED, 0, 0);
+    }
+
+    /**
+     * Returns {@code true} if the given token corresponds to an open channel.
+     */
+    public boolean isChannelOpen(String token) {
+        Long id = tokenToId.get(token);
+        return id != null && channels.containsKey(id);
+    }
+
+    /**
+     * Closes all open channels. Called during service shutdown.
+     */
+        public void closeAll() {
+        for (ChannelState state : new ArrayList<>(channels.values())) {
+            synchronized (state) {
+                state.close();
+            }
+        }
+        channels.clear();
+        tokenToId.clear();
+        Log.d(TAG, "All channels closed");
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private ChannelState stateForToken(String token) {
+        Long id = tokenToId.get(token);
+        return id != null ? channels.get(id) : null;
+    }
+
+    private void handleIncomingControl(String sourceNodeId, String requestPath,
+            ChannelControlRequest ctrl) {
+        int type = ctrl.type != null ? ctrl.type : 0;
+        long channelId = ctrl.channelId != null ? ctrl.channelId : -1L;
+        String path = ctrl.path != null ? ctrl.path : requestPath;
+
+        if (channelId <= 0) {
+            // Channel IDs start at 1 (locally) and must be positive; 0 and negative values
+            // indicate a missing/unset field in the proto and should be ignored.
+            Log.w(TAG, "handleIncomingControl: invalid channelId=" + channelId
+                    + ", type=" + type + ", ignoring");
+            return;
+        }
+
+        if (type == CONTROL_TYPE_OPEN) {
+            // Advance our local counter past any peer-assigned id to prevent collisions.
+            // Use a CAS loop instead of updateAndGet (which requires API 24) for API 19 compat.
+            long minId = channelId + 1;
+            long current;
+            do {
+                current = nextChannelId.get();
+                if (current >= minId) break;
+            } while (!nextChannelId.compareAndSet(current, minId));
+            ChannelState existing = channels.get(channelId);
+            if (existing != null) {
+                // A second OPEN for a live id must not replace the first ChannelState.
+                // Do not send CLOSE here: tests construct ChannelManager(null) and
+                // sendChannelControl requires a non-null WearableImpl.
+                Log.w(TAG, "handleIncomingControl: colliding OPEN for live channelId="
+                        + channelId + " path=" + existing.path + "; ignoring " + path);
+                return;
+            }
+            String token = Long.toString(channelId);
+            ChannelState state = new ChannelState(token, channelId, sourceNodeId, path);
+            channels.put(channelId, state);
+            tokenToId.put(token, channelId);
+            Log.d(TAG, "Peer opened channel: id=" + channelId + ", path=" + path
+                    + ", from=" + sourceNodeId);
+            dispatchChannelEvent(state, EVENT_TYPE_OPENED, 0, 0);
+
+        } else if (type == CONTROL_TYPE_CLOSE) {
+            String token = Long.toString(channelId);
+            tokenToId.remove(token);
+            ChannelState state = channels.remove(channelId);
+            if (state != null) {
+                int errorCode = ctrl.closeErrorCode != null ? ctrl.closeErrorCode : 0;
+                state.close();
+                dispatchChannelEvent(state, EVENT_TYPE_CLOSED, errorCode, 0);
+                Log.d(TAG, "Peer closed channel: id=" + channelId + ", errorCode=" + errorCode);
+            }
+        } else {
+            Log.w(TAG, "handleIncomingControl: unknown type=" + type);
+        }
+    }
+
+    private void handleIncomingData(ChannelDataRequest data) {
+        if (data.header == null) {
+            Log.w(TAG, "handleIncomingData: null header");
+            return;
+        }
+        long channelId = data.header.channelId != null ? data.header.channelId : -1L;
+        ChannelState state = channels.get(channelId);
+        if (state == null) {
+            Log.w(TAG, "handleIncomingData: unknown channelId " + channelId);
+            return;
+        }
+        synchronized (state) {
+            try {
+                if (state.inputPipe == null) {
+                    state.inputPipe = ParcelFileDescriptor.createPipe();
+                }
+                if (state.inputPipeWriter == null && state.inputPipe[1] != null) {
+                    // Open a single OutputStream over the write-end PFD and keep it alive
+                    // across all chunks. Wrapping the PFD rather than its raw FileDescriptor
+                    // ensures the FD is NOT closed when the stream would otherwise be closed.
+                    state.inputPipeWriter = new ParcelFileDescriptor.AutoCloseOutputStream(
+                            state.inputPipe[1]);
+                }
+                if (data.payload != null && data.payload.size() > 0) {
+                    try {
+                        state.inputPipeWriter.write(data.payload.toByteArray());
+                    } catch (IOException e) {
+                        // Reset on write error so the next message re-creates the pipe
+                        try { state.inputPipeWriter.close(); } catch (IOException ignored) { }
+                        if (state.inputPipe != null) {
+                            if (state.inputPipe[0] != null) {
+                                try { state.inputPipe[0].close(); } catch (IOException ignored) { }
+                            }
+                            if (state.inputPipe[1] != null) {
+                                try { state.inputPipe[1].close(); } catch (IOException ignored) { }
+                            }
+                        }
+                        state.inputPipeWriter = null;
+                        state.inputPipe = null;
+                        Log.e(TAG, "handleIncomingData: write error for channel " + channelId, e);
+                        return;
+                    }
+                }
+                if (Boolean.TRUE.equals(data.finalMessage)) {
+                    // Peer has finished sending; close the write-end to signal EOF to the reader.
+                    // The read-end (inputPipe[0]) is kept alive so the app can drain remaining data;
+                    // it will be released when the channel itself is closed via state.close().
+                    if (state.inputPipeWriter != null) {
+                        try { state.inputPipeWriter.close(); } catch (IOException ignored) { }
+                        state.inputPipeWriter = null;
+                    }
+                    if (state.inputPipe != null) {
+                        state.inputPipe[1] = null; // write-end closed by inputPipeWriter above
+                    }
+                    dispatchChannelEvent(state, EVENT_TYPE_INPUT_CLOSED, 0, 0);
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "handleIncomingData: pipe creation failed for channel " + channelId, e);
+            }
+        }
+    }
+
+    private void handleIncomingDataAck(ChannelDataAckRequest ack) {
+        if (ack.header == null) return;
+        long channelId = ack.header.channelId != null ? ack.header.channelId : -1L;
+        Log.d(TAG, "handleIncomingDataAck: channelId=" + channelId
+                + ", final=" + ack.finalMessage);
+        if (Boolean.TRUE.equals(ack.finalMessage)) {
+            ChannelState state = channels.get(channelId);
+            if (state != null) {
+                dispatchChannelEvent(state, EVENT_TYPE_OUTPUT_CLOSED, 0, 0);
+            }
+        }
+    }
+
+    /**
+     * Starts a background thread that reads from {@code state.outputPipe[0]} and
+     * forwards data to the peer as {@link ChannelDataRequest} messages.
+     * <p>
+     * Precondition: {@code state.outputPipe} must already be initialised.
+     */
+    private void startOutputForwarder(ChannelState state) {
+        if (wearable == null) {
+            Log.w(TAG, "startOutputForwarder: no WearableImpl; skip network forwarder for channel "
+                    + state.channelId);
+            return;
+        }
+        final ParcelFileDescriptor readEnd;
+        // Caller must hold synchronized(state) when creating the pipe / starting the forwarder.
+        try {
+            // Forwarder holds its own dup; ChannelState retains the canonical read end.
+            readEnd = state.outputPipe[0].dup();
+        } catch (IOException e) {
+            Log.e(TAG, "startOutputForwarder: failed to dup output read end for channel "
+                    + state.channelId, e);
+            return;
+        }
+        final WearableImpl wearableRef = wearable;
+        new Thread(() -> {
+            try (InputStream in = new ParcelFileDescriptor.AutoCloseInputStream(readEnd)) {
+                byte[] buf = new byte[CHUNK_SIZE];
+                int n;
+                long requestId = 0;
+                while ((n = in.read(buf)) != -1) {
+                    byte[] chunk = new byte[n];
+                    System.arraycopy(buf, 0, chunk, 0, n);
+                    ChannelDataRequest dataMsg = new ChannelDataRequest.Builder()
+                            .header(new ChannelDataHeader.Builder()
+                                    .channelId(state.channelId)
+                                    .fromChannelOperator(true)
+                                    .requestId(requestId++)
+                                    .build())
+                            .payload(ByteString.of(chunk))
+                            .finalMessage(false)
+                            .build();
+                    try {
+                        wearableRef.sendChannelMessage(state.nodeId,
+                                new Request.Builder()
+                                        .path(state.path)
+                                        .sourceNodeId(wearableRef.getLocalNodeId())
+                                        .targetNodeId(state.nodeId)
+                                        .request(new ChannelRequest.Builder()
+                                                .channelDataRequest(dataMsg)
+                                                .build())
+                                        .build());
+                    } catch (IOException e) {
+                        Log.e(TAG, "Output forwarder: send error for channel "
+                                + state.channelId, e);
+                        break;
+                    }
+                }
+                // EOF — send a final message to signal the peer that the stream is done
+                try {
+                    wearableRef.sendChannelMessage(state.nodeId,
+                            new Request.Builder()
+                                    .path(state.path)
+                                    .sourceNodeId(wearableRef.getLocalNodeId())
+                                    .targetNodeId(state.nodeId)
+                                    .request(new ChannelRequest.Builder()
+                                            .channelDataRequest(new ChannelDataRequest.Builder()
+                                                    .header(new ChannelDataHeader.Builder()
+                                                            .channelId(state.channelId)
+                                                            .fromChannelOperator(true)
+                                                            .requestId(-1L)
+                                                            .build())
+                                                    .payload(ByteString.EMPTY)
+                                                    .finalMessage(true)
+                                                    .build())
+                                            .build())
+                                    .build());
+                } catch (IOException e) {
+                    Log.w(TAG, "Output forwarder: failed to send final for channel "
+                            + state.channelId, e);
+                }
+                dispatchChannelEvent(state, EVENT_TYPE_OUTPUT_CLOSED, 0, 0);
+            } catch (IOException e) {
+                Log.e(TAG, "Output forwarder: pipe read error for channel "
+                        + state.channelId, e);
+            }
+        }, "WearChanFwd-" + state.channelId).start();
+    }
+
+    private void sendChannelControl(String targetNodeId, ChannelControlRequest ctrl)
+            throws IOException {
+        wearable.sendChannelMessage(targetNodeId,
+                new Request.Builder()
+                        .path(ctrl.path != null ? ctrl.path : "")
+                        .sourceNodeId(wearable.getLocalNodeId())
+                        .targetNodeId(targetNodeId)
+                        .request(new ChannelRequest.Builder()
+                                .channelControlRequest(ctrl)
+                                .build())
+                        .build());
+    }
+
+    private void dispatchChannelEvent(ChannelState state, int eventType,
+            int closeReason, int appSpecificErrorCode) {
+        if (wearable == null) {
+            return;
+        }
+        ChannelEventParcelable event = new ChannelEventParcelable();
+        event.channel = new ChannelParcelable(state.token, state.nodeId, state.path);
+        event.eventType = eventType;
+        event.closeReason = closeReason;
+        event.appSpecificErrorCode = appSpecificErrorCode;
+        wearable.invokeChannelEvent(event);
+    }
+
+    // -------------------------------------------------------------------------
+    // ChannelState
+    // -------------------------------------------------------------------------
+
+    private static class ChannelState {
+        final String token;
+        final long channelId;
+        final String nodeId;
+        final String path;
+        ParcelFileDescriptor[] inputPipe;  // [0]=read end (given to app), [1]=write end (filled by network)
+        ParcelFileDescriptor[] outputPipe; // [0]=read end (read by forwarder), [1]=write end (given to app)
+        /** Kept open across chunks so the write-end FD is never closed between messages. */
+        OutputStream inputPipeWriter;
+
+        ChannelState(String token, long channelId, String nodeId, String path) {
+            this.token = token;
+            this.channelId = channelId;
+            this.nodeId = nodeId;
+            this.path = path;
+        }
+
+        /** Caller should hold synchronized(this) when closing an active channel. */
+        void close() {
+            if (inputPipeWriter != null) {
+                try {
+                    inputPipeWriter.close();
+                } catch (IOException ignored) {
+                } catch (RuntimeException ignored) {
+                    // Robolectric / double-close safety
+                }
+                inputPipeWriter = null;
+            }
+            closePipe(inputPipe);
+            closePipe(outputPipe);
+            inputPipe = null;
+            outputPipe = null;
+        }
+
+        private static void closePipe(ParcelFileDescriptor[] pipe) {
+            if (pipe == null) return;
+            for (ParcelFileDescriptor fd : pipe) {
+                if (fd != null) {
+                    try {
+                        fd.close();
+                    } catch (IOException ignored) {
+                    } catch (RuntimeException ignored) {
+                        // Robolectric may NPE when closing an already-closed / detached PFD.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/MediaBridge.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/MediaBridge.java
@@ -1,0 +1,400 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.media.AudioManager;
+import android.media.MediaMetadata;
+import android.media.session.MediaController;
+import android.media.session.MediaSession;
+import android.media.session.MediaSessionManager;
+import android.media.session.PlaybackState;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.lang.ref.WeakReference;
+import java.util.List;
+
+/**
+ * Bridges media playback state between the Android phone and connected Wear OS peers.
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Listens for active media-session changes via {@link MediaSessionManager}.
+ *   <li>Attaches a {@link MediaController.Callback} to the first active session to receive
+ *       metadata and playback-state updates.
+ *   <li>Sends media-state updates to all connected watch nodes via
+ *       {@link WearableImpl#sendMessage} on path {@value #MEDIA_PATH}.
+ *   <li>Handles media-control commands arriving from the watch on path
+ *       {@value #MEDIA_COMMAND_PATH}: play, pause, next, previous, volume up/down.
+ * </ul>
+ *
+ * <h3>Media-state payload format (path {@value #MEDIA_PATH})</h3>
+ * <pre>
+ *   byte  state    0 = paused / stopped, 1 = playing
+ *   UTF   title    (empty string when unavailable)
+ *   UTF   artist   (empty string when unavailable)
+ *   UTF   album    (empty string when unavailable)
+ *   long  position current playback position in milliseconds (−1 when unknown)
+ *   long  duration track duration in milliseconds (−1 when unknown)
+ * </pre>
+ *
+ * <h3>Command payload format (path {@value #MEDIA_COMMAND_PATH})</h3>
+ * <pre>
+ *   byte  command  1 = play, 2 = pause, 3 = next, 4 = previous,
+ *                  5 = volume up, 6 = volume down
+ * </pre>
+ *
+ * <p>Requires API 21+ ({@link Build.VERSION_CODES#LOLLIPOP}) for
+ * {@link MediaSessionManager} and {@link MediaController}.
+ */
+public class MediaBridge {
+
+    private static final String TAG = "GmsWearMediaBridge";
+
+    /** Path used to push media-state updates to connected wearable peers. */
+    public static final String MEDIA_PATH = "/wearable/media";
+
+    /** Path on which the wearable peer sends media-control commands. */
+    public static final String MEDIA_COMMAND_PATH = "/wearable/media/command";
+
+    /** Component name of the in-process {@link android.service.notification.NotificationListenerService}. */
+    private static final String NOTIFICATION_LISTENER_CLASS =
+            "org.microg.gms.wearable.notification.WearableNotificationService";
+    private static final byte STATE_PAUSED  = 0;
+    private static final byte STATE_PLAYING = 1;
+
+    // Command constants (received from the watch)
+    private static final byte CMD_PLAY        = 1;
+    private static final byte CMD_PAUSE       = 2;
+    private static final byte CMD_NEXT        = 3;
+    private static final byte CMD_PREVIOUS    = 4;
+    private static final byte CMD_VOLUME_UP   = 5;
+    private static final byte CMD_VOLUME_DOWN = 6;
+
+    private static MediaSessionManager.OnActiveSessionsChangedListener sSessionsChangedListener;
+    private static MediaController sActiveController;
+    private static MediaController.Callback sControllerCallback;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Starts monitoring active media sessions and registering a playback callback
+     * on the currently active controller.
+     *
+     * <p>Requires API 21+; silently exits on older versions.
+     *
+     * @param context  application context
+     * @param wearable the running {@link WearableImpl} instance to forward updates to
+     */
+    public static synchronized void start(Context context, WearableImpl wearable) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            Log.d(TAG, "start: MediaSessionManager requires API 21+, skipping");
+            return;
+        }
+        stop(context);
+
+        MediaSessionManager msm =
+                (MediaSessionManager) context.getSystemService(Context.MEDIA_SESSION_SERVICE);
+        if (msm == null) {
+            Log.w(TAG, "start: MediaSessionManager unavailable");
+            return;
+        }
+
+        sSessionsChangedListener = new WearSessionsChangedListener(context, wearable);
+
+        // The NotificationListenerService component name is required to call
+        // getActiveSessions().  Using the WearableNotificationService which is
+        // already running in this process.
+        ComponentName notifListenerComponent = new ComponentName(
+                context, NOTIFICATION_LISTENER_CLASS);
+        try {
+            msm.addOnActiveSessionsChangedListener(sSessionsChangedListener, notifListenerComponent);
+            // Trigger an initial update for the currently active session.
+            List<MediaController> sessions = msm.getActiveSessions(notifListenerComponent);
+            sSessionsChangedListener.onActiveSessionsChanged(sessions);
+            Log.d(TAG, "start: media session listener registered");
+        } catch (SecurityException e) {
+            Log.w(TAG, "start: no permission to list media sessions", e);
+        }
+    }
+
+    /**
+     * Stops monitoring media sessions and detaches any active playback callback.
+     */
+    public static synchronized void stop(Context context) {
+        detachController();
+        if (sSessionsChangedListener == null) return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            MediaSessionManager msm =
+                    (MediaSessionManager) context.getSystemService(Context.MEDIA_SESSION_SERVICE);
+            if (msm != null) {
+                try {
+                    msm.removeOnActiveSessionsChangedListener(sSessionsChangedListener);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        sSessionsChangedListener = null;
+        Log.d(TAG, "stop: media session listener unregistered");
+    }
+
+    // -------------------------------------------------------------------------
+    // Incoming command handling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Dispatches a media-control command received from the watch to the currently
+     * active {@link MediaController}, or adjusts system volume for volume commands.
+     *
+     * @param context application context
+     * @param data    raw payload bytes from the watch message
+     */
+    public static void handleCommand(Context context, byte[] data) {
+        if (data == null || data.length == 0) {
+            Log.w(TAG, "handleCommand: empty payload");
+            return;
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            Log.d(TAG, "handleCommand: requires API 21+, ignoring");
+            return;
+        }
+        try {
+            DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data));
+            byte command = dis.readByte();
+            Log.d(TAG, "handleCommand: command=" + command);
+
+            MediaController.TransportControls controls =
+                    sActiveController != null ? sActiveController.getTransportControls() : null;
+
+            switch (command) {
+                case CMD_PLAY:
+                    if (controls != null) controls.play();
+                    break;
+                case CMD_PAUSE:
+                    if (controls != null) controls.pause();
+                    break;
+                case CMD_NEXT:
+                    if (controls != null) controls.skipToNext();
+                    break;
+                case CMD_PREVIOUS:
+                    if (controls != null) controls.skipToPrevious();
+                    break;
+                case CMD_VOLUME_UP:
+                    adjustVolume(context, AudioManager.ADJUST_RAISE);
+                    break;
+                case CMD_VOLUME_DOWN:
+                    adjustVolume(context, AudioManager.ADJUST_LOWER);
+                    break;
+                default:
+                    Log.w(TAG, "handleCommand: unknown command=" + command);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "handleCommand: failed to parse payload", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private static void adjustVolume(Context context, int direction) {
+        AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (am != null) {
+            am.adjustStreamVolume(AudioManager.STREAM_MUSIC, direction, 0);
+        }
+    }
+
+    private static synchronized void detachController() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+        if (sActiveController != null && sControllerCallback != null) {
+            sActiveController.unregisterCallback(sControllerCallback);
+        }
+        sActiveController = null;
+        sControllerCallback = null;
+    }
+
+    private static synchronized void attachController(
+            MediaController controller, Context context, WearableImpl wearable) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+        detachController();
+        if (controller == null) return;
+        sActiveController = controller;
+        sControllerCallback = new WearControllerCallback(context, wearable);
+        controller.registerCallback(sControllerCallback);
+        Log.d(TAG, "attachController: " + controller.getPackageName());
+        // Send the current state immediately so the watch is up-to-date.
+        sendCurrentState(context, wearable, controller);
+    }
+
+    private static void sendCurrentState(
+            Context context, WearableImpl wearable, MediaController controller) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+        byte[] payload = encodeState(controller);
+        if (payload == null) return;
+        for (String nodeId : wearable.getAllConnectedNodes()) {
+            int result = wearable.sendMessage(context.getPackageName(), nodeId, MEDIA_PATH, payload);
+            if (result < 0) {
+                Log.w(TAG, "sendCurrentState: sendMessage to " + nodeId + " failed");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Encoding helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Encodes the current playback state of {@code controller} into a byte array
+     * to send to the watch.
+     *
+     * @return encoded bytes or {@code null} on error / missing state
+     */
+    static byte[] encodeState(MediaController controller) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return null;
+        try {
+            PlaybackState ps = controller.getPlaybackState();
+            MediaMetadata mm = controller.getMetadata();
+
+            byte playingByte = STATE_PAUSED;
+            long position = -1L;
+            if (ps != null) {
+                int psState = ps.getState();
+                if (psState == PlaybackState.STATE_PLAYING
+                        || psState == PlaybackState.STATE_BUFFERING
+                        || psState == PlaybackState.STATE_FAST_FORWARDING
+                        || psState == PlaybackState.STATE_REWINDING) {
+                    playingByte = STATE_PLAYING;
+                }
+                position = ps.getPosition();
+            }
+
+            String title  = "";
+            String artist = "";
+            String album  = "";
+            long duration = -1L;
+            if (mm != null) {
+                CharSequence t = mm.getText(MediaMetadata.METADATA_KEY_TITLE);
+                CharSequence ar = mm.getText(MediaMetadata.METADATA_KEY_ARTIST);
+                CharSequence al = mm.getText(MediaMetadata.METADATA_KEY_ALBUM);
+                if (t  != null) title  = t.toString();
+                if (ar != null) artist = ar.toString();
+                if (al != null) album  = al.toString();
+                duration = mm.getLong(MediaMetadata.METADATA_KEY_DURATION);
+            }
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataOutputStream dos = new DataOutputStream(baos);
+            dos.writeByte(playingByte);
+            dos.writeUTF(title);
+            dos.writeUTF(artist);
+            dos.writeUTF(album);
+            dos.writeLong(position);
+            dos.writeLong(duration);
+            dos.flush();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            Log.e(TAG, "encodeState: failed", e);
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner listener classes
+    // -------------------------------------------------------------------------
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private static final class WearSessionsChangedListener
+            implements MediaSessionManager.OnActiveSessionsChangedListener {
+        private final Context context;
+        private final WeakReference<WearableImpl> wearableRef;
+
+        WearSessionsChangedListener(Context context, WearableImpl wearable) {
+            this.context = context.getApplicationContext();
+            this.wearableRef = new WeakReference<>(wearable);
+        }
+
+        @Override
+        public void onActiveSessionsChanged(List<MediaController> controllers) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+            WearableImpl wearable = wearableRef.get();
+            if (wearable == null) return;
+
+            MediaController first = (controllers != null && !controllers.isEmpty())
+                    ? controllers.get(0) : null;
+            Log.d(TAG, "onActiveSessionsChanged: first="
+                    + (first != null ? first.getPackageName() : "none"));
+            attachController(first, context, wearable);
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private static final class WearControllerCallback extends MediaController.Callback {
+        private final Context context;
+        private final WeakReference<WearableImpl> wearableRef;
+
+        WearControllerCallback(Context context, WearableImpl wearable) {
+            this.context = context.getApplicationContext();
+            this.wearableRef = new WeakReference<>(wearable);
+        }
+
+        @Override
+        public void onPlaybackStateChanged(PlaybackState state) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+            dispatch();
+        }
+
+        @Override
+        public void onMetadataChanged(MediaMetadata metadata) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+            dispatch();
+        }
+
+        @Override
+        public void onSessionDestroyed() {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return;
+            Log.d(TAG, "onSessionDestroyed");
+            WearableImpl wearable = wearableRef.get();
+            if (wearable == null) return;
+            // Send a "paused / stopped" empty state to the watch.
+            try {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream dos = new DataOutputStream(baos);
+                dos.writeByte(STATE_PAUSED);
+                dos.writeUTF("");
+                dos.writeUTF("");
+                dos.writeUTF("");
+                dos.writeLong(-1L);
+                dos.writeLong(-1L);
+                dos.flush();
+                byte[] payload = baos.toByteArray();
+                for (String nodeId : wearable.getAllConnectedNodes()) {
+                    wearable.sendMessage(context.getPackageName(), nodeId, MEDIA_PATH, payload);
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "onSessionDestroyed: failed to encode stop state", e);
+            }
+            detachController();
+        }
+
+        private void dispatch() {
+            MediaController controller = sActiveController;
+            if (controller == null) return;
+            WearableImpl wearable = wearableRef.get();
+            if (wearable == null) return;
+            sendCurrentState(context, wearable, controller);
+        }
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/MessageHandler.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/MessageHandler.java
@@ -76,8 +76,9 @@ public class MessageHandler extends ServerMessageListener {
                     .version(2)
                     .syncTable(Arrays.asList(
                             new SyncTableEntry.Builder().key("cloud").value(1L).build(),
-                            new SyncTableEntry.Builder().key(wearable.getLocalNodeId()).value(wearable.getCurrentSeqId(wearable.getLocalNodeId())).build(), // TODO
-                            new SyncTableEntry.Builder().key(peerNodeId).value(wearable.getCurrentSeqId(peerNodeId)).build() // TODO
+                            // seqId tracks the last message received from each node; init with current seq
+                            new SyncTableEntry.Builder().key(wearable.getLocalNodeId()).value(wearable.getCurrentSeqId(wearable.getLocalNodeId())).build(),
+                            new SyncTableEntry.Builder().key(peerNodeId).value(wearable.getCurrentSeqId(peerNodeId)).build()
                     )).build()).build());
         } catch (IOException e) {
             Log.w(TAG, e);
@@ -153,7 +154,7 @@ public class MessageHandler extends ServerMessageListener {
         } else if (rpcRequest.targetNodeId.equals(peerNodeId)) {
             // Drop it
         } else {
-            // TODO: find next hop
+            // No multi-hop routing: drop the message (WearOS uses direct peer-to-peer connections only)
         }
         try {
             getConnection().writeMessage(new RootMessage.Builder().heartbeat(new Heartbeat()).build());
@@ -176,5 +177,8 @@ public class MessageHandler extends ServerMessageListener {
     @Override
     public void onChannelRequest(Request channelRequest) {
         Log.d(TAG, "onChannelRequest:" + channelRequest);
+        String sourceNodeId = channelRequest.sourceNodeId != null ? channelRequest.sourceNodeId : peerNodeId;
+        // Route to the full handler so open/data/close sub-messages are all processed
+        wearable.getChannelManager().handleIncomingChannelMessage(sourceNodeId, channelRequest);
     }
 }

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/NodeDatabaseHelper.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/NodeDatabaseHelper.java
@@ -96,10 +96,28 @@ public class NodeDatabaseHelper extends SQLiteOpenHelper {
         return getDataItemsByHostAndPath(getReadableDatabase(), packageName, signatureDigest, host, path);
     }
 
+    /**
+     * Returns a cursor with columns (host, capability) for all non-deleted capability data items.
+     * Capabilities are stored as data items with path '/capabilities/&lt;pkg&gt;/&lt;sig&gt;/&lt;capabilityName&gt;'.
+     */
+    public synchronized Cursor getAllCapabilityItems() {
+        // Paths always match '/capabilities/...', so the last segment (the capability name) is
+        // everything after the final '/'.  We use rtrim+replace to locate that last '/' without
+        // relying on the non-standard reverse() function that is absent from stock SQLite.
+        return getReadableDatabase().rawQuery(
+                "SELECT DISTINCT host, " +
+                "substr(path, length(rtrim(path, replace(path, '/', ''))) + 1) AS capability " +
+                "FROM appKeyDataItems " +
+                "WHERE path LIKE '/capabilities/%' AND deleted=0",
+                null);
+    }
+
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         if (oldVersion != VERSION) {
-            // TODO: Upgrade not supported, cleaning up
+            // Schema upgrades are not implemented: reset all tables on version change.
+            // This is acceptable for v1 since the database is private to GmsCore and there
+            // is no user data that must be preserved across upgrades.
             db.execSQL("DROP TABLE IF EXISTS appkeys;");
             db.execSQL("DROP TABLE IF EXISTS dataitems;");
             db.execSQL("DROP TABLE IF EXISTS assets;");

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/NotificationBridge.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/NotificationBridge.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+import android.service.notification.StatusBarNotification;
+import android.util.Log;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Shared bridge between {@link WearableServiceImpl} and the in-process
+ * {@code WearableNotificationService} (play-services-core).
+ * <p>
+ * {@code WearableNotificationService} populates {@link #activeNotifications}
+ * so that ANCS action requests from a Wear OS peer can be dispatched to the
+ * correct Android notification.
+ */
+public class NotificationBridge {
+
+    private static final String TAG = "GmsWearNotifBridge";
+
+    /** Path on which the wearable peer sends notification-control commands. */
+    public static final String NOTIFICATION_COMMAND_PATH = "/wearable/notification/command";
+
+    /** Positive / content action (first Notification.Action or contentIntent). */
+    public static final byte CMD_POSITIVE = 1;
+
+    /** Negative action: dismiss / cancel the notification. */
+    public static final byte CMD_NEGATIVE = 2;
+
+    /**
+     * Maps notification UID (the value sent to the wearable peer) to the live
+     * {@link StatusBarNotification}.  Entries are added/removed by the
+     * {@code WearableNotificationService} running in the same process.
+     */
+    public static final Map<Integer, StatusBarNotification> activeNotifications =
+            new ConcurrentHashMap<>();
+
+
+    /**
+     * Dispatches a notification-control command received from the watch.
+     *
+     * <p>Payload format:
+     * <pre>
+     *   byte action  1 = positive, 2 = negative
+     *   int  uid     notification uid previously assigned by WearableNotificationService
+     * </pre>
+     */
+    public static void handleCommand(Context context, byte[] data) {
+        if (data == null || data.length < 5) {
+            Log.w(TAG, "handleCommand: empty or short payload");
+            return;
+        }
+        try {
+            java.io.DataInputStream dis =
+                    new java.io.DataInputStream(new java.io.ByteArrayInputStream(data));
+            byte action = dis.readByte();
+            int uid = dis.readInt();
+            Log.d(TAG, "handleCommand: action=" + action + ", uid=" + uid);
+            switch (action) {
+                case CMD_POSITIVE:
+                    doPositiveAction(context, uid);
+                    break;
+                case CMD_NEGATIVE:
+                    doNegativeAction(context, uid);
+                    break;
+                default:
+                    Log.w(TAG, "handleCommand: unknown action=" + action);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "handleCommand: failed to parse payload", e);
+        }
+    }
+
+    /**
+     * Executes the <em>positive</em> ANCS action for {@code uid}: fires the first
+     * {@link android.app.Notification.Action} on the notification if one exists.
+     */
+    public static void doPositiveAction(Context context, int uid) {
+        StatusBarNotification sbn = activeNotifications.get(uid);
+        if (sbn == null) {
+            Log.d(TAG, "doPositiveAction: no notification for uid=" + uid);
+            return;
+        }
+        Notification n = sbn.getNotification();
+        if (n == null) return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            Notification.Action[] actions = n.actions;
+            if (actions != null && actions.length > 0 && actions[0].actionIntent != null) {
+                try {
+                    actions[0].actionIntent.send(context, 0, null);
+                } catch (Exception e) {
+                    Log.w(TAG, "doPositiveAction: PendingIntent.send() failed", e);
+                }
+                return;
+            }
+        }
+        // No action available — fall back to content intent
+        if (n.contentIntent != null) {
+            try {
+                n.contentIntent.send(context, 0, null);
+            } catch (Exception e) {
+                Log.w(TAG, "doPositiveAction: contentIntent.send() failed", e);
+            }
+        }
+    }
+
+    /**
+     * Executes the <em>negative</em> ANCS action for {@code uid}: dismisses / cancels
+     * the notification.
+     */
+    public static void doNegativeAction(Context context, int uid) {
+        StatusBarNotification sbn = activeNotifications.get(uid);
+        if (sbn == null) {
+            Log.d(TAG, "doNegativeAction: no notification for uid=" + uid);
+            return;
+        }
+        NotificationManager nm =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                nm.cancel(sbn.getTag(), sbn.getId());
+            }
+        }
+        activeNotifications.remove(uid);
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java
@@ -16,6 +16,8 @@
 
 package org.microg.gms.wearable;
 
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -34,6 +36,7 @@ import com.google.android.gms.common.data.DataHolder;
 import com.google.android.gms.wearable.Asset;
 import com.google.android.gms.wearable.ConnectionConfiguration;
 import com.google.android.gms.wearable.Node;
+import com.google.android.gms.wearable.internal.CapabilityInfoParcelable;
 import com.google.android.gms.wearable.internal.IWearableListener;
 import com.google.android.gms.wearable.internal.MessageEventParcelable;
 import com.google.android.gms.wearable.internal.NodeParcelable;
@@ -43,6 +46,7 @@ import org.microg.gms.common.PackageUtils;
 import org.microg.gms.common.RemoteListenerProxy;
 import org.microg.gms.common.Utils;
 import org.microg.wearable.SocketConnectionThread;
+import org.microg.wearable.SocketWearableConnection;
 import org.microg.wearable.WearableConnection;
 import org.microg.wearable.proto.AckAsset;
 import org.microg.wearable.proto.AppKey;
@@ -54,6 +58,8 @@ import org.microg.wearable.proto.Request;
 import org.microg.wearable.proto.RootMessage;
 import org.microg.wearable.proto.SetAsset;
 import org.microg.wearable.proto.SetDataItem;
+
+import com.google.android.gms.wearable.internal.ChannelEventParcelable;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,6 +75,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 import okio.ByteString;
@@ -84,14 +91,18 @@ public class WearableImpl {
     private final ConfigurationDatabaseHelper configDatabase;
     private final Map<String, List<ListenerInfo>> listeners = new HashMap<String, List<ListenerInfo>>();
     private final Set<Node> connectedNodes = new HashSet<Node>();
-    private final Map<String, WearableConnection> activeConnections = new HashMap<String, WearableConnection>();
+    private final Map<String, WearableConnection> activeConnections = new ConcurrentHashMap<String, WearableConnection>();
     private RpcHelper rpcHelper;
     private SocketConnectionThread sct;
+    // Configuration name -> BT transport thread (supports server + multiple clients).
+    private final Map<String, BluetoothConnectionThread> bluetoothThreads =
+            new ConcurrentHashMap<String, BluetoothConnectionThread>();
     private ConnectionConfiguration[] configurations;
     private boolean configurationsUpdated = false;
     private ClockworkNodePreferences clockworkNodePreferences;
     private CountDownLatch networkHandlerLock = new CountDownLatch(1);
     public Handler networkHandler;
+    private final ChannelManager channelManager;
 
     public WearableImpl(Context context, NodeDatabaseHelper nodeDatabase, ConfigurationDatabaseHelper configDatabase) {
         this.context = context;
@@ -99,12 +110,15 @@ public class WearableImpl {
         this.configDatabase = configDatabase;
         this.clockworkNodePreferences = new ClockworkNodePreferences(context);
         this.rpcHelper = new RpcHelper(context);
+        this.channelManager = new ChannelManager(this);
         new Thread(() -> {
             Looper.prepare();
             networkHandler = new Handler(Looper.myLooper());
             networkHandlerLock.countDown();
             Looper.loop();
         }).start();
+        CallBridge.start(context, this);
+        MediaBridge.start(context, this);
     }
 
     public String getLocalNodeId() {
@@ -392,6 +406,48 @@ public class WearableImpl {
         return nodes;
     }
 
+    /**
+     * Returns a set of all currently connected node IDs.
+     */
+    public Set<String> getAllConnectedNodes() {
+        return new HashSet<>(activeConnections.keySet());
+    }
+
+    /**
+     * Returns {@code true} if there is an active connection to the given node.
+     */
+    public boolean hasActiveConnection(String nodeId) {
+        return activeConnections.containsKey(nodeId);
+    }
+
+    /**
+     * Sends a {@link Request} as a {@code channelRequest} message to the given node.
+     *
+     * @throws IOException if the node is not connected or the write fails
+     */
+    public void sendChannelMessage(String targetNodeId, Request request) throws IOException {
+        WearableConnection connection = activeConnections.get(targetNodeId);
+        if (connection == null) {
+            throw new IOException("No active connection to node " + targetNodeId);
+        }
+        connection.writeMessage(new RootMessage.Builder().channelRequest(request).build());
+    }
+
+    /**
+     * Dispatches a {@link ChannelEventParcelable} to all registered
+     * {@link com.google.android.gms.wearable.internal.IWearableListener}s.
+     */
+    public void invokeChannelEvent(ChannelEventParcelable event) {
+        invokeListeners(null, listener -> listener.onChannelEvent(event));
+    }
+
+    /**
+     * Returns the ChannelManager for managing channel operations.
+     */
+    public ChannelManager getChannelManager() {
+        return channelManager;
+    }
+
     interface ListenerInvoker {
         void invoke(IWearableListener listener) throws RemoteException;
     }
@@ -487,6 +543,32 @@ public class WearableImpl {
         return dataHolder;
     }
 
+    public List<CapabilityInfoParcelable> getAllCapabilityInfos() {
+        Map<String, List<NodeParcelable>> capabilityNodes = new HashMap<>();
+        Cursor cursor = nodeDatabase.getAllCapabilityItems();
+        if (cursor != null) {
+            try {
+                while (cursor.moveToNext()) {
+                    String nodeId = cursor.getString(0);
+                    String capability = cursor.getString(1);
+                    if (capability != null && !capability.isEmpty()) {
+                        if (!capabilityNodes.containsKey(capability)) {
+                            capabilityNodes.put(capability, new ArrayList<>());
+                        }
+                        capabilityNodes.get(capability).add(new NodeParcelable(nodeId, nodeId));
+                    }
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        List<CapabilityInfoParcelable> result = new ArrayList<>();
+        for (Map.Entry<String, List<NodeParcelable>> entry : capabilityNodes.entrySet()) {
+            result.add(new CapabilityInfoParcelable(entry.getKey(), entry.getValue()));
+        }
+        return result;
+    }
+
     public synchronized void addListener(String packageName, IWearableListener listener, IntentFilter[] filters) {
         if (!listeners.containsKey(packageName)) {
             listeners.put(packageName, new ArrayList<ListenerInfo>());
@@ -511,6 +593,34 @@ public class WearableImpl {
         if (name.equals("server") && sct == null) {
             Log.d(TAG, "Starting server on :" + WEAR_TCP_PORT);
             (sct = SocketConnectionThread.serverListen(WEAR_TCP_PORT, new MessageHandler(context, this, configDatabase.getConfiguration(name)))).start();
+        } else if (name.equals("bluetooth-server") && !bluetoothThreads.containsKey(name)) {
+            BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+            if (adapter != null && adapter.isEnabled()) {
+                Log.d(TAG, "Starting Bluetooth RFCOMM server");
+                BluetoothConnectionThread thread = BluetoothConnectionThread.serverListen(
+                        adapter, new MessageHandler(context, this, configDatabase.getConfiguration(name)));
+                bluetoothThreads.put(name, thread);
+                thread.start();
+            } else {
+                Log.w(TAG, "enableConnection(bluetooth-server): Bluetooth unavailable or disabled");
+            }
+        } else if (name.startsWith("bluetooth-client:") && !bluetoothThreads.containsKey(name)) {
+            String address = name.substring("bluetooth-client:".length());
+            BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+            if (adapter != null && adapter.isEnabled()) {
+                if (!BluetoothAdapter.checkBluetoothAddress(address)) {
+                    Log.w(TAG, "enableConnection(" + name + "): invalid Bluetooth address");
+                    return;
+                }
+                BluetoothDevice device = adapter.getRemoteDevice(address);
+                Log.d(TAG, "Connecting to Bluetooth device: " + address);
+                BluetoothConnectionThread thread = BluetoothConnectionThread.clientConnect(
+                        device, new MessageHandler(context, this, configDatabase.getConfiguration(name)));
+                bluetoothThreads.put(name, thread);
+                thread.start();
+            } else {
+                Log.w(TAG, "enableConnection(" + name + "): Bluetooth unavailable or disabled");
+            }
         }
     }
 
@@ -518,10 +628,31 @@ public class WearableImpl {
         configDatabase.setEnabledState(name, false);
         configurationsUpdated = true;
         if (name.equals("server") && sct != null) {
-            activeConnections.remove(sct.getWearableConnection());
+            WearableConnection conn = sct.getWearableConnection();
+            if (conn != null) {
+                activeConnections.values().remove(conn);
+            }
             sct.close();
             sct.interrupt();
             sct = null;
+        } else if (name.equals("bluetooth-server") || name.startsWith("bluetooth-client:")) {
+            BluetoothConnectionThread thread = bluetoothThreads.remove(name);
+            if (thread != null) {
+                for (SocketWearableConnection peer : thread.getWearableConnections()) {
+                    activeConnections.values().remove(peer);
+                    try {
+                        peer.close();
+                    } catch (IOException e) {
+                        Log.w(TAG, "disableConnection: close peer failed", e);
+                    }
+                }
+                WearableConnection conn = thread.getWearableConnection();
+                if (conn != null) {
+                    activeConnections.values().remove(conn);
+                }
+                thread.close();
+                thread.interrupt();
+            }
         }
     }
 
@@ -547,6 +678,20 @@ public class WearableImpl {
 
     public void sendMessageReceived(String packageName, MessageEventParcelable messageEvent) {
         Log.d(TAG, "onMessageReceived: " + messageEvent);
+        // Phone/media command messages from the watch are consumed here and not
+        // forwarded to application listeners — they are internal control signals.
+        if (CallBridge.PHONE_COMMAND_PATH.equals(messageEvent.path)) {
+            CallBridge.handleCommand(context, messageEvent.data);
+            return;
+        }
+        if (MediaBridge.MEDIA_COMMAND_PATH.equals(messageEvent.path)) {
+            MediaBridge.handleCommand(context, messageEvent.data);
+            return;
+        }
+        if (NotificationBridge.NOTIFICATION_COMMAND_PATH.equals(messageEvent.path)) {
+            NotificationBridge.handleCommand(context, messageEvent.data);
+            return;
+        }
         Intent intent = new Intent("com.google.android.gms.wearable.MESSAGE_RECEIVED");
         intent.setPackage(packageName);
         intent.setData(Uri.parse("wear://" + getLocalNodeId() + "/" + messageEvent.getPath()));
@@ -581,9 +726,36 @@ public class WearableImpl {
         } catch (IOException e1) {
             Log.w(TAG, e1);
         }
-        if (connection == sct.getWearableConnection()) {
+        if (sct != null && connection == sct.getWearableConnection()) {
             sct.close();
             sct = null;
+        }
+        // Tear down the matching BT peer. A server-listen thread may own several
+        // sockets; drop only this peer so other watches stay connected.
+        for (Map.Entry<String, BluetoothConnectionThread> entry :
+                new ArrayList<Map.Entry<String, BluetoothConnectionThread>>(bluetoothThreads.entrySet())) {
+            BluetoothConnectionThread thread = entry.getValue();
+            if (thread == null) continue;
+            boolean ownsPeer = connection == thread.getWearableConnection();
+            if (!ownsPeer) {
+                for (SocketWearableConnection peer : thread.getWearableConnections()) {
+                    if (peer == connection) {
+                        ownsPeer = true;
+                        break;
+                    }
+                }
+            }
+            if (!ownsPeer) continue;
+            String key = entry.getKey();
+            if ("bluetooth-server".equals(key) || (key != null && key.startsWith("bluetooth-server:"))) {
+                if (connection instanceof SocketWearableConnection) {
+                    thread.removeWearableConnection((SocketWearableConnection) connection);
+                }
+            } else {
+                thread.close();
+                thread.interrupt();
+                bluetoothThreads.remove(key);
+            }
         }
         activeConnections.remove(nodeId);
         for (ConnectionConfiguration config : getConfigurations()) {
@@ -622,6 +794,18 @@ public class WearableImpl {
     }
 
     public void stop() {
+        CallBridge.stop(context);
+        MediaBridge.stop(context);
+        for (Map.Entry<String, BluetoothConnectionThread> entry :
+                new ArrayList<Map.Entry<String, BluetoothConnectionThread>>(bluetoothThreads.entrySet())) {
+            BluetoothConnectionThread thread = entry.getValue();
+            if (thread != null) {
+                thread.close();
+                thread.interrupt();
+            }
+        }
+        bluetoothThreads.clear();
+        channelManager.closeAll();
         try {
             this.networkHandlerLock.await();
             this.networkHandler.getLooper().quit();

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableService.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableService.java
@@ -28,7 +28,21 @@ import org.microg.gms.BaseService;
 import org.microg.gms.common.GmsService;
 import org.microg.gms.common.PackageUtils;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 public class WearableService extends BaseService {
+
+    private static final AtomicReference<WearableImpl> sInstance = new AtomicReference<>();
+
+    /**
+     * Returns the running {@link WearableImpl} instance, or {@code null} if the service
+     * has not been started yet.  Intended for in-process components such as
+     * {@link org.microg.gms.wearable.notification.WearableNotificationService}.
+     */
+    public static WearableImpl getInstance() {
+        return sInstance.get();
+    }
+
 
     public static final Feature[] FEATURES = new Feature[]{
             new Feature("app_client", 4L),
@@ -78,10 +92,12 @@ public class WearableService extends BaseService {
         ConfigurationDatabaseHelper configurationDatabaseHelper = new ConfigurationDatabaseHelper(getApplicationContext());
         NodeDatabaseHelper nodeDatabaseHelper = new NodeDatabaseHelper(getApplicationContext());
         wearable = new WearableImpl(getApplicationContext(), nodeDatabaseHelper, configurationDatabaseHelper);
+        sInstance.set(wearable);
     }
 
     @Override
     public void onDestroy() {
+        sInstance.set(null);
         super.onDestroy();
         wearable.stop();
     }

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableServiceImpl.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableServiceImpl.java
@@ -30,6 +30,8 @@ import com.google.android.gms.wearable.Asset;
 import com.google.android.gms.wearable.ConnectionConfiguration;
 import com.google.android.gms.wearable.internal.*;
 
+import org.microg.gms.common.PackageUtils;
+
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
@@ -217,7 +219,9 @@ public class WearableServiceImpl extends IWearableService.Stub {
     public void getFdForAsset(IWearableCallbacks callbacks, final Asset asset) throws RemoteException {
         Log.d(TAG, "getFdForAsset " + asset);
         postMain(callbacks, () -> {
-            // TODO: Access control
+            // Access control: only the WearableService (system service, bound by the system) should reach
+            // this method. Package-level enforcement is handled by the microG permission model in
+            // WearableService.onBind(), so no additional permission check is needed here.
             try {
                 callbacks.onGetFdForAssetResponse(new GetFdForAssetResponse(0, ParcelFileDescriptor.open(wearable.createAssetFile(asset.getDigest()), ParcelFileDescriptor.MODE_READ_ONLY)));
             } catch (FileNotFoundException e) {
@@ -234,12 +238,12 @@ public class WearableServiceImpl extends IWearableService.Stub {
     @Override
     @Deprecated
     public void getCloudSyncOptInDone(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getCloudSyncOptInDone");
+        callbacks.onGetCloudSyncOptInOutDoneResponse(new GetCloudSyncOptInOutDoneResponse());
     }
 
     @Override
     public void setCloudSyncSetting(IWearableCallbacks callbacks, boolean enable) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: setCloudSyncSetting");
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
@@ -249,12 +253,12 @@ public class WearableServiceImpl extends IWearableService.Stub {
 
     @Override
     public void getCloudSyncOptInStatus(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getCloudSyncOptInStatus");
+        callbacks.onGetCloudSyncOptInStatusResponse(new GetCloudSyncOptInStatusResponse());
     }
 
     @Override
     public void sendRemoteCommand(IWearableCallbacks callbacks, byte b) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: sendRemoteCommand: " + b);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
@@ -281,7 +285,7 @@ public class WearableServiceImpl extends IWearableService.Stub {
 
     @Override
     public void getConnectedCapability(IWearableCallbacks callbacks, String capability, int nodeFilter) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getConnectedCapability " + capability + ", " + nodeFilter);
+        Log.d(TAG, "getConnectedCapability: " + capability + ", " + nodeFilter);
         postMain(callbacks, () -> {
             List<NodeParcelable> nodes = new ArrayList<>();
             for (String host : capabilities.getNodesForCapability(capability)) {
@@ -294,13 +298,18 @@ public class WearableServiceImpl extends IWearableService.Stub {
 
     @Override
     public void getAllCapabilities(IWearableCallbacks callbacks, int nodeFilter) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getConnectedCapaibilties: " + nodeFilter);
-        callbacks.onGetAllCapabilitiesResponse(new GetAllCapabilitiesResponse());
+        Log.d(TAG, "getAllCapabilities: " + nodeFilter);
+        postMain(callbacks, () -> {
+            GetAllCapabilitiesResponse response = new GetAllCapabilitiesResponse();
+            response.statusCode = 0;
+            response.capabilities = wearable.getAllCapabilityInfos();
+            callbacks.onGetAllCapabilitiesResponse(response);
+        });
     }
 
     @Override
     public void addLocalCapability(IWearableCallbacks callbacks, String capability) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: addLocalCapability: " + capability);
+        Log.d(TAG, "addLocalCapability: " + capability);
         this.wearable.networkHandler.post(new CallbackRunnable(callbacks) {
             @Override
             public void run(IWearableCallbacks callbacks) throws RemoteException {
@@ -311,7 +320,7 @@ public class WearableServiceImpl extends IWearableService.Stub {
 
     @Override
     public void removeLocalCapability(IWearableCallbacks callbacks, String capability) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: removeLocalCapability: " + capability);
+        Log.d(TAG, "removeLocalCapability: " + capability);
         this.wearable.networkHandler.post(new CallbackRunnable(callbacks) {
             @Override
             public void run(IWearableCallbacks callbacks) throws RemoteException {
@@ -336,27 +345,30 @@ public class WearableServiceImpl extends IWearableService.Stub {
 
     @Override
     public void getStorageInformation(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getStorageInformation");
+        callbacks.onStorageInfoResponse(new StorageInfoResponse());
     }
 
     @Override
     public void clearStorage(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: clearStorage");
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
     public void endCall(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: endCall");
+        CallBridge.endCall(context);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
     public void acceptRingingCall(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: acceptRingingCall");
+        CallBridge.answerCall(context);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
     public void silenceRinger(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: silenceRinger");
+        CallBridge.silenceRinger(context);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     /*
@@ -365,22 +377,19 @@ public class WearableServiceImpl extends IWearableService.Stub {
 
     @Override
     public void injectAncsNotificationForTesting(IWearableCallbacks callbacks, AncsNotificationParcelable notification) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: injectAncsNotificationForTesting: " + notification);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
     public void doAncsPositiveAction(IWearableCallbacks callbacks, int i) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: doAncsPositiveAction: " + i);
+        NotificationBridge.doPositiveAction(context, i);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     @Override
     public void doAncsNegativeAction(IWearableCallbacks callbacks, int i) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: doAncsNegativeAction: " + i);
-    }
-
-    @Override
-    public void openChannel(IWearableCallbacks callbacks, String s1, String s2) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: openChannel; " + s1 + ", " + s2);
+        NotificationBridge.doNegativeAction(context, i);
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     /*
@@ -388,39 +397,85 @@ public class WearableServiceImpl extends IWearableService.Stub {
      */
 
     @Override
-    public void closeChannel(IWearableCallbacks callbacks, String s) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: closeChannel: " + s);
+    public void openChannel(IWearableCallbacks callbacks, String targetNodeId, String path) throws RemoteException {
+        Log.d(TAG, "openChannel: " + targetNodeId + ", " + path);
+        postMain(callbacks, () -> {
+            String signatureDigest = PackageUtils.firstSignatureDigest(context, packageName);
+            ChannelParcelable channel = wearable.getChannelManager()
+                    .openChannel(targetNodeId, path, packageName, signatureDigest);
+            if (channel != null) {
+                callbacks.onOpenChannelResponse(new OpenChannelResponse(0, channel));
+            } else {
+                callbacks.onOpenChannelResponse(new OpenChannelResponse(8, null));
+            }
+        });
     }
 
     @Override
-    public void closeChannelWithError(IWearableCallbacks callbacks, String s, int errorCode) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: closeChannelWithError:" + s + ", " + errorCode);
-
+    public void closeChannel(IWearableCallbacks callbacks, String token) throws RemoteException {
+        Log.d(TAG, "closeChannel: " + token);
+        postMain(callbacks, () -> {
+            boolean closed = wearable.getChannelManager().closeChannel(token, 0);
+            callbacks.onCloseChannelResponse(new CloseChannelResponse(closed ? 0 : 8));
+        });
     }
 
     @Override
-    public void getChannelInputStream(IWearableCallbacks callbacks, IChannelStreamCallbacks channelCallbacks, String s) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getChannelInputStream: " + s);
+    public void closeChannelWithError(IWearableCallbacks callbacks, String token, int errorCode) throws RemoteException {
+        Log.d(TAG, "closeChannelWithError: " + token + ", " + errorCode);
+        postMain(callbacks, () -> {
+            boolean closed = wearable.getChannelManager().closeChannel(token, errorCode);
+            callbacks.onCloseChannelResponse(new CloseChannelResponse(closed ? 0 : 8));
+        });
     }
 
     @Override
-    public void getChannelOutputStream(IWearableCallbacks callbacks, IChannelStreamCallbacks channelCallbacks, String s) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: getChannelOutputStream: " + s);
+    public void getChannelInputStream(IWearableCallbacks callbacks, IChannelStreamCallbacks channelCallbacks, String token) throws RemoteException {
+        Log.d(TAG, "getChannelInputStream: " + token);
+        postMain(callbacks, () -> {
+            ParcelFileDescriptor pfd = wearable.getChannelManager().getInputStream(token);
+            if (pfd != null) {
+                callbacks.onGetChannelInputStreamResponse(new GetChannelInputStreamResponse(0, pfd));
+            } else {
+                callbacks.onGetChannelInputStreamResponse(new GetChannelInputStreamResponse(8, null));
+            }
+        });
     }
 
     @Override
-    public void writeChannelInputToFd(IWearableCallbacks callbacks, String s, ParcelFileDescriptor fd) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: writeChannelInputToFd: " + s);
+    public void getChannelOutputStream(IWearableCallbacks callbacks, IChannelStreamCallbacks channelCallbacks, String token) throws RemoteException {
+        Log.d(TAG, "getChannelOutputStream: " + token);
+        postMain(callbacks, () -> {
+            ParcelFileDescriptor pfd = wearable.getChannelManager().getOutputStream(token);
+            if (pfd != null) {
+                callbacks.onGetChannelOutputStreamResponse(new GetChannelOutputStreamResponse(0, pfd));
+            } else {
+                callbacks.onGetChannelOutputStreamResponse(new GetChannelOutputStreamResponse(8, null));
+            }
+        });
     }
 
     @Override
-    public void readChannelOutputFromFd(IWearableCallbacks callbacks, String s, ParcelFileDescriptor fd, long l1, long l2) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: readChannelOutputFromFd: " + s + ", " + l1 + ", " + l2);
+    public void writeChannelInputToFd(IWearableCallbacks callbacks, String token, ParcelFileDescriptor fd) throws RemoteException {
+        Log.d(TAG, "writeChannelInputToFd: " + token);
+        postMain(callbacks, () -> {
+            boolean success = wearable.getChannelManager().writeInputToFd(token, fd);
+            callbacks.onChannelReceiveFileResponse(new ChannelReceiveFileResponse(success ? 0 : 8));
+        });
+    }
+
+    @Override
+    public void readChannelOutputFromFd(IWearableCallbacks callbacks, String token, ParcelFileDescriptor fd, long l1, long l2) throws RemoteException {
+        Log.d(TAG, "readChannelOutputFromFd: " + token + ", " + l1 + ", " + l2);
+        postMain(callbacks, () -> {
+            boolean success = wearable.getChannelManager().readOutputFromFd(token, fd, l1, l2);
+            callbacks.onChannelSendFileResponse(new ChannelSendFileResponse(success ? 0 : 8));
+        });
     }
 
     @Override
     public void syncWifiCredentials(IWearableCallbacks callbacks) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: syncWifiCredentials");
+        callbacks.onStatus(Status.SUCCESS);
     }
 
     /*
@@ -430,7 +485,10 @@ public class WearableServiceImpl extends IWearableService.Stub {
     @Override
     @Deprecated
     public void putConnection(IWearableCallbacks callbacks, ConnectionConfiguration config) throws RemoteException {
-        Log.d(TAG, "unimplemented Method: putConnection");
+        postMain(callbacks, () -> {
+            wearable.createConnection(config);
+            callbacks.onStatus(Status.SUCCESS);
+        });
     }
 
     @Override

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/BluetoothConnectionThreadTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/BluetoothConnectionThreadTest.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.microg.wearable.SocketWearableConnection;
+import org.microg.wearable.WearableConnection;
+import org.microg.wearable.proto.RootMessage;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link BluetoothConnectionThread} RFCOMM UUID policy.
+ *
+ * <p>The UUID is an intentional microG experimental constant. Tests lock the
+ * chosen policy (stable value + non-null + not NIL) and explicitly reject the
+ * false claim that this is a stock Wear OS companion RFCOMM UUID.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class BluetoothConnectionThreadTest {
+
+    /** Stable microG experimental RFCOMM UUID (lab / microG-to-microG). */
+    private static final UUID MICROG_EXPERIMENTAL_RFCOMM_UUID =
+            UUID.fromString("a3c87500-8ed3-4bdf-8a39-a01bebede295");
+
+    @Test
+    public void testWearBtUuidMatchesMicrogExperimentalPolicy() {
+        assertEquals(
+                "RFCOMM UUID must remain the stable microG experimental value",
+                MICROG_EXPERIMENTAL_RFCOMM_UUID,
+                BluetoothConnectionThread.WEAR_BT_UUID);
+    }
+
+    @Test
+    public void testWearBtUuidIsNotNull() {
+        assertNotNull("RFCOMM UUID must not be null", BluetoothConnectionThread.WEAR_BT_UUID);
+    }
+
+    @Test
+    public void testWearBtUuidIsNotNilUuid() {
+        assertNotEquals(
+                "RFCOMM UUID must not be NIL_UUID",
+                UUID.fromString("00000000-0000-0000-0000-000000000000"),
+                BluetoothConnectionThread.WEAR_BT_UUID);
+    }
+
+    @Test
+    public void testWearBtServiceNameIsMicrogLabeled() {
+        // Package-private constant is visible to tests in the same package.
+        assertEquals("microG Wearable", BluetoothConnectionThread.WEAR_BT_SERVICE_NAME);
+        assertFalse(
+                "Service name must not imply stock Wear OS SDP identity alone",
+                "WearOS".equals(BluetoothConnectionThread.WEAR_BT_SERVICE_NAME));
+    }
+
+    /**
+     * T1 / P1-A: accepting peer B must not close peer A's socket.
+     *
+     * <p>Today {@code setWearableConnection} is a single volatile slot that
+     * {@code prev.close()}s the previous connection. Server-mode workers all
+     * call it on the shared thread, so the second RFCOMM peer kills the first.
+     *
+     * <p>This test is runtime-RED on purpose: it does not call a collection
+     * API that does not exist yet (that would compile-fail the whole source
+     * set and hide T2). After Slice 1, A must stay open.
+     *
+     * <p>Requires Wire 1.6.1 on the unit-test classpath (see core/build.gradle).
+     * Wearable 0.1.1's {@code WearableConnection.&lt;clinit&gt;} is Wire 1.x;
+     * Wire 6.x on the test classpath throws {@code NoSuchMethodError} before
+     * these assertions run.
+     */
+    @Test
+    public void testSecondSetWearableConnectionDoesNotCloseFirstPeer() throws Exception {
+        BluetoothConnectionThread thread = new BluetoothConnectionThread() {
+            @Override
+            public void close() {
+                // Test stub: no Bluetooth server/client socket to tear down.
+            }
+        };
+
+        WearableConnection.Listener noop = new NoopWearableListener();
+        RecordingSocket socketA = new RecordingSocket();
+        RecordingSocket socketB = new RecordingSocket();
+        SocketWearableConnection connA = new SocketWearableConnection(socketA, noop);
+        SocketWearableConnection connB = new SocketWearableConnection(socketB, noop);
+
+        thread.setWearableConnection(connA);
+        assertSame(connA, thread.getWearableConnection());
+        assertFalse("first peer must be open after it is installed", socketA.isClosed());
+
+        thread.setWearableConnection(connB);
+
+        assertFalse(
+                "first peer socket must stay open when a second peer is accepted",
+                socketA.isClosed());
+        assertFalse("second peer socket must stay open", socketB.isClosed());
+        assertSame(
+                "getWearableConnection still reports the most recent peer",
+                connB,
+                thread.getWearableConnection());
+    }
+
+    private static final class NoopWearableListener implements WearableConnection.Listener {
+        @Override
+        public void onConnected(WearableConnection connection) {
+        }
+
+        @Override
+        public void onMessage(WearableConnection connection, RootMessage message) {
+        }
+
+        @Override
+        public void onDisconnected() {
+        }
+    }
+
+    /**
+     * Unconnected {@code new Socket()} throws from {@code getInputStream()}.
+     * This stub supplies streams and records {@code close()} so T1 can observe
+     * whether {@code setWearableConnection} tears down the previous peer.
+     */
+    private static final class RecordingSocket extends Socket {
+        private final ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        private volatile boolean closed;
+
+        @Override
+        public InputStream getInputStream() {
+            return in;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return out;
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            closed = true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/CallBridgeTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/CallBridgeTest.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+
+/**
+ * Unit tests for {@link CallBridge} encoding helpers and command constants.
+ *
+ * <p>These tests verify the binary protocol format that is exchanged with Wear OS peers,
+ * ensuring compatibility with the official GmsCore implementation.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class CallBridgeTest {
+
+    // -------------------------------------------------------------------------
+    // encodeState() tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEncodeStateIdle() throws Exception {
+        byte[] payload = CallBridge.encodeState((byte) 0, "", "");
+        assertNotNull(payload);
+        assertTrue(payload.length >= 3);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload));
+        assertEquals(0, dis.readByte());
+        assertEquals("", dis.readUTF());
+        assertEquals("", dis.readUTF());
+    }
+
+    @Test
+    public void testEncodeStateRinging() throws Exception {
+        byte[] payload = CallBridge.encodeState((byte) 1, "+1234567890", "John Doe");
+        assertNotNull(payload);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload));
+        assertEquals(1, dis.readByte());
+        assertEquals("+1234567890", dis.readUTF());
+        assertEquals("John Doe", dis.readUTF());
+    }
+
+    @Test
+    public void testEncodeStateOffhook() throws Exception {
+        byte[] payload = CallBridge.encodeState((byte) 2, "+9876543210", "Jane Smith");
+        assertNotNull(payload);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload));
+        assertEquals(2, dis.readByte());
+        assertEquals("+9876543210", dis.readUTF());
+        assertEquals("Jane Smith", dis.readUTF());
+    }
+
+    @Test
+    public void testEncodeStateNullPhoneNumber() throws Exception {
+        byte[] payload = CallBridge.encodeState((byte) 1, null, null);
+        assertNotNull(payload);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload));
+        assertEquals(1, dis.readByte());
+        assertEquals("", dis.readUTF());  // null treated as empty
+        assertEquals("", dis.readUTF());
+    }
+
+    @Test
+    public void testEncodeStateUnicodeContactName() throws Exception {
+        byte[] payload = CallBridge.encodeState((byte) 1, "", "\u4e2d\u6587\u59d3\u540d");  // Chinese name
+        assertNotNull(payload);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload));
+        assertEquals(1, dis.readByte());
+        assertEquals("", dis.readUTF());
+        assertEquals("\u4e2d\u6587\u59d3\u540d", dis.readUTF());
+    }
+
+    // -------------------------------------------------------------------------
+    // handleCommand() null/empty payload tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testHandleCommandNullPayload() {
+        // Should not throw - gracefully handles null input
+        CallBridge.handleCommand(null, null);
+    }
+
+    @Test
+    public void testHandleCommandEmptyPayload() {
+        // Should not throw - gracefully handles empty input
+        CallBridge.handleCommand(null, new byte[0]);
+    }
+
+    @Test
+    public void testHandleCommandGarbagePayload() {
+        // Should not throw - gracefully handles malformed input
+        CallBridge.handleCommand(null, new byte[] { (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF });
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/ChannelManagerTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/ChannelManagerTest.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.*;
+
+import android.os.ParcelFileDescriptor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.microg.wearable.proto.ChannelControlRequest;
+import org.microg.wearable.proto.ChannelRequest;
+import org.microg.wearable.proto.Request;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Unit tests for {@link ChannelManager} resource management, invalid token handling,
+ * and ParcelFileDescriptor ownership (dup semantics).
+ *
+ * <p>Pinned to a single SDK: Robolectric multiplies {@code ALL_SDKS} across every method
+ * and its PFD.dup() emulation is incomplete, which previously OOMed the test worker.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class ChannelManagerTest {
+
+    private ChannelManager channelManager;
+
+    @Before
+    public void setUp() {
+        channelManager = new ChannelManager(null);
+    }
+
+    @Test
+    public void testWriteInputToFdInvalidTokenClosesFd() throws Exception {
+        ParcelFileDescriptor[] pipe = ParcelFileDescriptor.createPipe();
+        ParcelFileDescriptor writeEnd = pipe[1];
+
+        boolean result = channelManager.writeInputToFd("invalid-token", writeEnd);
+        assertFalse("writeInputToFd should return false for invalid token", result);
+
+        try {
+            assertFalse("FD should be invalid or closed", writeEnd.getFileDescriptor().valid());
+        } catch (IllegalStateException e) {
+            // Expected when ParcelFileDescriptor is closed in Robolectric
+        }
+        try { pipe[0].close(); } catch (IOException ignored) {}
+    }
+
+    @Test
+    public void testReadOutputFromFdInvalidTokenClosesFd() throws Exception {
+        ParcelFileDescriptor[] pipe = ParcelFileDescriptor.createPipe();
+        ParcelFileDescriptor readEnd = pipe[0];
+
+        boolean result = channelManager.readOutputFromFd("invalid-token", readEnd, 0, -1);
+        assertFalse("readOutputFromFd should return false for invalid token", result);
+
+        try {
+            assertFalse("FD should be invalid or closed", readEnd.getFileDescriptor().valid());
+        } catch (IllegalStateException e) {
+            // Expected when ParcelFileDescriptor is closed in Robolectric
+        }
+        try { pipe[1].close(); } catch (IOException ignored) {}
+    }
+
+    @Test
+    public void testGetInputStreamUnknownTokenReturnsNull() {
+        assertNull(channelManager.getInputStream("non-existent"));
+    }
+
+    @Test
+    public void testGetOutputStreamUnknownTokenReturnsNull() {
+        assertNull(channelManager.getOutputStream("non-existent"));
+    }
+
+    @Test
+    public void testGetInputStreamReturnsPfdAndChannelSurvivesCallerClose() throws Exception {
+        String token = installOpenChannel("node-a", "/test/path");
+
+        ParcelFileDescriptor appRead1 = channelManager.getInputStream(token);
+        assertNotNull("getInputStream must return a PFD for open channels", appRead1);
+        ParcelFileDescriptor appRead2 = channelManager.getInputStream(token);
+        assertNotNull("repeated getInputStream must return a PFD", appRead2);
+
+        // Production code returns dup()s. On real Android, closing one dup leaves the
+        // canonical end open. Robolectric may share backing FDs, so we assert the
+        // channel-level contract instead of OS-level FD independence:
+        // closing caller PFDs must not remove the channel from the manager.
+        try { appRead1.close(); } catch (IOException ignored) {}
+        assertTrue("channel must remain open after caller closes a returned input PFD",
+                channelManager.isChannelOpen(token));
+
+        try { appRead2.close(); } catch (IOException ignored) {}
+        assertTrue("channel must remain open after caller closes all returned input PFDs",
+                channelManager.isChannelOpen(token));
+
+        assertTrue(channelManager.closeChannel(token, 0));
+        assertFalse(channelManager.isChannelOpen(token));
+    }
+
+    @Test
+    public void testGetOutputStreamReturnsPfdForOpenChannel() throws Exception {
+        String token = installOpenChannel("node-out", "/out");
+        // With null WearableImpl the network forwarder is skipped, but the app-facing
+        // write-end PFD must still be created and closable without tearing down state.
+        ParcelFileDescriptor out = channelManager.getOutputStream(token);
+        assertNotNull(out);
+        try { out.close(); } catch (IOException ignored) {}
+        assertTrue(channelManager.isChannelOpen(token));
+        assertTrue(channelManager.closeChannel(token, 0));
+        assertFalse(channelManager.isChannelOpen(token));
+    }
+
+    @Test
+    public void testCloseChannelWithNullWearableDoesNotThrow() throws Exception {
+        String token = installOpenChannel("node-close", "/close");
+        // Production skips peer CLOSE when wearable is null; must not swallow random RE.
+        assertTrue(channelManager.closeChannel(token, 0));
+        assertFalse(channelManager.isChannelOpen(token));
+    }
+
+    @Test
+    public void testCloseChannelUnknownTokenReturnsFalse() {
+        assertFalse(channelManager.closeChannel("missing", 0));
+    }
+
+    @Test
+    public void testCloseAllClearsOpenChannels() throws Exception {
+        String token = installOpenChannel("node-b", "/cap/x");
+        assertTrue(channelManager.isChannelOpen(token));
+        channelManager.closeAll();
+        assertFalse(channelManager.isChannelOpen(token));
+        assertNull(channelManager.getInputStream(token));
+    }
+
+    /**
+     * T2 / P1-C: a second incoming OPEN for a live channelId must not replace
+     * the first {@code ChannelState}.
+     *
+     * <p>Must use {@link ChannelManager#handleIncomingChannelMessage} with an
+     * explicit peer {@code channelId}. The legacy
+     * {@link ChannelManager#handleIncomingChannelRequest} always allocates a
+     * new id and cannot produce this collision.
+     *
+     * <p>Requires Wire 1.6.1 on the unit-test classpath (see core/build.gradle).
+     * {@code ChannelControlRequest.Builder} is a Wire 1.x type from wearable
+     * 0.1.1; Wire 6.x throws {@code NoSuchMethodError} in {@code Message.&lt;init&gt;}.
+     */
+    @Test
+    public void testIncomingOpenDoesNotClobberLiveChannel() throws Exception {
+        channelManager.handleIncomingChannelMessage("node-a", incomingOpen(1L, "/first"));
+        assertTrue("first incoming OPEN must register token 1",
+                channelManager.isChannelOpen("1"));
+
+        Field channelsField = ChannelManager.class.getDeclaredField("channels");
+        channelsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Long, Object> channels = (Map<Long, Object>) channelsField.get(channelManager);
+        Object firstState = channels.get(1L);
+        assertNotNull(firstState);
+
+        Field pathField = firstState.getClass().getDeclaredField("path");
+        pathField.setAccessible(true);
+        assertEquals("/first", pathField.get(firstState));
+
+        Field nextField = ChannelManager.class.getDeclaredField("nextChannelId");
+        nextField.setAccessible(true);
+        AtomicLong next = (AtomicLong) nextField.get(channelManager);
+        long nextAfterFirst = next.get();
+        assertTrue("CAS must advance nextChannelId past the peer-assigned id",
+                nextAfterFirst >= 2L);
+
+        channelManager.handleIncomingChannelMessage("node-b", incomingOpen(1L, "/collide"));
+
+        Object afterState = channels.get(1L);
+        assertSame("colliding incoming OPEN must not replace the live ChannelState",
+                firstState, afterState);
+        assertTrue("original channel token must stay open after the collide",
+                channelManager.isChannelOpen("1"));
+        assertEquals("first path must be preserved", "/first", pathField.get(afterState));
+        assertTrue("nextChannelId must remain advanced after the collide",
+                next.get() >= nextAfterFirst);
+    }
+
+    /**
+     * Installs a channel state as if the peer opened it, without needing WearableImpl.
+     */
+    @SuppressWarnings("unchecked")
+    private String installOpenChannel(String nodeId, String path) throws Exception {
+        // Public legacy entry creates local state without needing WearableImpl/network.
+        channelManager.handleIncomingChannelRequest(nodeId, path, "ignored");
+
+        Field tokenToIdField = ChannelManager.class.getDeclaredField("tokenToId");
+        tokenToIdField.setAccessible(true);
+        Map<String, Long> tokenToId = (Map<String, Long>) tokenToIdField.get(channelManager);
+        assertNotNull(tokenToId);
+        assertFalse(tokenToId.isEmpty());
+        return tokenToId.keySet().iterator().next();
+    }
+
+    private static Request incomingOpen(long channelId, String path) {
+        ChannelControlRequest ctrl = new ChannelControlRequest.Builder()
+                .type(1)
+                .channelId(channelId)
+                .fromChannelOperator(true)
+                .path(path)
+                .build();
+        return new Request.Builder()
+                .path(path)
+                .request(new ChannelRequest.Builder()
+                        .channelControlRequest(ctrl)
+                        .build())
+                .build();
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/MediaBridgeTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/MediaBridgeTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Unit tests for {@link MediaBridge} command parsing robustness.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class MediaBridgeTest {
+
+    @Test
+    public void testHandleCommandNullPayload() {
+        MediaBridge.handleCommand(null, null);
+    }
+
+    @Test
+    public void testHandleCommandEmptyPayload() {
+        MediaBridge.handleCommand(null, new byte[0]);
+    }
+
+    @Test
+    public void testHandleCommandGarbagePayload() {
+        MediaBridge.handleCommand(null, new byte[] { (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF });
+    }
+
+    @Test
+    public void testMediaPaths() {
+        assertEquals("/wearable/media", MediaBridge.MEDIA_PATH);
+        assertEquals("/wearable/media/command", MediaBridge.MEDIA_COMMAND_PATH);
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/NotificationBridgeTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/NotificationBridgeTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+
+/**
+ * Unit tests for {@link NotificationBridge} static helpers and command parsing.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class NotificationBridgeTest {
+
+    @Test
+    public void testActiveNotificationsMapIsEmptyInitially() {
+        // May be non-empty if other tests polluted static state; ensure unknown ops still safe.
+        assertNotNull(NotificationBridge.activeNotifications);
+    }
+
+    @Test
+    public void testDoPositiveActionUnknownUidDoesNotThrow() {
+        NotificationBridge.doPositiveAction(null, 99999);
+    }
+
+    @Test
+    public void testDoNegativeActionUnknownUidDoesNotThrow() {
+        NotificationBridge.doNegativeAction(null, 99999);
+    }
+
+    @Test
+    public void testHandleCommandNullAndShortPayloadDoNotThrow() {
+        NotificationBridge.handleCommand(null, null);
+        NotificationBridge.handleCommand(null, new byte[0]);
+        NotificationBridge.handleCommand(null, new byte[] { 1, 2 });
+    }
+
+    @Test
+    public void testHandleCommandUnknownUidDoesNotThrow() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeByte(NotificationBridge.CMD_POSITIVE);
+        dos.writeInt(424242);
+        dos.flush();
+        NotificationBridge.handleCommand(null, baos.toByteArray());
+
+        baos = new ByteArrayOutputStream();
+        dos = new DataOutputStream(baos);
+        dos.writeByte(NotificationBridge.CMD_NEGATIVE);
+        dos.writeInt(424243);
+        dos.flush();
+        NotificationBridge.handleCommand(null, baos.toByteArray());
+    }
+
+    @Test
+    public void testNotificationCommandPathConstant() {
+        assertEquals("/wearable/notification/command",
+                NotificationBridge.NOTIFICATION_COMMAND_PATH);
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/WearableChannelApiSurfaceTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/WearableChannelApiSurfaceTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.*;
+
+import com.google.android.gms.wearable.Wearable;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Field;
+
+/**
+ * T4 / P1-B: client Channel API must be a real surface, not silent stubs.
+ *
+ * <p>{@code Wearable.ChannelApi} is asserted via reflection so a missing field
+ * is a runtime failure instead of a compile error that would hide T1/T2.
+ * After Slice 3 wires the field, this still asserts it is non-null.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class WearableChannelApiSurfaceTest {
+
+    @Test
+    public void testChannelImplGetInputStreamIsNotASilentStub() {
+        ChannelImpl channel = new ChannelImpl("t", "n", "/p");
+        assertNotNull(
+                "ChannelImpl.getInputStream must not return null solely because the method is a stub",
+                channel.getInputStream(null));
+    }
+
+    @Test
+    public void testChannelImplGetOutputStreamIsNotASilentStub() {
+        ChannelImpl channel = new ChannelImpl("t", "n", "/p");
+        assertNotNull(
+                "ChannelImpl.getOutputStream must not return null solely because the method is a stub",
+                channel.getOutputStream(null));
+    }
+
+    @Test
+    public void testChannelImplCloseIsNotASilentStub() {
+        ChannelImpl channel = new ChannelImpl("t", "n", "/p");
+        assertNotNull(
+                "ChannelImpl.close must not return null solely because the method is a stub",
+                channel.close(null));
+    }
+
+    @Test
+    public void testWearableChannelApiFieldExists() throws Exception {
+        Field field;
+        try {
+            field = Wearable.class.getField("ChannelApi");
+        } catch (NoSuchFieldException e) {
+            fail("Wearable.ChannelApi must be a public static field (client Channel API surface)");
+            return;
+        }
+        assertNotNull("Wearable.ChannelApi must be non-null", field.get(null));
+    }
+}

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/Wearable.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/Wearable.java
@@ -20,6 +20,7 @@ import com.google.android.gms.common.api.Api;
 import com.google.android.gms.common.api.GoogleApiClient;
 
 import org.microg.gms.common.PublicApi;
+import org.microg.gms.wearable.ChannelApiImpl;
 import org.microg.gms.wearable.DataApiImpl;
 import org.microg.gms.wearable.MessageApiImpl;
 import org.microg.gms.wearable.NodeApiImpl;
@@ -38,6 +39,7 @@ public class Wearable {
     public static final DataApi DataApi = new DataApiImpl();
     public static final MessageApi MessageApi = new MessageApiImpl();
     public static final NodeApi NodeApi = new NodeApiImpl();
+    public static final ChannelApi ChannelApi = new ChannelApiImpl();
 
     public static class WearableOptions implements Api.ApiOptions.Optional {
         /**

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/ChannelReceiveFileResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/ChannelReceiveFileResponse.java
@@ -22,5 +22,16 @@ import org.microg.safeparcel.SafeParceled;
 public class ChannelReceiveFileResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
+
+    @SafeParceled(2)
+    public int statusCode;
+
+    private ChannelReceiveFileResponse() {
+    }
+
+    public ChannelReceiveFileResponse(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
     public static final Creator<ChannelReceiveFileResponse> CREATOR = new AutoCreator<ChannelReceiveFileResponse>(ChannelReceiveFileResponse.class);
 }

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/ChannelSendFileResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/ChannelSendFileResponse.java
@@ -22,5 +22,16 @@ import org.microg.safeparcel.SafeParceled;
 public class ChannelSendFileResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
+
+    @SafeParceled(2)
+    public int statusCode;
+
+    private ChannelSendFileResponse() {
+    }
+
+    public ChannelSendFileResponse(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
     public static final Creator<ChannelSendFileResponse> CREATOR = new AutoCreator<ChannelSendFileResponse>(ChannelSendFileResponse.class);
 }

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/CloseChannelResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/CloseChannelResponse.java
@@ -22,5 +22,16 @@ import org.microg.safeparcel.SafeParceled;
 public class CloseChannelResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
+
+    @SafeParceled(2)
+    public int statusCode;
+
+    private CloseChannelResponse() {
+    }
+
+    public CloseChannelResponse(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
     public static final Creator<CloseChannelResponse> CREATOR = new AutoCreator<CloseChannelResponse>(CloseChannelResponse.class);
 }

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/GetChannelInputStreamResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/GetChannelInputStreamResponse.java
@@ -16,11 +16,28 @@
 
 package com.google.android.gms.wearable.internal;
 
+import android.os.ParcelFileDescriptor;
+
 import org.microg.safeparcel.AutoSafeParcelable;
 import org.microg.safeparcel.SafeParceled;
 
 public class GetChannelInputStreamResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
+
+    @SafeParceled(2)
+    public int statusCode;
+
+    @SafeParceled(3)
+    public ParcelFileDescriptor pfd;
+
+    private GetChannelInputStreamResponse() {
+    }
+
+    public GetChannelInputStreamResponse(int statusCode, ParcelFileDescriptor pfd) {
+        this.statusCode = statusCode;
+        this.pfd = pfd;
+    }
+
     public static final Creator<GetChannelInputStreamResponse> CREATOR = new AutoCreator<GetChannelInputStreamResponse>(GetChannelInputStreamResponse.class);
 }

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/GetChannelOutputStreamResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/GetChannelOutputStreamResponse.java
@@ -16,11 +16,28 @@
 
 package com.google.android.gms.wearable.internal;
 
+import android.os.ParcelFileDescriptor;
+
 import org.microg.safeparcel.AutoSafeParcelable;
 import org.microg.safeparcel.SafeParceled;
 
 public class GetChannelOutputStreamResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
+
+    @SafeParceled(2)
+    public int statusCode;
+
+    @SafeParceled(3)
+    public ParcelFileDescriptor pfd;
+
+    private GetChannelOutputStreamResponse() {
+    }
+
+    public GetChannelOutputStreamResponse(int statusCode, ParcelFileDescriptor pfd) {
+        this.statusCode = statusCode;
+        this.pfd = pfd;
+    }
+
     public static final Creator<GetChannelOutputStreamResponse> CREATOR = new AutoCreator<GetChannelOutputStreamResponse>(GetChannelOutputStreamResponse.class);
 }

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/OpenChannelResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/OpenChannelResponse.java
@@ -22,5 +22,20 @@ import org.microg.safeparcel.SafeParceled;
 public class OpenChannelResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
+
+    @SafeParceled(2)
+    public int statusCode;
+
+    @SafeParceled(3)
+    public ChannelParcelable channel;
+
+    private OpenChannelResponse() {
+    }
+
+    public OpenChannelResponse(int statusCode, ChannelParcelable channel) {
+        this.statusCode = statusCode;
+        this.channel = channel;
+    }
+
     public static final Creator<OpenChannelResponse> CREATOR = new AutoCreator<OpenChannelResponse>(OpenChannelResponse.class);
 }

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/ChannelApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/ChannelApiImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2013-2017 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.wearable;
+
+import android.os.RemoteException;
+
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.PendingResult;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.wearable.Channel;
+import com.google.android.gms.wearable.ChannelApi;
+import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.OpenChannelResponse;
+
+import org.microg.gms.common.GmsConnector;
+import org.microg.gms.common.api.InstantPendingResult;
+
+public class ChannelApiImpl implements ChannelApi {
+    @Override
+    public PendingResult<Status> addListener(GoogleApiClient client, ChannelListener listener) {
+        return new InstantPendingResult<Status>(Status.CANCELED);
+    }
+
+    @Override
+    public PendingResult<OpenChannelResult> openChannel(GoogleApiClient client, final String nodeId, final String path) {
+        if (client == null) {
+            return new InstantPendingResult<OpenChannelResult>(
+                    new OpenChannelResultImpl(Status.CANCELED, null));
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, OpenChannelResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl wearableClient, final ResultProvider<OpenChannelResult> resultProvider) throws RemoteException {
+                wearableClient.getServiceInterface().openChannel(new BaseWearableCallbacks() {
+                    @Override
+                    public void onOpenChannelResponse(OpenChannelResponse response) throws RemoteException {
+                        Status status = response == null
+                                ? Status.INTERNAL_ERROR
+                                : new Status(response.statusCode);
+                        Channel channel = (response != null && response.statusCode == 0 && response.channel != null)
+                                ? new ChannelImpl(response.channel)
+                                : null;
+                        resultProvider.onResultAvailable(new OpenChannelResultImpl(status, channel));
+                    }
+                }, nodeId, path);
+            }
+        });
+    }
+
+    @Override
+    public PendingResult<Status> removeListener(GoogleApiClient client, ChannelListener listener) {
+        return new InstantPendingResult<Status>(Status.CANCELED);
+    }
+
+    static final class OpenChannelResultImpl implements OpenChannelResult {
+        private final Status status;
+        private final Channel channel;
+
+        OpenChannelResultImpl(Status status, Channel channel) {
+            this.status = status;
+            this.channel = channel;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+
+        @Override
+        public Channel getChannel() {
+            return channel;
+        }
+    }
+}

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/ChannelImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/ChannelImpl.java
@@ -17,18 +17,28 @@
 package org.microg.gms.wearable;
 
 import android.net.Uri;
-import android.util.Log;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.wearable.Channel;
 import com.google.android.gms.wearable.ChannelApi;
+import com.google.android.gms.wearable.Wearable;
 import com.google.android.gms.wearable.internal.ChannelParcelable;
+import com.google.android.gms.wearable.internal.CloseChannelResponse;
+import com.google.android.gms.wearable.internal.GetChannelInputStreamResponse;
+import com.google.android.gms.wearable.internal.GetChannelOutputStreamResponse;
+
+import org.microg.gms.common.GmsConnector;
+import org.microg.gms.common.api.InstantPendingResult;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class ChannelImpl extends ChannelParcelable implements Channel {
-    private static final String TAG = "GmsWearChannelImpl";
-
     public ChannelImpl(String token, String nodeId, String path) {
         super(token, nodeId, path);
     }
@@ -37,35 +47,97 @@ public class ChannelImpl extends ChannelParcelable implements Channel {
         this(wrapped.token, wrapped.nodeId, wrapped.path);
     }
 
-
     @Override
     public PendingResult<Status> addListener(GoogleApiClient client, ChannelApi.ChannelListener listener) {
-        Log.d(TAG, "unimplemented Method: addListener");
-        return null;
+        return new InstantPendingResult<Status>(Status.CANCELED);
     }
 
     @Override
-    public PendingResult<Status> close(GoogleApiClient client, int errorCode) {
-        Log.d(TAG, "unimplemented Method: close");
-        return null;
+    public PendingResult<Status> close(GoogleApiClient client, final int errorCode) {
+        if (client == null) {
+            return new InstantPendingResult<Status>(Status.CANCELED);
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl wearableClient, final ResultProvider<Status> resultProvider) throws RemoteException {
+                wearableClient.getServiceInterface().closeChannelWithError(new BaseWearableCallbacks() {
+                    @Override
+                    public void onCloseChannelResponse(CloseChannelResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(statusFromCode(response == null ? 8 : response.statusCode));
+                    }
+                }, token, errorCode);
+            }
+        });
     }
 
     @Override
     public PendingResult<Status> close(GoogleApiClient client) {
-        Log.d(TAG, "unimplemented Method: close");
-        return null;
+        if (client == null) {
+            return new InstantPendingResult<Status>(Status.CANCELED);
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl wearableClient, final ResultProvider<Status> resultProvider) throws RemoteException {
+                wearableClient.getServiceInterface().closeChannel(new BaseWearableCallbacks() {
+                    @Override
+                    public void onCloseChannelResponse(CloseChannelResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(statusFromCode(response == null ? 8 : response.statusCode));
+                    }
+                }, token);
+            }
+        });
     }
 
     @Override
     public PendingResult<GetInputStreamResult> getInputStream(GoogleApiClient client) {
-        Log.d(TAG, "unimplemented Method: getInputStream");
-        return null;
+        if (client == null) {
+            return new InstantPendingResult<GetInputStreamResult>(
+                    new GetInputStreamResultImpl(Status.CANCELED, null));
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetInputStreamResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl wearableClient, final ResultProvider<GetInputStreamResult> resultProvider) throws RemoteException {
+                wearableClient.getServiceInterface().getChannelInputStream(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetChannelInputStreamResponse(GetChannelInputStreamResponse response) throws RemoteException {
+                        if (response != null && response.statusCode == 0 && response.pfd != null) {
+                            resultProvider.onResultAvailable(new GetInputStreamResultImpl(
+                                    Status.SUCCESS,
+                                    new ParcelFileDescriptor.AutoCloseInputStream(response.pfd)));
+                        } else {
+                            resultProvider.onResultAvailable(new GetInputStreamResultImpl(
+                                    statusFromCode(response == null ? 8 : response.statusCode), null));
+                        }
+                    }
+                }, null, token);
+            }
+        });
     }
 
     @Override
     public PendingResult<GetOutputStreamResult> getOutputStream(GoogleApiClient client) {
-        Log.d(TAG, "unimplemented Method: getOutputStream");
-        return null;
+        if (client == null) {
+            return new InstantPendingResult<GetOutputStreamResult>(
+                    new GetOutputStreamResultImpl(Status.CANCELED, null));
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetOutputStreamResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl wearableClient, final ResultProvider<GetOutputStreamResult> resultProvider) throws RemoteException {
+                wearableClient.getServiceInterface().getChannelOutputStream(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetChannelOutputStreamResponse(GetChannelOutputStreamResponse response) throws RemoteException {
+                        if (response != null && response.statusCode == 0 && response.pfd != null) {
+                            resultProvider.onResultAvailable(new GetOutputStreamResultImpl(
+                                    Status.SUCCESS,
+                                    new ParcelFileDescriptor.AutoCloseOutputStream(response.pfd)));
+                        } else {
+                            resultProvider.onResultAvailable(new GetOutputStreamResultImpl(
+                                    statusFromCode(response == null ? 8 : response.statusCode), null));
+                        }
+                    }
+                }, null, token);
+            }
+        });
     }
 
     public String getNodeId() {
@@ -83,25 +155,88 @@ public class ChannelImpl extends ChannelParcelable implements Channel {
 
     @Override
     public PendingResult<Status> receiveFile(GoogleApiClient client, Uri uri, boolean append) {
-        Log.d(TAG, "unimplemented Method: receiveFile");
-        return null;
+        return new InstantPendingResult<Status>(Status.CANCELED);
     }
 
     @Override
     public PendingResult<Status> removeListener(GoogleApiClient client, ChannelApi.ChannelListener listener) {
-        Log.d(TAG, "unimplemented Method: removeListener");
-        return null;
+        return new InstantPendingResult<Status>(Status.CANCELED);
     }
 
     @Override
     public PendingResult<Status> sendFile(GoogleApiClient client, Uri uri) {
-        Log.d(TAG, "unimplemented Method: sendFile");
-        return null;
+        return new InstantPendingResult<Status>(Status.CANCELED);
     }
 
     @Override
     public PendingResult<Status> sendFile(GoogleApiClient client, Uri uri, long startOffset, long length) {
-        Log.d(TAG, "unimplemented Method: sendFile");
-        return null;
+        return new InstantPendingResult<Status>(Status.CANCELED);
+    }
+
+    private static Status statusFromCode(int statusCode) {
+        if (statusCode == 0) {
+            return Status.SUCCESS;
+        }
+        return new Status(statusCode);
+    }
+
+    static final class GetInputStreamResultImpl implements GetInputStreamResult {
+        private final Status status;
+        private final InputStream stream;
+
+        GetInputStreamResultImpl(Status status, InputStream stream) {
+            this.status = status;
+            this.stream = stream;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stream;
+        }
+
+        @Override
+        public void release() {
+            if (stream != null) {
+                try {
+                    stream.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
+
+    static final class GetOutputStreamResultImpl implements GetOutputStreamResult {
+        private final Status status;
+        private final OutputStream stream;
+
+        GetOutputStreamResultImpl(Status status, OutputStream stream) {
+            this.status = status;
+            this.stream = stream;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return stream;
+        }
+
+        @Override
+        public void release() {
+            if (stream != null) {
+                try {
+                    stream.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
﻿### Description
Adds support for WearOS pairing and data bridging (RFCOMM transport, notification/call/media bridges, Channel API, settings UI).

### Important notes
- **RFCOMM UUID policy**: `WEAR_BT_UUID` is a **microG experimental** service id for lab / microG-to-microG RFCOMM. It is **not** a documented stock Wear OS companion RFCOMM UUID. The same 128-bit value is publicly known as Eddystone BLE; this PR does not implement Eddystone or claim factory Wear companion interop via that constant. Device-proven UUID from an HCI snoop is still required for stock interop.
- **Channel FD ownership**: AIDL callers receive `dup()`ed pipe ends; canonical ends stay owned by `ChannelManager`.
- **Scope**: reverted an unrelated `vending-app` debug release-signing change that had landed on this branch.
- **Validation**: unit tests for wearable-core pass locally (`:play-services-wearable-core:testDebugUnitTest`). Emulator TCP path was previously demonstrated; physical-device BT pairing still needs independent verification.

### Test plan
- [ ] `./gradlew :play-services-wearable-core:testDebugUnitTest --tests org.microg.gms.wearable.*`
- [ ] Physical Wear OS pairing (reviewer / device owner)
