### PR TITLE
Fix MCS disconnects on aggressive OEM process managers

### DIFF
--- a/play-services-base/core/src/main/java/org/microg/gms/common/ForegroundServiceContext.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/common/ForegroundServiceContext.java
@@ -20,14 +20,20 @@ import static android.os.Build.VERSION.SDK_INT;
 public class ForegroundServiceContext extends ContextWrapper {
     private static final String TAG = "ForegroundService";
     public static final String EXTRA_FOREGROUND = "foreground";
+    private final boolean forceForeground;
 
     public ForegroundServiceContext(Context base) {
+        this(base, false);
+    }
+
+    public ForegroundServiceContext(Context base, boolean forceForeground) {
         super(base);
+        this.forceForeground = forceForeground;
     }
 
     @Override
     public ComponentName startService(Intent service) {
-        if (SDK_INT >= 26 && !isIgnoringBatteryOptimizations()) {
+        if (SDK_INT >= 26 && (forceForeground || !isIgnoringBatteryOptimizations())) {
             Log.d(TAG, "Starting in foreground mode.");
             service.putExtra(EXTRA_FOREGROUND, true);
             return super.startForegroundService(service);

--- a/play-services-core/src/main/java/org/microg/gms/gcm/TriggerReceiver.java
+++ b/play-services-core/src/main/java/org/microg/gms/gcm/TriggerReceiver.java
@@ -95,7 +95,10 @@ public class TriggerReceiver extends WakefulBroadcastReceiver {
 
             if (!McsService.isConnected(context) || force) {
                 Log.d(TAG, "Not connected to GCM but should be, asking the service to start up. Triggered by: " + intent);
-                startWakefulService(new ForegroundServiceContext(context), new Intent(ACTION_CONNECT, null, context, McsService.class)
+                // Keep the long-lived MCS socket in a foreground service even when Android reports
+                // that battery optimizations are disabled. Some OEM process managers still assign
+                // the persistent process a cached OOM score and kill it within seconds otherwise.
+                startWakefulService(new ForegroundServiceContext(context, true), new Intent(ACTION_CONNECT, null, context, McsService.class)
                         .putExtra(EXTRA_REASON, intent));
             } else {
                 if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
@@ -103,7 +106,7 @@ public class TriggerReceiver extends WakefulBroadcastReceiver {
                     McsService.scheduleReconnect(context);
                 } else {
                     Log.d(TAG, "Ignoring " + intent + ": service is running. heartbeat instead.");
-                    startWakefulService(new ForegroundServiceContext(context), new Intent(ACTION_HEARTBEAT, null, context, McsService.class)
+                    startWakefulService(new ForegroundServiceContext(context, true), new Intent(ACTION_HEARTBEAT, null, context, McsService.class)
                             .putExtra(EXTRA_REASON, intent));
                 }
             }


### PR DESCRIPTION
## Summary

Keep the long-lived MCS connection in a foreground service even when the app is exempt from battery optimizations.

## Problem

On a Xiaomi device, Cloud Messaging connected briefly and then immediately returned to the disconnected state. The device log showed Xiaomi's low-memory killer terminating the persistent process within seconds:

```text
Kill 'app.revanced.android.gms:persistent' ..., oom_score_adj 905
```

The current `ForegroundServiceContext` skips foreground-service mode when `PowerManager.isIgnoringBatteryOptimizations()` returns `true`. On this device, the battery exemption did not prevent the OEM process manager from assigning the persistent process a cached OOM score and killing it.

Once the persistent process was killed, the MCS socket disappeared and Cloud Messaging reported that it was disconnected.

## Changes

- Add an opt-in `forceForeground` mode to `ForegroundServiceContext`.
- Use it when starting the MCS connection and heartbeat service.
- Preserve the existing behavior for all other callers.

## Verification

- `:play-services-core:assembleMapboxDefaultDebug --no-daemon --no-configuration-cache --max-workers=1`
- Build completed successfully and produced the Mapbox/default debug APK.
- The change only touches `ForegroundServiceContext.java` and `TriggerReceiver.java`.
