### PR TITLE
align account_state HTTP protobuf fields with stock GMS

### DIFF
--- a/play-services-core-proto/src/main/proto/account_state.proto
+++ b/play-services-core-proto/src/main/proto/account_state.proto
@@ -7,9 +7,9 @@ option java_package = "org.microg.gms.auth.capabilities.proto";
 option java_multiple_files = true;
 
 message AccountStateRequestHeader {
-  optional string packageName    = 1;
-  optional string appCertSha1Hex = 2;
-  optional string extra          = 3;
+  optional string extra          = 1;
+  optional string packageName    = 2;
+  optional string appCertSha1Hex = 3;
 }
 
 message AccountStateRequest {


### PR DESCRIPTION
### Summary

This PR corrects the protobuf field numbers used by microG's HTTP `account_state` request.

The request schema added by [#3420](https://github.com/microg/GmsCore/pull/3420) currently encodes:

```
nested field 1 = com.google.android.gms
nested field 2 = Google certificate SHA-1
nested field 3 = absent
```

Stock Google Play services encodes the same HTTP request as:
```text
nested field 1 = absent
nested field 2 = com.google.android.gms
nested field 3 = Google certificate SHA-1
```

### Stock HTTP schema


The stock HTTP layout is:
```proto
message AccountStateHttpClientInfo {
  // Field 1 is unset.
  optional string packageName    = 2;
  optional string appCertSha1Hex = 3;
}
message AccountStateHttpRequest {
  optional AccountStateHttpClientInfo clientInfo = 1;
}
```

### Google Play versions checked:

- Build: `26.26.62 (100400-945452815)`
- Build: `26.14.34 (040400-899752054)`
- Build: `25.08.34 (260800-739221510)`

All tested versions send:
```text
field 1 = absent
field 2 = package name
field 3 = certificate digest
```
The completed nested message is then placed in outer field 1 before the HTTP POST is created.

Field 1 appears to be a legacy AccountManager-stored account credential field. I found it in decompiles of old versions like 20.15.15 and 20.12.16.

### evidence

A public dataset contains three decoded stock requests with:
- Google Play services: `24.47.38`

Source repository: <https://github.com/doug-leith/cookies-etc-stored-by-google-android>

All three request bodies decode identically:
```text
1 {
  2: "com.google.android.gms"
  3: "38918a453d07199354f8b19af05ec6562ced5788"
}
```

The stock AANG application header uses:
```text
field 1 = package name
field 2 = certificate SHA-1
field 3 = request/network enum
```
The stock HTTP client-information message:
```text
field 1 = absent
field 2 = package name
field 3 = certificate SHA-1
```

### Runtime test

The HTTP request was tested on Android API 36 with an instrumented GmsCore build.
The request used:
- Endpoint: `https://android.googleapis.com/auth/lookup/account_state?rt=b`

| Mode | Nested body | Result |
| --- | --- | --- |
| `pr_fields_1_2` | Package in 1; certificate in 2 | Success |
| `stock_fields_2_3` | Package in 2; certificate in 3 | Success |
| `header_empty` | Outer field 1 with empty nested message | Success |
| `bogus_stock_fields` | Invalid package/certificate in 2 and 3 | Success |
| `body_absent` | No outer protobuf request | `IOException` |

Every successful request returned identical data. 

### effect

The field-number mismatch did not change the response in the auth flow.

This explains why the current implementation works despite not matching the stock format.
