### PR TITLE
feat(rcs): implement baseline Asterism and Constellation services

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/asterism/AsterismService.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/AsterismService.java
@@ -1,0 +1,25 @@
+﻿package org.microg.gms.asterism;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import org.microg.gms.BaseService;
+import org.microg.gms.common.GmsService;
+
+public class AsterismService extends BaseService {
+    public AsterismService() {
+        super("GmsAsterism", GmsService.ASTERISM);
+    }
+
+    @Override
+    public IBinder onBind(android.content.Intent intent) {
+        return new AsterismBinder();
+    }
+
+    private static class AsterismBinder extends Binder implements IInterface {
+        @Override
+        public IBinder asBinder() {
+            return this;
+        }
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/AsterismService.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/AsterismService.java
@@ -1,8 +1,9 @@
-﻿package org.microg.gms.asterism;
+package org.microg.gms.asterism;
 
 import android.os.Binder;
-import android.os.IBinder;
-import android.os.IInterface;
+import android.os.RemoteException;
+import com.google.android.gms.common.internal.GetServiceRequest;
+import com.google.android.gms.common.internal.IGmsCallbacks;
 import org.microg.gms.BaseService;
 import org.microg.gms.common.GmsService;
 
@@ -12,14 +13,7 @@ public class AsterismService extends BaseService {
     }
 
     @Override
-    public IBinder onBind(android.content.Intent intent) {
-        return new AsterismBinder();
-    }
-
-    private static class AsterismBinder extends Binder implements IInterface {
-        @Override
-        public IBinder asBinder() {
-            return this;
-        }
+    public void handleServiceRequest(IGmsCallbacks callback, GetServiceRequest request, GmsService service) throws RemoteException {
+        callback.onPostInitComplete(0, new Binder(), null);
     }
 }

--- a/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationService.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationService.java
@@ -1,8 +1,9 @@
-﻿package org.microg.gms.constellation;
+package org.microg.gms.constellation;
 
 import android.os.Binder;
-import android.os.IBinder;
-import android.os.IInterface;
+import android.os.RemoteException;
+import com.google.android.gms.common.internal.GetServiceRequest;
+import com.google.android.gms.common.internal.IGmsCallbacks;
 import org.microg.gms.BaseService;
 import org.microg.gms.common.GmsService;
 
@@ -12,14 +13,7 @@ public class ConstellationService extends BaseService {
     }
 
     @Override
-    public IBinder onBind(android.content.Intent intent) {
-        return new ConstellationBinder();
-    }
-
-    private static class ConstellationBinder extends Binder implements IInterface {
-        @Override
-        public IBinder asBinder() {
-            return this;
-        }
+    public void handleServiceRequest(IGmsCallbacks callback, GetServiceRequest request, GmsService service) throws RemoteException {
+        callback.onPostInitComplete(0, new Binder(), null);
     }
 }

--- a/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationService.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationService.java
@@ -1,0 +1,25 @@
+﻿package org.microg.gms.constellation;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import org.microg.gms.BaseService;
+import org.microg.gms.common.GmsService;
+
+public class ConstellationService extends BaseService {
+    public ConstellationService() {
+        super("GmsConstellation", GmsService.CONSTELLATION);
+    }
+
+    @Override
+    public IBinder onBind(android.content.Intent intent) {
+        return new ConstellationBinder();
+    }
+
+    private static class ConstellationBinder extends Binder implements IInterface {
+        @Override
+        public IBinder asBinder() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the baseline Binder implementation for Asterism and Constellation services. 

These components are essential for the Google Messages RCS provisioning state machine to progress without crashing or returning errors (Issue #2994).

Summary:
- Implemented `AsterismService` and `ConstellationService` following the microG `BaseService` pattern.
- Provided initial Binder stubs to satisfy IPC requests from Google Messages.
- Verified as a working baseline for the RCS connection handshake.