### PR TITLE
Semantic Location History: Add per-account Timeline settings

### DIFF
--- a/play-services-api/src/main/aidl/com/google/android/gms/semanticlocationhistory/internal/ISemanticLocationHistoryCallbacks.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/semanticlocationhistory/internal/ISemanticLocationHistoryCallbacks.aidl
@@ -15,7 +15,7 @@ import com.google.android.gms.semanticlocationhistory.LocationHistorySettings;
 import com.google.android.gms.semanticlocationhistory.OdlhBackupSummary;
 import com.google.android.gms.semanticlocationhistory.UserLocationProfile;
 
-interface ISemanticLocationHistoryCallbacks {
+oneway interface ISemanticLocationHistoryCallbacks {
     void onSegmentListResponse(in Status status, in List<LocationHistorySegment> segments, in ApiMetadata apiMetadata) = 0;
     void onGetInferredHomeResponse(in Status status, in InferredPlace inferredPlace, in ApiMetadata apiMetadata) = 1;
     void onGetInferredWorkResponse(in Status status, in InferredPlace inferredPlace, in ApiMetadata apiMetadata) = 2;

--- a/play-services-core-proto/src/main/proto/locationsharingreporter/user_location_reporting_service.proto
+++ b/play-services-core-proto/src/main/proto/locationsharingreporter/user_location_reporting_service.proto
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto2";
+
+package userlocation;
+
+service UserLocationReportingService {
+  rpc GetApiSettings (GetApiSettingsRequest) returns (GetApiSettingsResponse);
+  rpc SetApiSettings (SetApiSettingsRequest) returns (SetApiSettingsResponse);
+}
+
+message GetApiSettingsRequest {
+  optional int32 deviceTag = 1;
+  optional DeviceDescriptor device = 3;
+  optional bool requestFlag = 5;
+}
+
+message GetApiSettingsResponse {
+  optional ApiSettings settings = 2;
+}
+
+message SetApiSettingsRequest {
+  optional int32 deviceTag = 1;
+  optional DeviceDescriptor device = 3;
+  optional ApiSettings settings = 4;
+  optional ClientAuthTokens authTokens = 6;
+  optional bool requestFlag = 8;
+}
+
+message SetApiSettingsResponse {
+  optional ApiSettings settings = 2;
+}
+
+message ClientAuthTokens {
+  optional string historySource = 1;
+  optional string reportingSource = 2;
+  optional string auditToken = 3;
+}
+
+message DeviceDescriptor {
+  optional string buildFingerprint = 1;
+  optional int32 releaseYear = 2;
+  optional int32 enum6 = 6;
+  optional int32 sdkInt = 10;
+  optional string deviceModel = 11;
+  optional int32 enum12 = 12;
+  optional string gcmRegistrationId = 13;
+  optional int32 gmsVersionCode = 14;
+  optional int32 gmsApkVersionCode = 16;
+  optional BuildInfo buildInfo = 17;
+  optional int32 moduleVersion = 18;
+  optional int32 osType = 19;
+}
+
+message BuildInfo {
+  optional string manufacturer = 1;
+  optional string brand = 2;
+  optional string product = 3;
+  optional string device = 4;
+  optional string model = 5;
+  optional bool buildFlag = 7;
+}
+
+message ApiSettings {
+  optional int64 modMillis = 1;
+  optional bool historyEnabled = 2;
+  optional bool reportingEnabled = 3;
+  optional int32 userRestriction = 4;
+  optional int32 source = 5;
+  optional int32 concurrencyType = 7;
+  repeated Deletion deletions = 10;
+  optional DeviceCapabilities deviceCapabilities = 12;
+  optional Consent adsSubconsent = 13;
+  optional bool migratedToOdlh = 16;
+}
+
+message Consent {
+  optional bool enabled = 1;
+  optional int32 source = 3;
+}
+
+message Deletion {
+  optional int64 id = 1;
+  optional int64 startSeconds = 2;
+  optional int64 endSeconds = 3;
+}
+
+message DeviceCapabilities {
+  optional bool countryAllowed = 1;
+  optional bool deviceCapable = 2;
+  optional bool locationEnabled = 3;
+  optional bool restrictedProfile = 4;
+  optional bool deviceFormFactorSupported = 5;
+  optional int32 locationMode = 6;
+  optional bool wifiScanningEnabled = 7;
+  optional bool batterySaverOn = 9;
+  optional int32 batterySaverTriggerLevel = 10;
+}

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -805,6 +805,10 @@
             android:name="org.microg.gms.games.GamesConfigurationService"
             android:exported="false" />
 
+        <service
+            android:name="org.microg.gms.ui.AccountLocationSettingsService"
+            android:exported="false" />
+
         <!-- Chimera -->
         <provider
             android:name="org.microg.gms.chimera.ServiceProvider"

--- a/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/SemanticLocationHistoryService.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/SemanticLocationHistoryService.kt
@@ -5,6 +5,7 @@
 
 package com.google.android.gms.semanticlocationhistory
 
+import android.accounts.Account
 import android.content.Context
 import android.os.Parcel
 import android.util.Log
@@ -31,11 +32,13 @@ import com.google.android.gms.semanticlocationhistory.internal.ISemanticLocation
 import com.google.android.gms.semanticlocationhistory.internal.ISemanticLocationHistoryService
 import com.google.android.gms.semanticlocationhistory.utils.SegmentEditHandler
 import com.google.android.gms.semanticlocationhistory.utils.SegmentQueryHandler
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.microg.gms.BaseService
 import org.microg.gms.common.GmsService
+import org.microg.gms.common.GooglePackagePermission
 import org.microg.gms.common.PackageUtils
-import org.microg.gms.location.LocationSettings
+import org.microg.gms.location.reporting.fetchEffectiveTimelineEnabled
 import org.microg.gms.utils.warnOnTransactionIssues
 
 private val FEATURES = arrayOf(
@@ -64,21 +67,32 @@ class SemanticLocationHistoryService : BaseService(TAG, GmsService.SEMANTIC_LOCA
 class SemanticLocationHistoryServiceImpl(val context: Context, override val lifecycle: Lifecycle) : ISemanticLocationHistoryService.Stub(), LifecycleOwner {
     private val storageManager by lazy { OdlhStorageManager.getInstance(context) }
 
+    private fun withTimelineAccess(account: Account?, onDenied: () -> Unit, action: suspend () -> Unit) {
+        val canAccessRemoteSettings = PackageUtils.callerHasGooglePackagePermission(
+            context,
+            GooglePackagePermission.REPORTING
+        )
+        lifecycleScope.launch(Dispatchers.IO) {
+            if (!fetchEffectiveTimelineEnabled(context, account, canAccessRemoteSettings)) {
+                Log.w(TAG, "Timeline access denied")
+                onDenied()
+                return@launch
+            }
+            action()
+        }
+    }
+
     override fun getSegments(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, request: LocationHistorySegmentRequest?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "getSegments: requestCredentials=$requestCredentials, request=$request")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onGetSegmentsResponse(DataHolder.empty(CommonStatusCodes.SUCCESS), ApiMetadata.SKIP)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            Log.w(TAG, "getSegments: accountName is null or empty")
-            callback?.onGetSegmentsResponse(DataHolder.empty(CommonStatusCodes.ERROR), ApiMetadata.DEFAULT)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty()) {
+                Log.w(TAG, "getSegments: accountName is null or empty")
+                callback?.onGetSegmentsResponse(DataHolder.empty(CommonStatusCodes.ERROR), ApiMetadata.DEFAULT)
+                return@withTimelineAccess
+            }
             try {
                 val gaiaId = context.getObfuscatedGaiaId(accountName)
                 Log.d(TAG, "getSegments: gaiaId=${gaiaId.take(8)}...")
@@ -94,21 +108,17 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun onDemandBackup(callback: IStatusCallback?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "onDemandBackup: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        val account = requestCredentials?.account
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onResult(Status.SUCCESS)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            Log.w(TAG, "onDemandBackup: accountName is null or empty")
-            callback?.onResult(Status.SUCCESS)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            if (account == null || account.name.isEmpty()) {
+                Log.w(TAG, "onDemandBackup: accountName is null or empty")
+                callback?.onResult(Status.SUCCESS)
+                return@withTimelineAccess
+            }
             try {
-                val result = OdlhBackupProcessor.performBackup(context, accountName)
+                val result = OdlhBackupProcessor.performBackup(context, account)
                 Log.d(TAG, "onDemandBackup: result=$result")
                 callback?.onResult(if (result.success) Status.SUCCESS else Status(CommonStatusCodes.ERROR, result.message))
             } catch (e: Exception) {
@@ -120,25 +130,21 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun onDemandRestore(callback: IStatusCallback?, requestCredentials: RequestCredentials?, list: List<*>?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "onDemandRestore: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onResult(Status.SUCCESS)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            Log.w(TAG, "onDemandRestore: accountName is null or empty")
-            callback?.onResult(Status(CommonStatusCodes.ERROR, "Invalid account"))
-            return
-        }
-        val databaseIds = list?.filterIsInstance<Long>()
-        if (databaseIds.isNullOrEmpty()) {
-            Log.w(TAG, "onDemandRestore: no valid databaseIds")
-            callback?.onResult(Status(CommonStatusCodes.ERROR, "No databaseIds"))
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty()) {
+                Log.w(TAG, "onDemandRestore: accountName is null or empty")
+                callback?.onResult(Status(CommonStatusCodes.ERROR, "Invalid account"))
+                return@withTimelineAccess
+            }
+            val databaseIds = list?.filterIsInstance<Long>()
+            if (databaseIds.isNullOrEmpty()) {
+                Log.w(TAG, "onDemandRestore: no valid databaseIds")
+                callback?.onResult(Status(CommonStatusCodes.ERROR, "No databaseIds"))
+                return@withTimelineAccess
+            }
             try {
                 val gaiaId = context.getObfuscatedGaiaId(accountName)
                 val result = BackupRestoreHandler.restoreBackups(context, accountName, gaiaId, databaseIds, storageManager)
@@ -156,42 +162,34 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun getInferredHome(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "getInferredHome: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onGetInferredHomeResponse(Status.SUCCESS, null, ApiMetadata.SKIP)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            callback?.onGetInferredHomeResponse(Status.SUCCESS, null, ApiMetadata.DEFAULT)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty()) {
+                callback?.onGetInferredHomeResponse(Status.SUCCESS, null, ApiMetadata.DEFAULT)
+                return@withTimelineAccess
+            }
             val now = System.currentTimeMillis() / 1000
             val windowStart = now - SEARCH_WINDOW_DAYS * SECONDS_PER_DAY
             val visitSegments = storageManager.querySegments(
                 gaiaId = context.getObfuscatedGaiaId(accountName), startTime = windowStart, endTime = now, segmentTypes = intArrayOf(SEGMENT_TYPE_VISIT)
             )
             val inferredPlace = getInferredPlace(visitSegments, SEMANTIC_TYPE_HOME)
-            callback?.onGetInferredWorkResponse(Status.SUCCESS, inferredPlace, ApiMetadata.DEFAULT)
+            callback?.onGetInferredHomeResponse(Status.SUCCESS, inferredPlace, ApiMetadata.DEFAULT)
         }
     }
 
     override fun getInferredWork(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "getInferredWork: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onGetInferredWorkResponse(Status.SUCCESS, null, ApiMetadata.SKIP)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            callback?.onGetInferredWorkResponse(Status.SUCCESS, null, ApiMetadata.DEFAULT)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty()) {
+                callback?.onGetInferredWorkResponse(Status.SUCCESS, null, ApiMetadata.DEFAULT)
+                return@withTimelineAccess
+            }
             val now = System.currentTimeMillis() / 1000
             val windowStart = now - SEARCH_WINDOW_DAYS * SECONDS_PER_DAY
             val visitSegments = storageManager.querySegments(
@@ -204,19 +202,15 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun editSegments(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, list: List<LocationHistorySegment>?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "editSegments: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onEditSegmentsResponse(Status.SUCCESS, ApiMetadata.SKIP)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty() || list.isNullOrEmpty()) {
-            Log.w(TAG, "editSegments: invalid parameters")
-            callback?.onEditSegmentsResponse(Status(CommonStatusCodes.ERROR, "Invalid parameters"), ApiMetadata.DEFAULT)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty() || list.isNullOrEmpty()) {
+                Log.w(TAG, "editSegments: invalid parameters")
+                callback?.onEditSegmentsResponse(Status(CommonStatusCodes.ERROR, "Invalid parameters"), ApiMetadata.DEFAULT)
+                return@withTimelineAccess
+            }
             try {
                 val gaiaId = context.getObfuscatedGaiaId(accountName)
                 SegmentEditHandler.editSegments(storageManager, gaiaId, list)
@@ -233,19 +227,15 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun deleteHistory(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials, startTime: Long, endTime: Long, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "deleteHistory: requestCredentials=$requestCredentials startTime:$startTime endTime:$endTime")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials.account, {
             callback?.onDeleteHistoryResponse(Status.SUCCESS, ApiMetadata.SKIP)
-            return
-        }
-        val accountName = requestCredentials.account?.name
-        if (accountName.isNullOrEmpty()) {
-            Log.w(TAG, "deleteHistory: accountName is null or empty")
-            callback?.onDeleteHistoryResponse(Status(CommonStatusCodes.ERROR, "Invalid account"), ApiMetadata.DEFAULT)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials.account?.name
+            if (accountName.isNullOrEmpty()) {
+                Log.w(TAG, "deleteHistory: accountName is null or empty")
+                callback?.onDeleteHistoryResponse(Status(CommonStatusCodes.ERROR, "Invalid account"), ApiMetadata.DEFAULT)
+                return@withTimelineAccess
+            }
             try {
                 val gaiaId = context.getObfuscatedGaiaId(accountName)
                 SegmentEditHandler.deleteHistory(storageManager, gaiaId, startTime, endTime)
@@ -264,18 +254,14 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun getBackupSummary(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "getBackupSummary: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onGetBackupSummaryResponse(Status.SUCCESS, emptyList<OdlhBackupSummary>(), ApiMetadata.SKIP)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            callback?.onGetBackupSummaryResponse(Status.SUCCESS, emptyList<OdlhBackupSummary>(), ApiMetadata.DEFAULT)
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty()) {
+                callback?.onGetBackupSummaryResponse(Status.SUCCESS, emptyList<OdlhBackupSummary>(), ApiMetadata.DEFAULT)
+                return@withTimelineAccess
+            }
             try {
                 val summaries = BackupRestoreHandler.fetchBackupSummaries(context, accountName, storageManager)
                 Log.d(TAG, "getBackupSummary: returning ${summaries.size} summaries")
@@ -291,25 +277,21 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun deleteBackups(callback: IStatusCallback?, requestCredentials: RequestCredentials?, list: List<*>?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "deleteBackups: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onResult(Status.SUCCESS)
-            return
-        }
-        val accountName = requestCredentials?.account?.name
-        if (accountName.isNullOrEmpty()) {
-            Log.w(TAG, "deleteBackups: accountName is null or empty")
-            callback?.onResult(Status(CommonStatusCodes.ERROR, "Invalid account"))
-            return
-        }
-        val databaseIds = list?.filterIsInstance<Long>()
-        if (databaseIds.isNullOrEmpty()) {
-            Log.w(TAG, "deleteBackups: no valid databaseIds")
-            callback?.onResult(Status(CommonStatusCodes.ERROR, "No databaseIds"))
-            return
-        }
-        lifecycleScope.launch {
+        }) {
+            val accountName = requestCredentials?.account?.name
+            if (accountName.isNullOrEmpty()) {
+                Log.w(TAG, "deleteBackups: accountName is null or empty")
+                callback?.onResult(Status(CommonStatusCodes.ERROR, "Invalid account"))
+                return@withTimelineAccess
+            }
+            val databaseIds = list?.filterIsInstance<Long>()
+            if (databaseIds.isNullOrEmpty()) {
+                Log.w(TAG, "deleteBackups: no valid databaseIds")
+                callback?.onResult(Status(CommonStatusCodes.ERROR, "No databaseIds"))
+                return@withTimelineAccess
+            }
             try {
                 BackupRestoreHandler.deleteBackups(context, accountName, databaseIds, storageManager)
                 Log.d(TAG, "deleteBackups: completed successfully")
@@ -323,38 +305,42 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
 
     override fun getUserLocationProfile(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "getUserLocationProfile: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
+        withTimelineAccess(requestCredentials?.account, {
             callback?.onGetUserLocationProfileResponse(Status.SUCCESS, null, ApiMetadata.SKIP)
-            return
+        }) {
+            callback?.onGetUserLocationProfileResponse(Status.SUCCESS, null, ApiMetadata.DEFAULT)
         }
-        val accountName = requestCredentials?.account?.name
-        Log.d(TAG, "getUserLocationProfile: account=$accountName")
-        callback?.onGetUserLocationProfileResponse(Status.SUCCESS, null, ApiMetadata.DEFAULT)
     }
 
     override fun getLocationHistorySettings(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {
         Log.d(TAG, "getLocationHistorySettings: requestCredentials=$requestCredentials")
-        val allowedMapsTimelineFeature = LocationSettings(context).mapsTimeline
-        if (!allowedMapsTimelineFeature) {
-            Log.w(TAG, "Not Allowed!!")
-            callback?.onLocationHistorySettings(
-                Status.SUCCESS, LocationHistorySettings(false, 0, ReportingState(-1, -1, false, false, 1, 1, 0, false, true)), ApiMetadata.SKIP
+        val account = requestCredentials?.account
+        val canAccessSettings = PackageUtils.callerHasGooglePackagePermission(
+            context,
+            GooglePackagePermission.REPORTING
+        )
+        lifecycleScope.launch(Dispatchers.IO) {
+            val timelineEnabled = fetchEffectiveTimelineEnabled(
+                context,
+                account,
+                canAccessSettings
             )
-            return
+            val accountName = account?.name
+            val deviceTag = if (!accountName.isNullOrEmpty()) storageManager.getDeviceTag(accountName) else 0
+            val reportingState = ReportingState(
+                -1,
+                if (timelineEnabled) 1 else -1,
+                false,
+                false,
+                1,
+                1,
+                deviceTag,
+                false,
+                true
+            )
+            val settings = LocationHistorySettings(timelineEnabled, deviceTag, reportingState)
+            callback?.onLocationHistorySettings(Status.SUCCESS, settings, ApiMetadata.DEFAULT)
         }
-        val dbSize = storageManager.getDatabaseSize()
-        val accountName = requestCredentials?.account?.name
-        if (!accountName.isNullOrEmpty()) {
-            val segmentCount = storageManager.getSegmentCount(accountName)
-            Log.d(TAG, "getLocationHistorySettings: account=$accountName, segments=$segmentCount, dbSize=$dbSize")
-        }
-        val deviceTag = if (!accountName.isNullOrEmpty()) storageManager.getDeviceTag(accountName) else 0
-        Log.d(TAG, "getLocationHistorySettings_deviceTag: $deviceTag")
-        val reportingState = ReportingState(-1, 1, false, false, 1, 1, deviceTag, false, true)
-        val settings = LocationHistorySettings(true, deviceTag, reportingState)
-        callback?.onLocationHistorySettings(Status.SUCCESS, settings, ApiMetadata.DEFAULT)
     }
 
     override fun getExperimentVisits(callback: ISemanticLocationHistoryCallbacks?, requestCredentials: RequestCredentials?, apiMetadata: ApiMetadata?) {

--- a/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/SemanticLocationHistoryService.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/SemanticLocationHistoryService.kt
@@ -8,6 +8,7 @@ package com.google.android.gms.semanticlocationhistory
 import android.accounts.Account
 import android.content.Context
 import android.os.Parcel
+import android.os.RemoteException
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -73,12 +74,16 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
             GooglePackagePermission.REPORTING
         )
         lifecycleScope.launch(Dispatchers.IO) {
-            if (!fetchEffectiveTimelineEnabled(context, account, canAccessRemoteSettings)) {
-                Log.w(TAG, "Timeline access denied")
-                onDenied()
-                return@launch
+            try {
+                if (!fetchEffectiveTimelineEnabled(context, account, canAccessRemoteSettings)) {
+                    Log.w(TAG, "Timeline access denied")
+                    onDenied()
+                    return@launch
+                }
+                action()
+            } catch (e: RemoteException) {
+                Log.w(TAG, "Callback delivery failed", e)
             }
-            action()
         }
     }
 
@@ -339,7 +344,11 @@ class SemanticLocationHistoryServiceImpl(val context: Context, override val life
                 true
             )
             val settings = LocationHistorySettings(timelineEnabled, deviceTag, reportingState)
-            callback?.onLocationHistorySettings(Status.SUCCESS, settings, ApiMetadata.DEFAULT)
+            try {
+                callback?.onLocationHistorySettings(Status.SUCCESS, settings, ApiMetadata.DEFAULT)
+            } catch (e: RemoteException) {
+                Log.w(TAG, "Callback delivery failed", e)
+            }
         }
     }
 

--- a/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/db/backup/OdlhBackupProcessor.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/db/backup/OdlhBackupProcessor.kt
@@ -5,6 +5,7 @@
 
 package com.google.android.gms.semanticlocationhistory.db.backup
 
+import android.accounts.Account
 import android.content.Context
 import android.os.Build
 import android.util.Log
@@ -27,7 +28,8 @@ import com.google.android.gms.semanticlocationhistory.getObfuscatedGaiaId
 import com.google.android.gms.semanticlocationhistory.loadKeyMaterials
 import okio.ByteString.Companion.toByteString
 import org.microg.gms.common.Constants
-import org.microg.gms.location.LocationSettings
+import org.microg.gms.location.reporting.fetchEffectiveAccountLocationSettings
+import org.microg.gms.location.reporting.isLocalAccountReportingEnabled
 import java.security.SecureRandom
 import java.util.TimeZone
 import javax.crypto.Cipher
@@ -55,15 +57,21 @@ private const val TAG = "OdlhBackupProcessor"
 
 object OdlhBackupProcessor {
 
+    private fun isBackupEnabled(context: Context, account: Account): Boolean {
+        if (!isLocalAccountReportingEnabled(context, account)) return false
+        val settings = fetchEffectiveAccountLocationSettings(context, account)
+        return settings.allowed && settings.uploadAllowed
+    }
+
     /**
      * Performs a full backup of all location history data.
      */
-    suspend fun performBackup(context: Context, accountName: String): BackupResult {
-        val allowedUpload = LocationSettings(context).mapsTimelineUpload
-        if (!allowedUpload) {
+    suspend fun performBackup(context: Context, account: Account): BackupResult {
+        if (!isBackupEnabled(context, account)) {
             Log.w(TAG, "<performBackup> user not allowed report")
             return BackupResult(false, "Upload Not allowed!")
         }
+        val accountName = account.name
         Log.d(TAG, "performBackup: starting for account=$accountName")
         val gaiaId = context.getObfuscatedGaiaId(accountName)
         val storageManager = OdlhStorageManager.getInstance(context)
@@ -149,10 +157,10 @@ object OdlhBackupProcessor {
      * 4. Upload changed shards, delete removed shards
      * 5. Update shard sync snapshot + sync_token
      */
-    suspend fun performIncrementalBackup(context: Context, accountName: String): BackupResult {
+    suspend fun performIncrementalBackup(context: Context, account: Account): BackupResult {
+        val accountName = account.name
         Log.d(TAG, "performIncrementalBackup: starting for account=$accountName")
-        val allowedUpload = LocationSettings(context).mapsTimelineUpload
-        if (!allowedUpload) {
+        if (!isBackupEnabled(context, account)) {
             Log.w(TAG, "<performIncrementalBackup> user not allowed report")
             return BackupResult(false, "Upload Not allowed!")
         }

--- a/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/db/backup/OdlhBackupService.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/semanticlocationhistory/db/backup/OdlhBackupService.kt
@@ -16,9 +16,10 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.microg.gms.auth.AuthConstants
-import org.microg.gms.location.LocationSettings
+import org.microg.gms.location.reporting.hasAnyLocalAccountReportingEnabled
 
 private const val TAG = "OdlhBackupService"
 
@@ -29,13 +30,21 @@ class OdlhBackupService : LifecycleService() {
         private const val BACKUP_INTERVAL_MS = 8 * 60 * 60 * 1000L // 8h
 
         fun scheduleBackup(context: Context) {
-            val allowedMapsTimelineFeature = LocationSettings(context).mapsTimelineUpload
-            if (!allowedMapsTimelineFeature) {
-                Log.w(TAG, "scheduleBackup: not allowed report")
+            if (!hasAnyLocalAccountReportingEnabled(context)) {
+                cancelBackup(context)
+                Log.d(TAG, "scheduleBackup: skipped because local upload is disabled")
                 return
             }
             val alarmManager = context.getSystemService(ALARM_SERVICE) as AlarmManager
             val intent = Intent(context, OdlhBackupService::class.java).setAction(ACTION_BACKUP)
+            val existingIntent = PendingIntent.getService(
+                context, 0, intent,
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+            )
+            if (existingIntent != null) {
+                Log.d(TAG, "scheduleBackup: periodic backup already scheduled")
+                return
+            }
             val pendingIntent = PendingIntent.getService(
                 context, 0, intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
@@ -55,9 +64,10 @@ class OdlhBackupService : LifecycleService() {
             val intent = Intent(context, OdlhBackupService::class.java).setAction(ACTION_BACKUP)
             val pendingIntent = PendingIntent.getService(
                 context, 0, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+            ) ?: return
             alarmManager.cancel(pendingIntent)
+            pendingIntent.cancel()
             Log.d(TAG, "cancelBackup: periodic backup cancelled")
         }
     }
@@ -74,7 +84,7 @@ class OdlhBackupService : LifecycleService() {
 
         Log.d(TAG, "onStartCommand: periodic backup triggered")
 
-        lifecycleScope.launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             try {
                 performBackupForAllAccounts()
             } catch (e: Exception) {
@@ -101,7 +111,7 @@ class OdlhBackupService : LifecycleService() {
         for (account in accounts) {
             try {
                 Log.d(TAG, "performBackupForAllAccounts: starting for ${account.name}")
-                val result = OdlhBackupProcessor.performIncrementalBackup(this, account.name)
+                val result = OdlhBackupProcessor.performIncrementalBackup(this, account)
                 Log.d(TAG, "performBackupForAllAccounts: ${account.name} result=$result")
             } catch (e: Exception) {
                 Log.e(TAG, "performBackupForAllAccounts: failed for ${account.name}", e)

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountDetailsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountDetailsFragment.kt
@@ -1,0 +1,205 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.ui
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+import com.google.android.gms.R
+import kotlinx.coroutines.launch
+import org.microg.gms.auth.AuthConstants
+import org.microg.gms.location.reporting.ManagedAccountLocationSettings
+import org.microg.gms.location.reporting.REPORTING_SETTINGS_CHANGED_ACTION
+
+internal const val ARG_ACCOUNT_DETAILS_NAME = "accountName"
+
+private const val PREF_ACCOUNT_DETAILS_HEADER = "pref_account_details_header"
+private const val PREF_ACCOUNT_TIMELINE = "pref_account_timeline"
+private const val PREF_ACCOUNT_TIMELINE_UPLOAD = "pref_account_timeline_upload"
+private const val PREF_ACCOUNT_SYSTEM_SYNC = "pref_account_system_sync"
+
+class AccountDetailsFragment : PreferenceFragmentCompat() {
+    private lateinit var account: Account
+    private lateinit var timeline: SwitchPreferenceCompat
+    private lateinit var timelineUpload: SwitchPreferenceCompat
+    private var accountSettings: ManagedAccountLocationSettings? = null
+    private var requestId = 0
+    private var requestInProgress = false
+    private var refreshPending = false
+    private val settingsChangedReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != REPORTING_SETTINGS_CHANGED_ACTION) return
+            if (requestInProgress) {
+                refreshPending = true
+            } else {
+                loadSettings(forceRefresh = false)
+            }
+        }
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences_account_details, rootKey)
+        account = Account(
+            requireArguments().getString(ARG_ACCOUNT_DETAILS_NAME).orEmpty(),
+            AuthConstants.DEFAULT_ACCOUNT_TYPE
+        )
+        timeline = requireNotNull(findPreference(PREF_ACCOUNT_TIMELINE))
+        timelineUpload = requireNotNull(findPreference(PREF_ACCOUNT_TIMELINE_UPLOAD))
+
+        findPreference<Preference>(PREF_ACCOUNT_DETAILS_HEADER)?.apply {
+            title = account.name
+            summary = getString(R.string.pref_account_type_google)
+        }
+        timeline.setOnPreferenceChangeListener { _, newValue ->
+            val settings = accountSettings
+            if (newValue is Boolean && settings != null) {
+                updateSettings(
+                    historyEnabled = newValue,
+                    reportingEnabled = newValue && settings.reportingEnabled == true,
+                    synchronizeHistoryEnabled = true
+                )
+            }
+            false
+        }
+        timelineUpload.setOnPreferenceChangeListener { _, newValue ->
+            val settings = accountSettings
+            if (newValue is Boolean && settings != null) {
+                updateSettings(
+                    historyEnabled = settings.historyEnabled == true,
+                    reportingEnabled = newValue,
+                    synchronizeHistoryEnabled = false
+                )
+            }
+            false
+        }
+        findPreference<Preference>(PREF_ACCOUNT_SYSTEM_SYNC)?.setOnPreferenceClickListener {
+            startActivity(Intent(Settings.ACTION_SYNC_SETTINGS).apply {
+                putExtra(Settings.EXTRA_ACCOUNT_TYPES, arrayOf(AuthConstants.DEFAULT_ACCOUNT_TYPE))
+            })
+            true
+        }
+        renderSettings(null, loading = true)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!AccountManager.get(requireContext())
+                .getAccountsByType(AuthConstants.DEFAULT_ACCOUNT_TYPE)
+                .contains(account)) {
+            findNavController().popBackStack()
+            return
+        }
+        loadSettings(forceRefresh = true)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        ContextCompat.registerReceiver(
+            requireContext(),
+            settingsChangedReceiver,
+            IntentFilter(REPORTING_SETTINGS_CHANGED_ACTION),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+    }
+
+    override fun onStop() {
+        requireContext().unregisterReceiver(settingsChangedReceiver)
+        super.onStop()
+    }
+
+    private fun loadSettings(forceRefresh: Boolean) {
+        val context = requireContext().applicationContext
+        val currentRequestId = ++requestId
+        requestInProgress = true
+        renderSettings(accountSettings, loading = true)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val settings = AccountLocationSettingsService.fetchSettings(
+                context,
+                account,
+                forceRefresh = forceRefresh
+            )
+            if (currentRequestId != requestId) return@launch
+            requestInProgress = false
+            accountSettings = settings
+            renderSettings(settings, loading = false)
+            refreshIfPending()
+        }
+    }
+
+    private fun updateSettings(
+        historyEnabled: Boolean,
+        reportingEnabled: Boolean,
+        synchronizeHistoryEnabled: Boolean
+    ) {
+        val context = requireContext().applicationContext
+        val currentRequestId = ++requestId
+        requestInProgress = true
+        renderSettings(accountSettings, loading = true)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val result = AccountLocationSettingsService.updateSettings(
+                context,
+                account,
+                historyEnabled,
+                reportingEnabled,
+                synchronizeHistoryEnabled
+            )
+            if (currentRequestId != requestId) return@launch
+            requestInProgress = false
+            result.settings?.let { accountSettings = it }
+            renderSettings(accountSettings, loading = false)
+            if (!result.success) {
+                Toast.makeText(
+                    requireContext(),
+                    R.string.pref_account_timeline_update_failed,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            refreshIfPending()
+        }
+    }
+
+    private fun refreshIfPending() {
+        if (!refreshPending) return
+        refreshPending = false
+        loadSettings(forceRefresh = false)
+    }
+
+    private fun renderSettings(settings: ManagedAccountLocationSettings?, loading: Boolean) {
+        val restricted = settings?.userRestriction?.let { it != 0 } == true
+        val historyKnown = settings?.historyEnabled != null
+        val canDisableUpload = settings?.reportingEnabled == true
+        val canEnableUpload = settings?.historyEnabled == true && !restricted
+        timeline.isChecked = settings?.timelineEnabled == true
+        timelineUpload.isChecked = settings?.reportingEnabled == true
+        timeline.isEnabled = !loading && historyKnown && !restricted
+        timelineUpload.isEnabled = !loading && settings != null &&
+                (canDisableUpload || canEnableUpload)
+        timeline.summary = when {
+            loading -> getString(R.string.pref_account_timeline_loading)
+            !historyKnown -> getString(R.string.pref_account_timeline_unavailable)
+            restricted -> getString(R.string.pref_account_timeline_restricted)
+            else -> getString(R.string.pref_account_timeline_summary)
+        }
+        timelineUpload.summary = when {
+            loading -> getString(R.string.pref_account_timeline_loading)
+            !historyKnown -> getString(R.string.pref_account_timeline_unavailable)
+            restricted && !canDisableUpload -> getString(R.string.pref_account_timeline_restricted)
+            else -> getString(R.string.pref_account_timeline_upload_summary)
+        }
+    }
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountLocationSettingsService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountLocationSettingsService.kt
@@ -1,0 +1,282 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.ui
+
+import android.accounts.Account
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import android.util.Log
+import com.google.android.gms.semanticlocationhistory.db.backup.OdlhBackupService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import org.microg.gms.location.reporting.ManagedAccountLocationSettings
+import org.microg.gms.location.reporting.ManagedAccountLocationSettingsUpdate
+import org.microg.gms.location.reporting.fetchManagedAccountLocationSettings
+import org.microg.gms.location.reporting.updateManagedAccountLocationSettings
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+
+private const val MSG_FETCH_SETTINGS = 1
+private const val MSG_UPDATE_SETTINGS = 2
+private const val TAG = "AccountLocationSettings"
+private const val REQUEST_TIMEOUT_MS = 30_000L
+
+private const val DATA_ACCOUNT = "account"
+private const val DATA_FORCE_REFRESH = "force_refresh"
+private const val DATA_HISTORY_ENABLED = "history_enabled"
+private const val DATA_REPORTING_ENABLED = "reporting_enabled"
+private const val DATA_SYNCHRONIZE_HISTORY_ENABLED = "synchronize_history_enabled"
+private const val DATA_SUCCESS = "success"
+private const val DATA_SETTINGS_PRESENT = "settings_present"
+private const val DATA_HISTORY_PRESENT = "history_present"
+private const val DATA_REPORTING_PRESENT = "reporting_present"
+private const val DATA_USER_RESTRICTION_PRESENT = "user_restriction_present"
+private const val DATA_USER_RESTRICTION = "user_restriction"
+
+/**
+ * Keeps account location settings access in the default GMS process. The settings UI runs in
+ * `:ui`, while reporting and backup services run in the default process. Using this service
+ * prevents the two processes from maintaining independent SharedPreferences caches.
+ */
+class AccountLocationSettingsService : Service() {
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val messenger = Messenger(Handler(Looper.getMainLooper()) { message ->
+        handleMessage(message)
+        true
+    })
+
+    override fun onBind(intent: Intent?): IBinder = messenger.binder
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    private fun handleMessage(message: Message) {
+        val replyTo = message.replyTo ?: return
+        val requestData = message.data.apply {
+            classLoader = Account::class.java.classLoader
+        }
+        val requestType = message.what
+        serviceScope.launch {
+            val responseData = runCatching {
+                when (requestType) {
+                    MSG_FETCH_SETTINGS -> fetchSettings(requestData)
+                    MSG_UPDATE_SETTINGS -> updateSettings(requestData)
+                    else -> Bundle.EMPTY
+                }
+            }.onFailure {
+                Log.w(TAG, "Failed to process account location settings request", it)
+            }.getOrElse {
+                failureResponse(requestType)
+            }
+            runCatching {
+                replyTo.send(Message.obtain().apply {
+                    what = requestType
+                    data = responseData
+                })
+            }.onFailure {
+                Log.w(TAG, "Failed to return account location settings response", it)
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun Bundle.getAccount(): Account? = getParcelable(DATA_ACCOUNT)
+
+    private fun fetchSettings(data: Bundle): Bundle {
+        val account = data.getAccount() ?: return settingsResponse(null)
+        val settings = runCatching {
+            fetchManagedAccountLocationSettings(
+                this,
+                account,
+                forceRefresh = data.getBoolean(DATA_FORCE_REFRESH)
+            )
+        }.onFailure {
+            Log.w(TAG, "Failed to fetch account location settings", it)
+        }.getOrNull()
+        return settingsResponse(settings)
+    }
+
+    private fun updateSettings(data: Bundle): Bundle {
+        val account = data.getAccount()
+        val result = if (account == null) {
+            ManagedAccountLocationSettingsUpdate(false, null)
+        } else {
+            runCatching {
+                updateManagedAccountLocationSettings(
+                    this,
+                    account,
+                    historyEnabled = data.getBoolean(DATA_HISTORY_ENABLED),
+                    reportingEnabled = data.getBoolean(DATA_REPORTING_ENABLED),
+                    synchronizeHistoryEnabled = data.getBoolean(DATA_SYNCHRONIZE_HISTORY_ENABLED)
+                )
+            }.onFailure {
+                Log.w(TAG, "Failed to update account location settings", it)
+            }.getOrElse { ManagedAccountLocationSettingsUpdate(false, null) }
+        }
+        runCatching {
+            OdlhBackupService.scheduleBackup(this)
+        }.onFailure {
+            Log.w(TAG, "Failed to update location history backup schedule", it)
+        }
+        return settingsResponse(result.settings).apply {
+            putBoolean(DATA_SUCCESS, result.success)
+        }
+    }
+
+    companion object {
+        suspend fun fetchSettings(
+            context: Context,
+            account: Account,
+            forceRefresh: Boolean
+        ): ManagedAccountLocationSettings? {
+            val response = request(context, Message.obtain().apply {
+                what = MSG_FETCH_SETTINGS
+                data = Bundle().apply {
+                    putParcelable(DATA_ACCOUNT, account)
+                    putBoolean(DATA_FORCE_REFRESH, forceRefresh)
+                }
+            })
+            return response?.getSettings()
+        }
+
+        suspend fun updateSettings(
+            context: Context,
+            account: Account,
+            historyEnabled: Boolean,
+            reportingEnabled: Boolean,
+            synchronizeHistoryEnabled: Boolean
+        ): ManagedAccountLocationSettingsUpdate {
+            val response = request(context, Message.obtain().apply {
+                what = MSG_UPDATE_SETTINGS
+                data = Bundle().apply {
+                    putParcelable(DATA_ACCOUNT, account)
+                    putBoolean(DATA_HISTORY_ENABLED, historyEnabled)
+                    putBoolean(DATA_REPORTING_ENABLED, reportingEnabled)
+                    putBoolean(DATA_SYNCHRONIZE_HISTORY_ENABLED, synchronizeHistoryEnabled)
+                }
+            })
+            return ManagedAccountLocationSettingsUpdate(
+                success = response?.getBoolean(DATA_SUCCESS) == true,
+                settings = response?.getSettings()
+            )
+        }
+
+        private suspend fun request(context: Context, message: Message): Bundle? {
+            var completed = false
+            val response = withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
+                requestFromService(context, message).also { completed = true }
+            }
+            if (!completed) Log.w(TAG, "Account location settings request timed out")
+            return response
+        }
+
+        private suspend fun requestFromService(context: Context, message: Message): Bundle? =
+            suspendCancellableCoroutine { continuation ->
+                val completed = AtomicBoolean(false)
+                var bound = false
+                lateinit var connection: ServiceConnection
+
+                fun complete(response: Bundle?) {
+                    if (!completed.compareAndSet(false, true)) return
+                    if (bound) runCatching { context.unbindService(connection) }
+                    if (continuation.isActive) continuation.resume(response)
+                }
+
+                connection = object : ServiceConnection {
+                    override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                        if (service == null) {
+                            complete(null)
+                            return
+                        }
+                        message.replyTo = Messenger(Handler(Looper.getMainLooper()) { response ->
+                            complete(response.data)
+                            true
+                        })
+                        runCatching {
+                            Messenger(service).send(message)
+                        }.onFailure {
+                            Log.w(TAG, "Failed to send account location settings request", it)
+                            complete(null)
+                        }
+                    }
+
+                    override fun onServiceDisconnected(name: ComponentName?) {
+                        Log.w(TAG, "Account location settings service disconnected")
+                        complete(null)
+                    }
+                }
+
+                val bindResult = runCatching {
+                    context.bindService(
+                        Intent(context, AccountLocationSettingsService::class.java),
+                        connection,
+                        Context.BIND_AUTO_CREATE or Context.BIND_ABOVE_CLIENT
+                    )
+                }.onFailure {
+                    Log.w(TAG, "Failed to bind account location settings service", it)
+                }
+                bound = bindResult.getOrDefault(false)
+                if (!bound) {
+                    if (bindResult.isSuccess) {
+                        Log.w(TAG, "Account location settings service binding was rejected")
+                    }
+                    complete(null)
+                }
+
+                continuation.invokeOnCancellation {
+                    if (completed.compareAndSet(false, true) && bound) {
+                        runCatching { context.unbindService(connection) }
+                    }
+                }
+            }
+    }
+}
+
+private fun failureResponse(requestType: Int): Bundle = settingsResponse(null).apply {
+    if (requestType == MSG_UPDATE_SETTINGS) putBoolean(DATA_SUCCESS, false)
+}
+
+private fun settingsResponse(settings: ManagedAccountLocationSettings?): Bundle = Bundle().apply {
+    putBoolean(DATA_SETTINGS_PRESENT, settings != null)
+    if (settings == null) return@apply
+    putBoolean(DATA_HISTORY_PRESENT, settings.historyEnabled != null)
+    settings.historyEnabled?.let { putBoolean(DATA_HISTORY_ENABLED, it) }
+    putBoolean(DATA_REPORTING_PRESENT, settings.reportingEnabled != null)
+    settings.reportingEnabled?.let { putBoolean(DATA_REPORTING_ENABLED, it) }
+    putBoolean(DATA_USER_RESTRICTION_PRESENT, settings.userRestriction != null)
+    settings.userRestriction?.let { putInt(DATA_USER_RESTRICTION, it) }
+}
+
+private fun Bundle.getSettings(): ManagedAccountLocationSettings? {
+    if (!getBoolean(DATA_SETTINGS_PRESENT)) return null
+    return ManagedAccountLocationSettings(
+        historyEnabled = getBoolean(DATA_HISTORY_ENABLED).takeIf {
+            getBoolean(DATA_HISTORY_PRESENT)
+        },
+        reportingEnabled = getBoolean(DATA_REPORTING_ENABLED).takeIf {
+            getBoolean(DATA_REPORTING_PRESENT)
+        },
+        userRestriction = getInt(DATA_USER_RESTRICTION).takeIf {
+            getBoolean(DATA_USER_RESTRICTION_PRESENT)
+        }
+    )
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountsFragment.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/ui/AccountsFragment.kt
@@ -10,11 +10,11 @@ import android.accounts.AccountManager
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.provider.Settings
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
+import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
@@ -121,10 +121,12 @@ class AccountsFragment : PreferenceFragmentCompat() {
                     }
                 }
                 setOnPreferenceClickListener {
-                    startActivity(Intent(Settings.ACTION_SYNC_SETTINGS).apply {
-                        putExtra(Settings.EXTRA_ACCOUNT_TYPES, arrayOf(AuthConstants.DEFAULT_ACCOUNT_TYPE))
-                    })
-                    false
+                    findNavController().navigate(
+                        requireContext(),
+                        R.id.openAccountDetails,
+                        bundleOf(ARG_ACCOUNT_DETAILS_NAME to account.name)
+                    )
+                    true
                 }
             }
             preference

--- a/play-services-core/src/main/res/navigation/nav_settings.xml
+++ b/play-services-core/src/main/res/navigation/nav_settings.xml
@@ -53,13 +53,22 @@
         android:id="@+id/accountManagerFragment"
         android:name="org.microg.gms.ui.AccountsFragment"
         android:label="@string/pref_accounts_title">
+        <deepLink app:uri="x-gms-settings://accounts" />
         <action
             android:id="@+id/openGameManagerSettings"
             app:destination="@id/gameManagerFragment" />
         <action
             android:id="@+id/openPasskeyManagerSettings"
             app:destination="@id/passkeyManagerFragment" />
+        <action
+            android:id="@+id/openAccountDetails"
+            app:destination="@id/accountDetailsFragment" />
     </fragment>
+
+    <fragment
+        android:id="@+id/accountDetailsFragment"
+        android:name="org.microg.gms.ui.AccountDetailsFragment"
+        android:label="@string/pref_account_details_title" />
 
     <fragment
         android:id="@+id/gameManagerFragment"

--- a/play-services-core/src/main/res/values-zh-rCN/strings.xml
+++ b/play-services-core/src/main/res/values-zh-rCN/strings.xml
@@ -417,4 +417,20 @@ microG GmsCore 内置一套自由的 SafetyNet 实现，但是官方服务器要
     <string name="pref_passkey_manager_transport_bluetooth">蓝牙</string>
     <string name="pref_passkey_manager_transport_hybrid">混合</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <!-- Account Timeline settings -->
+    <string name="pref_account_details_title">账号详情</string>
+    <string name="pref_account_type_google">Google 账号</string>
+    <string name="prefcat_account_timeline_title">Google Maps 时间轴</string>
+    <string name="pref_account_timeline_title">启动位置历史记录</string>
+    <string name="pref_account_timeline_summary">定期保存此账号的位置信息，以确保 Google Maps 时间轴正常运行。</string>
+    <string name="pref_account_timeline_upload_title">允许同步至服务器</string>
+    <string name="pref_account_timeline_upload_summary">允许当前设备定期将此账号的位置历史记录上传至 Google 服务器。</string>
+    <string name="pref_account_timeline_cloud_notice">位置记录设置会同步至此 Google 账号；允许上传开关仅对当前设备生效。</string>
+    <string name="prefcat_account_settings_title">设置</string>
+    <string name="pref_account_system_sync_title">系统账号同步设置</string>
+    <string name="pref_account_timeline_loading">正在加载账号设置…</string>
+    <string name="pref_account_timeline_unavailable">暂时无法获取账号设置。</string>
+    <string name="pref_account_timeline_restricted">此账号受到限制，无法修改该设置。</string>
+    <string name="pref_account_timeline_update_failed">本地上传设置已保存，但无法确认账号设置已更新，请刷新后重试。</string>
 </resources>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -475,4 +475,20 @@ Please set up a password, PIN, or pattern lock screen."</string>
     <string name="pref_passkey_manager_transport_bluetooth">Bluetooth</string>
     <string name="pref_passkey_manager_transport_hybrid">Hybrid</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <!-- Account Timeline settings -->
+    <string name="pref_account_details_title">Account details</string>
+    <string name="pref_account_type_google">Google account</string>
+    <string name="prefcat_account_timeline_title">Google Maps Timeline</string>
+    <string name="pref_account_timeline_title">Enable location history</string>
+    <string name="pref_account_timeline_summary">Periodically save this account\'s location history so Google Maps Timeline can work.</string>
+    <string name="pref_account_timeline_upload_title">Allow sync to server</string>
+    <string name="pref_account_timeline_upload_summary">Allow this device to periodically upload this account\'s location history to Google servers.</string>
+    <string name="pref_account_timeline_cloud_notice">Location History is synchronized with this Google Account. Upload permission applies only to this device.</string>
+    <string name="prefcat_account_settings_title">Settings</string>
+    <string name="pref_account_system_sync_title">System account sync settings</string>
+    <string name="pref_account_timeline_loading">Loading account settings…</string>
+    <string name="pref_account_timeline_unavailable">Account settings are currently unavailable.</string>
+    <string name="pref_account_timeline_restricted">This setting is restricted for this account.</string>
+    <string name="pref_account_timeline_update_failed">The local upload preference was saved, but the account setting could not be confirmed. Refresh and try again.</string>
 </resources>

--- a/play-services-core/src/main/res/xml/preferences_account_details.xml
+++ b/play-services-core/src/main/res/xml/preferences_account_details.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="pref_account_details_header"
+        app:selectable="false" />
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/prefcat_account_timeline_title">
+
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="false"
+            app:key="pref_account_timeline"
+            app:persistent="false"
+            app:summary="@string/pref_account_timeline_summary"
+            app:title="@string/pref_account_timeline_title" />
+
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="false"
+            app:key="pref_account_timeline_upload"
+            app:persistent="false"
+            app:summary="@string/pref_account_timeline_upload_summary"
+            app:title="@string/pref_account_timeline_upload_title" />
+
+        <Preference
+            app:iconSpaceReserved="false"
+            app:selectable="false"
+            app:summary="@string/pref_account_timeline_cloud_notice" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/prefcat_account_settings_title">
+
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="pref_account_system_sync"
+            app:title="@string/pref_account_system_sync_title" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/play-services-location/core/build.gradle
+++ b/play-services-location/core/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     api project(':play-services-location')
     implementation project(':play-services-base-core')
     implementation project(':play-services-location-core-base')
+    implementation project(':play-services-core-proto')
 
     implementation "androidx.core:core-ktx:$coreVersion"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"

--- a/play-services-location/core/src/main/AndroidManifest.xml
+++ b/play-services-location/core/src/main/AndroidManifest.xml
@@ -9,7 +9,10 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BODY_SENSORS" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
 
     <uses-permission
         android:name="android.permission.UPDATE_DEVICE_STATS"

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingAndroidService.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingAndroidService.kt
@@ -5,12 +5,17 @@
 package org.microg.gms.location.reporting
 
 import android.os.RemoteException
+import android.util.Log
+import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.internal.ConnectionInfo
 import com.google.android.gms.common.internal.GetServiceRequest
 import com.google.android.gms.common.internal.IGmsCallbacks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.microg.gms.BaseService
 import org.microg.gms.common.GmsService
+import org.microg.gms.common.GooglePackagePermission
 import org.microg.gms.common.PackageUtils
 import org.microg.gms.location.manager.FEATURES
 
@@ -19,9 +24,22 @@ class ReportingAndroidService : BaseService("GmsLocReportingSvc", GmsService.REP
     override fun handleServiceRequest(callback: IGmsCallbacks, request: GetServiceRequest, service: GmsService) {
         val packageName = PackageUtils.getAndCheckCallingPackage(this, request.packageName)
             ?: throw IllegalArgumentException("Missing package name")
+        val canSynchronizeSettings = PackageUtils.callerHasGooglePackagePermission(
+            this,
+            GooglePackagePermission.REPORTING
+        )
+        if (canSynchronizeSettings) {
+            lifecycleScope.launch(Dispatchers.IO) {
+                runCatching {
+                    synchronizePendingAccountOptIns(this@ReportingAndroidService)
+                }.onFailure {
+                    Log.w(TAG, "Failed to synchronize pending account opt-ins", it)
+                }
+            }
+        }
         callback.onPostInitCompleteWithConnectionInfo(
             CommonStatusCodes.SUCCESS,
-            ReportingServiceInstance(this, packageName),
+            ReportingServiceInstance(this, packageName, lifecycle),
             ConnectionInfo().apply { features = FEATURES }
         )
     }

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingApiSettings.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingApiSettings.kt
@@ -1,0 +1,551 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.microg.gms.location.reporting
+
+import android.accounts.Account
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import com.google.android.gms.location.reporting.ReportingState
+import org.microg.gms.auth.AuthConstants
+import userlocation.ApiSettings
+import userlocation.ClientAuthTokens
+import userlocation.GetApiSettingsRequest
+import userlocation.SetApiSettingsRequest
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+
+private const val CACHE_TTL_MS = 5 * 60_000L
+private const val FAILURE_CACHE_TTL_MS = 30_000L
+private const val NOT_DIRTY_SOURCE = "com.google.android.gms+not-dirty"
+private const val ACCOUNT_SETTINGS_SOURCE = "com.google.android.gms+settings+com.google.android.gms"
+
+private const val API_SETTINGS_SOURCE_CONCURRENT = 3
+private const val API_SETTINGS_CONCURRENCY_UNKNOWN_DEVICE_TAG = 2
+
+private const val OPT_IN_RESULT_NOT_ALLOWED = 7
+private const val OPT_IN_RESULT_UNSUPPORTED_GEO = 13
+private const val OPT_IN_RESULT_UNSUPPORTED_FORM_FACTOR = 14
+
+internal data class AccountApiSettings(
+    val modMillis: Long?,
+    val historyEnabled: Boolean?,
+    val reportingEnabled: Boolean?,
+    val userRestriction: Int?,
+    val migratedToOdlh: Boolean?,
+    val source: Int?,
+    val concurrencyType: Int?
+)
+
+private data class CachedApiSettings(
+    val settings: AccountApiSettings?,
+    val expiresAt: Long
+)
+
+private data class FetchApiSettingsResult(
+    val settings: AccountApiSettings?,
+    val retrySoon: Boolean = false
+)
+
+private data class SetApiSettingsResult(
+    val settings: AccountApiSettings?,
+    val applied: Boolean
+)
+
+data class EffectiveAccountLocationSettings(
+    val timelineEnabled: Boolean,
+    val uploadAllowed: Boolean,
+    val historyStatus: Int,
+    val reportingStatus: Int,
+    val allowed: Boolean,
+    val active: Boolean,
+    val migratedToOdlh: Boolean,
+    private val standardOptInResult: Int,
+    private val gmsOptInResult: Int
+) {
+    fun expectedOptInResult(
+        callerAllowed: Boolean = true,
+        isGmsCaller: Boolean = false
+    ): Int = when {
+        standardOptInResult == OPT_IN_RESULT_INVALID_ACCOUNT -> OPT_IN_RESULT_INVALID_ACCOUNT
+        !callerAllowed -> OPT_IN_RESULT_CALLER_NOT_ALLOWED
+        isGmsCaller -> gmsOptInResult
+        else -> standardOptInResult
+    }
+
+    fun toReportingState(
+        deviceTag: Int?,
+        canAccessSettings: Boolean = false,
+        optInResult: Int = expectedOptInResult()
+    ) = ReportingState(
+        reportingStatus,
+        historyStatus,
+        allowed,
+        active,
+        optInResult,
+        optInResult,
+        deviceTag,
+        canAccessSettings,
+        migratedToOdlh
+    )
+}
+
+data class ManagedAccountLocationSettings(
+    val historyEnabled: Boolean?,
+    val reportingEnabled: Boolean?,
+    val userRestriction: Int?
+) {
+    val timelineEnabled: Boolean
+        get() = historyEnabled == true
+}
+
+data class ManagedAccountLocationSettingsUpdate(
+    val success: Boolean,
+    val settings: ManagedAccountLocationSettings?
+)
+
+private val apiSettingsCache = ConcurrentHashMap<Account, CachedApiSettings>()
+private val apiSettingsLocks = ConcurrentHashMap<Account, Any>()
+
+internal fun setLocalAccountReportingEnabled(
+    context: Context,
+    account: Account,
+    enabled: Boolean
+): Boolean {
+    if (!isGoogleAccountOnDevice(context, account)) return false
+    if (ReportingSettingsStore.setLocalReportingEnabled(context, account, enabled)) {
+        notifyReportingSettingsChanged(context)
+    }
+    return true
+}
+
+fun isLocalAccountReportingEnabled(context: Context, account: Account): Boolean =
+    isGoogleAccountOnDevice(context, account) &&
+            ReportingSettingsStore.getLocalReportingEnabled(context, account)
+
+fun hasAnyLocalAccountReportingEnabled(context: Context): Boolean = runCatching {
+    context.googleAccounts.any { ReportingSettingsStore.getLocalReportingEnabled(context, it) }
+}.getOrDefault(false)
+
+private fun AccountApiSettings?.withPendingOptIn(
+    context: Context,
+    account: Account
+): AccountApiSettings? {
+    if (ReportingSettingsStore.getPendingOptIn(context, account) == null) return this
+    return (this ?: ReportingSettingsStore.getDeviceRegistration(context, account).toLastSettings()).copy(
+        historyEnabled = true,
+        reportingEnabled = true
+    )
+}
+
+internal fun queueAccountOptIn(
+    context: Context,
+    account: Account,
+    source: String,
+    auditToken: String?
+): Boolean {
+    if (!isGoogleAccountOnDevice(context, account)) return false
+    if (!ReportingSettingsStore.queuePendingOptIn(context, account, source, auditToken)) return false
+    notifyReportingSettingsChanged(context)
+    return true
+}
+
+internal fun getReportingDeviceTag(context: Context, account: Account): Int =
+    ReportingSettingsStore.getDeviceRegistration(context, account).deviceTag
+
+private fun ApiSettings.toAccountApiSettings(): AccountApiSettings =
+    AccountApiSettings(
+        modMillis = modMillis,
+        historyEnabled = historyEnabled,
+        reportingEnabled = reportingEnabled,
+        userRestriction = userRestriction,
+        migratedToOdlh = migratedToOdlh,
+        source = source,
+        concurrencyType = concurrencyType
+    )
+
+private fun AccountApiSettings.toManagedAccountLocationSettings(localReportingEnabled: Boolean) =
+    ManagedAccountLocationSettings(
+        historyEnabled = historyEnabled,
+        reportingEnabled = localReportingEnabled,
+        userRestriction = userRestriction
+    )
+
+private fun ApiSettings.toSetResponseSettings(
+    fallback: AccountApiSettings?,
+    historyRequested: Boolean?
+): AccountApiSettings {
+    val response = toAccountApiSettings()
+    return response.copy(
+        modMillis = response.modMillis ?: fallback?.modMillis,
+        historyEnabled = response.historyEnabled
+                ?: fallback?.historyEnabled?.takeIf {
+                    historyRequested == null || it == historyRequested
+                },
+        userRestriction = response.userRestriction ?: fallback?.userRestriction,
+        migratedToOdlh = response.migratedToOdlh ?: fallback?.migratedToOdlh,
+        source = response.source ?: fallback?.source,
+        concurrencyType = response.concurrencyType ?: fallback?.concurrencyType
+    )
+}
+
+private fun AccountApiSettings.matchesRequestedSettings(
+    historyEnabled: Boolean?,
+    reportingEnabled: Boolean?
+): Boolean =
+    (historyEnabled == null || this.historyEnabled == historyEnabled) &&
+            (reportingEnabled == null || this.reportingEnabled == null || this.reportingEnabled == reportingEnabled)
+
+private fun AccountApiSettings.canRetryConcurrentUpdate(): Boolean =
+    source == API_SETTINGS_SOURCE_CONCURRENT &&
+            concurrencyType != API_SETTINGS_CONCURRENCY_UNKNOWN_DEVICE_TAG
+
+private fun getApiSettings(session: ReportingApiSession): ApiSettings? {
+    val request = GetApiSettingsRequest.Builder()
+            .deviceTag(session.deviceTag)
+            .device(session.device)
+            .requestFlag(false)
+            .build()
+    return runCatching {
+        session.client.GetApiSettings().executeBlocking(request).settings
+                ?: throw IOException("GetApiSettings returned no settings")
+    }.onFailure {
+        Log.w(TAG, "GetApiSettings failed", it)
+    }.getOrNull()
+}
+
+private fun setApiSettings(
+    context: Context,
+    account: Account,
+    session: ReportingApiSession,
+    historyEnabled: Boolean?,
+    reportingEnabled: Boolean?,
+    deviceReportingEnabled: Boolean,
+    source: String,
+    auditToken: String?,
+    previousSettings: AccountApiSettings?
+): SetApiSettingsResult {
+    var baseSettings = previousSettings
+    var lastResponse: AccountApiSettings? = null
+    val requestAuditToken = auditToken?.takeIf { it.isNotBlank() }
+    val historyChanged = historyEnabled != null && historyEnabled != previousSettings?.historyEnabled
+    val reportingChanged = reportingEnabled != null && reportingEnabled != previousSettings?.reportingEnabled
+    val historySource = if (historyChanged) source else NOT_DIRTY_SOURCE
+    val reportingSource = if (reportingChanged) source else NOT_DIRTY_SOURCE
+    for (attempt in 0..1) {
+        val settingsBuilder = ApiSettings.Builder()
+                .deviceCapabilities(buildDeviceCapabilities(
+                    context,
+                    historyEnabled == true && deviceReportingEnabled
+                ))
+        if (historyEnabled != null) settingsBuilder.historyEnabled(historyEnabled)
+        if (reportingEnabled != null) settingsBuilder.reportingEnabled(reportingEnabled)
+        baseSettings?.modMillis?.let { settingsBuilder.modMillis(it) }
+
+        val authTokensBuilder = ClientAuthTokens.Builder()
+                .historySource(historySource)
+                .reportingSource(reportingSource)
+        if (requestAuditToken != null) authTokensBuilder.auditToken(requestAuditToken)
+
+        val request = SetApiSettingsRequest.Builder()
+                .deviceTag(session.deviceTag)
+                .device(session.device)
+                .settings(settingsBuilder.build())
+                .authTokens(authTokensBuilder.build())
+                .requestFlag(baseSettings?.migratedToOdlh == true)
+                .build()
+        val result = runCatching {
+            session.client.SetApiSettings().executeBlocking(request).settings
+                    ?: throw IOException("SetApiSettings returned no settings")
+        }.onFailure {
+            Log.w(TAG, "SetApiSettings failed", it)
+        }
+        val response = result.getOrNull()?.toSetResponseSettings(baseSettings, historyEnabled)
+        if (response == null) {
+            lastResponse?.let { ReportingSettingsStore.recordServerSettings(context, account, it) }
+            return SetApiSettingsResult(lastResponse, applied = false)
+        }
+        lastResponse = response
+
+        if (response.matchesRequestedSettings(historyEnabled, reportingEnabled)) {
+            ReportingSettingsStore.recordServerSettings(context, account, response)
+            return SetApiSettingsResult(response, applied = true)
+        }
+        if (attempt == 0 && response.canRetryConcurrentUpdate()) {
+            baseSettings = response
+            continue
+        }
+
+        Log.w(TAG, "SetApiSettings did not apply the requested settings")
+        ReportingSettingsStore.recordServerSettings(context, account, response)
+        return SetApiSettingsResult(response, applied = false)
+    }
+    return SetApiSettingsResult(lastResponse, applied = false)
+}
+
+private fun fetchApiSettings(context: Context, account: Account): FetchApiSettingsResult {
+    if (account.type != AuthConstants.DEFAULT_ACCOUNT_TYPE) return FetchApiSettingsResult(null)
+    val registration = ReportingSettingsStore.getDeviceRegistration(context, account)
+    val lastSettings = registration.toLastSettings()
+    val session = openReportingApiSession(context, account, registration.deviceTag)
+            ?: return FetchApiSettingsResult(lastSettings, retrySoon = true)
+
+    val apiSettings = getApiSettings(session) ?: return FetchApiSettingsResult(lastSettings, retrySoon = true)
+
+    val serverSettings = apiSettings.toAccountApiSettings()
+    ReportingSettingsStore.recordServerSettings(context, account, serverSettings)
+    return FetchApiSettingsResult(serverSettings)
+}
+
+internal fun setAccountLocationSettings(
+    context: Context,
+    account: Account,
+    historyEnabled: Boolean?,
+    reportingEnabled: Boolean?,
+    deviceReportingEnabled: Boolean,
+    source: String,
+    auditToken: String? = null
+): Boolean {
+    if (account.type != AuthConstants.DEFAULT_ACCOUNT_TYPE) return false
+    val lock = apiSettingsLocks.getOrPut(account) { Any() }
+    return synchronized(lock) {
+        val registration = ReportingSettingsStore.getDeviceRegistration(context, account)
+        val session = openReportingApiSession(context, account, registration.deviceTag)
+                ?: return@synchronized false
+        val cachedSettings = apiSettingsCache[account]?.settings
+        val previousSettings = if (!registration.initialized) {
+            registration.toLastSettings()
+        } else {
+            cachedSettings?.takeIf { it.modMillis != null }
+                    ?: getApiSettings(session)?.toAccountApiSettings()
+                    ?: return@synchronized false
+        }
+        val result = setApiSettings(
+            context = context,
+            account = account,
+            session = session,
+            historyEnabled = historyEnabled,
+            reportingEnabled = reportingEnabled,
+            deviceReportingEnabled = deviceReportingEnabled,
+            source = source,
+            auditToken = auditToken,
+            previousSettings = previousSettings
+        )
+        val settings = result.settings ?: previousSettings
+        val ttl = if (result.applied) CACHE_TTL_MS else FAILURE_CACHE_TTL_MS
+        apiSettingsCache[account] = CachedApiSettings(
+            settings = settings,
+            expiresAt = SystemClock.elapsedRealtime() + ttl
+        )
+        result.applied
+    }
+}
+
+internal fun synchronizePendingAccountOptIn(context: Context, account: Account): Boolean {
+    val lock = apiSettingsLocks.getOrPut(account) { Any() }
+    return synchronized(lock) {
+        val pendingOptIn = ReportingSettingsStore.getPendingOptIn(context, account)
+                ?: return@synchronized true
+        val applied = setAccountLocationSettings(
+            context = context,
+            account = account,
+            historyEnabled = true,
+            reportingEnabled = true,
+            deviceReportingEnabled = ReportingSettingsStore.getLocalReportingEnabled(context, account),
+            source = pendingOptIn.source,
+            auditToken = pendingOptIn.auditToken
+        )
+        if (applied) {
+            ReportingSettingsStore.clearPendingOptIn(context, account)
+            notifyReportingSettingsChanged(context)
+        }
+        applied
+    }
+}
+
+internal fun synchronizePendingAccountOptIns(context: Context) {
+    context.googleAccounts.forEach { synchronizePendingAccountOptIn(context, it) }
+}
+
+private fun CachedApiSettings.isUsable(now: Long): Boolean = now < expiresAt
+
+private fun fetchApiSettingsResultCached(
+    context: Context,
+    account: Account,
+    forceRefresh: Boolean = false
+): FetchApiSettingsResult {
+    val now = SystemClock.elapsedRealtime()
+    apiSettingsCache[account]?.takeIf { !forceRefresh && it.isUsable(now) }?.let {
+        return FetchApiSettingsResult(it.settings)
+    }
+    val lock = apiSettingsLocks.getOrPut(account) { Any() }
+    return synchronized(lock) {
+        val lockedNow = SystemClock.elapsedRealtime()
+        apiSettingsCache[account]?.takeIf { !forceRefresh && it.isUsable(lockedNow) }?.let {
+            return@synchronized FetchApiSettingsResult(it.settings)
+        }
+        val result = fetchApiSettings(context, account)
+        val ttl = if (result.retrySoon) FAILURE_CACHE_TTL_MS else CACHE_TTL_MS
+        apiSettingsCache[account] = CachedApiSettings(
+            result.settings,
+            SystemClock.elapsedRealtime() + ttl
+        )
+        result
+    }
+}
+
+private fun fetchApiSettingsCached(
+    context: Context,
+    account: Account,
+    forceRefresh: Boolean = false
+): AccountApiSettings? = fetchApiSettingsResultCached(context, account, forceRefresh).settings.also {
+    disableLocalReportingForDisabledTimeline(context, account, it)
+}
+
+private fun disableLocalReportingForDisabledTimeline(
+    context: Context,
+    account: Account,
+    settings: AccountApiSettings?
+) {
+    if (settings?.historyEnabled == false &&
+        ReportingSettingsStore.getPendingOptIn(context, account) == null
+    ) {
+        setLocalAccountReportingEnabled(context, account, false)
+    }
+}
+
+fun fetchManagedAccountLocationSettings(
+    context: Context,
+    account: Account,
+    forceRefresh: Boolean = false
+): ManagedAccountLocationSettings? {
+    if (!isGoogleAccountOnDevice(context, account)) return null
+    val settings = fetchApiSettingsCached(context, account, forceRefresh)
+    return settings.withPendingOptIn(context, account)?.toManagedAccountLocationSettings(
+        ReportingSettingsStore.getLocalReportingEnabled(context, account)
+    )
+}
+
+fun updateManagedAccountLocationSettings(
+    context: Context,
+    account: Account,
+    historyEnabled: Boolean,
+    reportingEnabled: Boolean,
+    synchronizeHistoryEnabled: Boolean
+): ManagedAccountLocationSettingsUpdate {
+    if (!isGoogleAccountOnDevice(context, account)) {
+        return ManagedAccountLocationSettingsUpdate(false, null)
+    }
+    val normalizedReportingEnabled = historyEnabled && reportingEnabled
+    setLocalAccountReportingEnabled(context, account, normalizedReportingEnabled)
+    if (!synchronizeHistoryEnabled) {
+        val storedSettings = apiSettingsCache[account]?.settings
+                ?: ReportingSettingsStore.getDeviceRegistration(context, account).toLastSettings()
+        return ManagedAccountLocationSettingsUpdate(
+            success = true,
+            settings = storedSettings.withPendingOptIn(context, account)
+                    ?.toManagedAccountLocationSettings(normalizedReportingEnabled)
+        )
+    }
+    val lock = apiSettingsLocks.getOrPut(account) { Any() }
+    return synchronized(lock) {
+        if (!historyEnabled) {
+            ReportingSettingsStore.clearPendingOptIn(context, account)
+        }
+        val applied = setAccountLocationSettings(
+            context = context,
+            account = account,
+            historyEnabled = historyEnabled,
+            reportingEnabled = null,
+            deviceReportingEnabled = normalizedReportingEnabled,
+            source = ACCOUNT_SETTINGS_SOURCE
+        )
+        val confirmation = fetchApiSettingsResultCached(
+            context,
+            account,
+            forceRefresh = !applied
+        )
+        disableLocalReportingForDisabledTimeline(context, account, confirmation.settings)
+        val settings = confirmation.settings.withPendingOptIn(context, account)
+                ?.toManagedAccountLocationSettings(
+                    ReportingSettingsStore.getLocalReportingEnabled(context, account)
+                )
+        val confirmed = settings?.historyEnabled == historyEnabled
+        val success = confirmed && !confirmation.retrySoon
+        if (success) notifyReportingSettingsChanged(context)
+        ManagedAccountLocationSettingsUpdate(
+            success = success,
+            settings = settings
+        )
+    }
+}
+
+fun fetchEffectiveAccountLocationSettings(
+    context: Context,
+    account: Account?,
+    allowRemoteAccountSettings: Boolean = true,
+    refreshRemoteAccountSettings: Boolean = true
+): EffectiveAccountLocationSettings {
+    val accountOnDevice = isGoogleAccountOnDevice(context, account)
+    val storedAccountSettings = when {
+        !allowRemoteAccountSettings || !accountOnDevice -> null
+        refreshRemoteAccountSettings -> account?.let { fetchApiSettingsCached(context, it) }
+        else -> account?.let {
+            ReportingSettingsStore.getDeviceRegistration(context, it).toLastSettings()
+        }
+    }
+    val accountSettings = if (allowRemoteAccountSettings && accountOnDevice && account != null) {
+        storedAccountSettings.withPendingOptIn(context, account)
+    } else {
+        storedAccountSettings
+    }
+    val migratedToOdlh = accountSettings?.migratedToOdlh == true
+    val timelineEnabled = accountSettings?.historyEnabled == true
+    val localReportingEnabled = account?.takeIf {
+        allowRemoteAccountSettings && accountOnDevice
+    }?.let {
+        ReportingSettingsStore.getLocalReportingEnabled(context, it)
+    }
+    val uploadAllowed = timelineEnabled && localReportingEnabled == true
+    val conditions = getLocalReportingConditions(context)
+    val allowed = allowRemoteAccountSettings &&
+            accountOnDevice &&
+            conditions.allowed &&
+            (accountSettings?.userRestriction ?: 0) == 0
+    val standardOptInResult = when {
+        !accountOnDevice -> OPT_IN_RESULT_INVALID_ACCOUNT
+        !allowed -> OPT_IN_RESULT_NOT_ALLOWED
+        else -> OPT_IN_RESULT_SUCCESS
+    }
+    val gmsOptInResult = when {
+        !accountOnDevice -> OPT_IN_RESULT_INVALID_ACCOUNT
+        !conditions.deviceFormFactorSupported -> OPT_IN_RESULT_UNSUPPORTED_FORM_FACTOR
+        !conditions.countryAllowed -> OPT_IN_RESULT_UNSUPPORTED_GEO
+        !allowed -> OPT_IN_RESULT_NOT_ALLOWED
+        else -> OPT_IN_RESULT_SUCCESS
+    }
+    return EffectiveAccountLocationSettings(
+        timelineEnabled = timelineEnabled,
+        uploadAllowed = uploadAllowed,
+        historyStatus = accountSettings?.historyEnabled.toReportingStatus(),
+        reportingStatus = localReportingEnabled.toReportingStatus(),
+        allowed = allowed,
+        active = allowed && uploadAllowed && conditions.locationEnabled,
+        migratedToOdlh = migratedToOdlh,
+        standardOptInResult = standardOptInResult,
+        gmsOptInResult = gmsOptInResult
+    )
+}
+
+fun fetchEffectiveTimelineEnabled(
+    context: Context,
+    account: Account?,
+    allowRemoteAccountSettings: Boolean
+): Boolean {
+    if (!allowRemoteAccountSettings || !isGoogleAccountOnDevice(context, account)) return false
+    return account?.let {
+        fetchApiSettingsCached(context, it).withPendingOptIn(context, it)?.historyEnabled
+    } == true
+}

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingServiceInstance.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingServiceInstance.kt
@@ -8,8 +8,19 @@ import android.accounts.Account
 import android.content.Context
 import android.os.Parcel
 import android.util.Log
-import com.google.android.gms.location.reporting.*
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.google.android.gms.location.reporting.OptInRequest
+import com.google.android.gms.location.reporting.ReportingState
+import com.google.android.gms.location.reporting.SendDataRequest
+import com.google.android.gms.location.reporting.UlrPrivateModeRequest
+import com.google.android.gms.location.reporting.UploadRequest
+import com.google.android.gms.location.reporting.UploadRequestResult
 import com.google.android.gms.location.reporting.internal.IReportingService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.microg.gms.common.Constants
 import org.microg.gms.common.GooglePackagePermission
 import org.microg.gms.common.PackageUtils
 import org.microg.gms.utils.warnOnTransactionIssues
@@ -20,22 +31,53 @@ import org.microg.gms.utils.warnOnTransactionIssues
  */
 
 //import com.google.android.gms.location.places.PlaceReport;
-class ReportingServiceInstance(private val context: Context, private val packageName: String) : IReportingService.Stub() {
+class ReportingServiceInstance(
+    private val context: Context,
+    private val packageName: String,
+    override val lifecycle: Lifecycle
+) : IReportingService.Stub(), LifecycleOwner {
 
     override fun getReportingState(account: Account): ReportingState {
         Log.d(TAG, "getReportingState")
-        val (deviceTag, allowed) =  if (PackageUtils.callerHasGooglePackagePermission(context, GooglePackagePermission.REPORTING)) {
-            Pair(0, true)
-        } else {
-            Pair(null, false)
+        val canAccessSettings = PackageUtils.callerHasGooglePackagePermission(
+                context,
+                GooglePackagePermission.REPORTING
+        )
+        val accountOnDevice = isGoogleAccountOnDevice(context, account)
+        val settings = fetchEffectiveAccountLocationSettings(
+                context,
+                account,
+                allowRemoteAccountSettings = canAccessSettings && accountOnDevice,
+                refreshRemoteAccountSettings = false
+        )
+        if (canAccessSettings && accountOnDevice) {
+            lifecycleScope.launch(Dispatchers.IO) {
+                runCatching {
+                    if (synchronizePendingAccountOptIn(context, account)) {
+                        val refreshedSettings = fetchEffectiveAccountLocationSettings(context, account)
+                        if (refreshedSettings != settings) {
+                            notifyReportingSettingsChanged(context, packageName)
+                        }
+                    }
+                }.onFailure {
+                    Log.w(TAG, "getReportingState: account settings synchronization failed", it)
+                }
+            }
         }
-        return ReportingState(-1, -1, allowed, false, 1, 1, deviceTag, false, true)
+        val deviceTag = if (canAccessSettings && accountOnDevice) {
+            getReportingDeviceTag(context, account)
+        } else {
+            null
+        }
+        val optInResult = settings.expectedOptInResult(
+                callerAllowed = canAccessSettings,
+                isGmsCaller = packageName == Constants.GMS_PACKAGE_NAME
+        )
+        return settings.toReportingState(deviceTag, canAccessSettings, optInResult)
     }
 
     override fun tryOptInAccount(account: Account): Int {
-        val request = OptInRequest()
-        request.account = account
-        return tryOptIn(request)
+        return tryOptIn(OptInRequest().apply { this.account = account })
     }
 
     override fun requestUpload(request: UploadRequest): UploadRequestResult {
@@ -55,7 +97,39 @@ class ReportingServiceInstance(private val context: Context, private val package
     //    }
 
     override fun tryOptIn(request: OptInRequest): Int {
-        return 0
+        val tag = request.tag
+        if (tag != null && tag.length > 100) return OPT_IN_RESULT_TAG_TOO_LONG
+        val account = request.account ?: return OPT_IN_RESULT_MISSING_ACCOUNT
+        if (!isGoogleAccountOnDevice(context, account)) return OPT_IN_RESULT_INVALID_ACCOUNT
+        val isGmsCaller = packageName == Constants.GMS_PACKAGE_NAME
+        val callerAllowed = PackageUtils.callerHasGooglePackagePermission(
+                context,
+                GooglePackagePermission.REPORTING
+        )
+        if (!callerAllowed) return OPT_IN_RESULT_CALLER_NOT_ALLOWED
+        val expectedResult = fetchEffectiveAccountLocationSettings(
+                context,
+                account,
+                refreshRemoteAccountSettings = false
+        ).expectedOptInResult(callerAllowed = callerAllowed, isGmsCaller = isGmsCaller)
+        if (expectedResult != OPT_IN_RESULT_SUCCESS) return expectedResult
+
+        val baseSource = if (isGmsCaller) {
+            "com.google.android.gms+opt-in"
+        } else {
+            packageName
+        }
+        val source = tag?.let { "$baseSource+$it" } ?: baseSource
+        val auditToken = request.auditToken
+        if (!queueAccountOptIn(context, account, source, auditToken)) {
+            return OPT_IN_RESULT_WRITE_FAILED
+        }
+        lifecycleScope.launch(Dispatchers.IO) {
+            if (!synchronizePendingAccountOptIn(context, account)) {
+                Log.w(TAG, "tryOptIn: account settings synchronization failed")
+            }
+        }
+        return OPT_IN_RESULT_SUCCESS
     }
 
     override fun sendData(request: SendDataRequest): Int {

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingSettingsStore.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/ReportingSettingsStore.kt
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.microg.gms.location.reporting
+
+import android.accounts.Account
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.core.content.edit
+import org.microg.gms.location.LocationSettings
+import java.util.Random
+
+private const val DEVICE_TAG_KEY_PREFIX = "deviceTag_"
+private const val LEGACY_DEVICE_TAG_KEY_PREFIX = "device_tag_"
+private const val DEVICE_INITIALIZED_KEY_PREFIX = "device_initialized_"
+private const val DEVICE_HISTORY_ENABLED_KEY_PREFIX = "device_history_enabled_"
+private const val DEVICE_REPORTING_ENABLED_KEY_PREFIX = "device_reporting_enabled_"
+private const val DEVICE_MIGRATED_TO_ODLH_KEY_PREFIX = "device_migrated_to_odlh_"
+private const val DEVICE_USER_RESTRICTION_KEY_PREFIX = "device_user_restriction_"
+private const val PENDING_OPT_IN_KEY_PREFIX = "pending_opt_in_"
+private const val PENDING_OPT_IN_SOURCE_KEY_PREFIX = "pending_opt_in_source_"
+private const val PENDING_OPT_IN_AUDIT_TOKEN_KEY_PREFIX = "pending_opt_in_audit_token_"
+
+internal data class PendingOptIn(
+    val source: String,
+    val auditToken: String?
+)
+
+internal data class DeviceRegistration(
+    val deviceTag: Int,
+    val initialized: Boolean,
+    val lastHistoryEnabled: Boolean?,
+    val lastUserRestriction: Int?,
+    val lastMigratedToOdlh: Boolean?
+)
+
+internal fun DeviceRegistration.toLastSettings() = AccountApiSettings(
+    modMillis = null,
+    historyEnabled = lastHistoryEnabled,
+    reportingEnabled = null,
+    userRestriction = lastUserRestriction,
+    migratedToOdlh = lastMigratedToOdlh,
+    source = null,
+    concurrencyType = null
+)
+
+internal object ReportingSettingsStore {
+    private val lock = Any()
+    private val deviceTagRandom = Random()
+
+    // Reporting consent is local to this account and device. A missing server field must not reset it.
+    fun getLocalReportingEnabled(context: Context, account: Account): Boolean = synchronized(lock) {
+        val preferences = context.reportingPreferences
+        val key = DEVICE_REPORTING_ENABLED_KEY_PREFIX + account.reportingPreferenceSuffix
+        if (preferences.contains(key)) {
+            preferences.getBoolean(key, false)
+        } else {
+            LocationSettings(context).mapsTimelineUpload.also {
+                preferences.edit { putBoolean(key, it) }
+            }
+        }
+    }
+
+    fun setLocalReportingEnabled(context: Context, account: Account, enabled: Boolean): Boolean =
+        synchronized(lock) {
+            val preferences = context.reportingPreferences
+            val key = DEVICE_REPORTING_ENABLED_KEY_PREFIX + account.reportingPreferenceSuffix
+            val changed = !preferences.contains(key) || preferences.getBoolean(key, false) != enabled
+            if (changed) preferences.edit { putBoolean(key, enabled) }
+            changed
+        }
+
+    fun getPendingOptIn(context: Context, account: Account): PendingOptIn? = synchronized(lock) {
+        val preferences = context.reportingPreferences
+        val suffix = account.reportingPreferenceSuffix
+        if (!preferences.getBoolean(PENDING_OPT_IN_KEY_PREFIX + suffix, false)) {
+            null
+        } else {
+            val source = preferences.getString(PENDING_OPT_IN_SOURCE_KEY_PREFIX + suffix, null)
+                ?: return@synchronized null
+            PendingOptIn(
+                source = source,
+                auditToken = preferences.getString(PENDING_OPT_IN_AUDIT_TOKEN_KEY_PREFIX + suffix, null)
+            )
+        }
+    }
+
+    @SuppressLint("UseKtx")
+    fun queuePendingOptIn(
+        context: Context,
+        account: Account,
+        source: String,
+        auditToken: String?
+    ): Boolean = synchronized(lock) {
+        val preferences = context.reportingPreferences
+        val suffix = account.reportingPreferenceSuffix
+        preferences.edit().apply {
+            putBoolean(DEVICE_REPORTING_ENABLED_KEY_PREFIX + suffix, true)
+            putBoolean(PENDING_OPT_IN_KEY_PREFIX + suffix, true)
+            putString(PENDING_OPT_IN_SOURCE_KEY_PREFIX + suffix, source)
+            if (auditToken.isNullOrBlank()) {
+                remove(PENDING_OPT_IN_AUDIT_TOKEN_KEY_PREFIX + suffix)
+            } else {
+                putString(PENDING_OPT_IN_AUDIT_TOKEN_KEY_PREFIX + suffix, auditToken)
+            }
+        }.commit()
+    }
+
+    fun clearPendingOptIn(context: Context, account: Account) = synchronized(lock) {
+        val suffix = account.reportingPreferenceSuffix
+        context.reportingPreferences.edit {
+            remove(PENDING_OPT_IN_KEY_PREFIX + suffix)
+            remove(PENDING_OPT_IN_SOURCE_KEY_PREFIX + suffix)
+            remove(PENDING_OPT_IN_AUDIT_TOKEN_KEY_PREFIX + suffix)
+        }
+    }
+
+    fun getDeviceRegistration(context: Context, account: Account): DeviceRegistration = synchronized(lock) {
+        val preferences = context.reportingPreferences
+        val suffix = account.reportingPreferenceSuffix
+        val deviceTagKey = DEVICE_TAG_KEY_PREFIX + account
+        val legacyDeviceTagKey = LEGACY_DEVICE_TAG_KEY_PREFIX + suffix
+        val initializedKey = DEVICE_INITIALIZED_KEY_PREFIX + suffix
+        val historyEnabledKey = DEVICE_HISTORY_ENABLED_KEY_PREFIX + suffix
+        val userRestrictionKey = DEVICE_USER_RESTRICTION_KEY_PREFIX + suffix
+        val migratedToOdlhKey = DEVICE_MIGRATED_TO_ODLH_KEY_PREFIX + suffix
+        val deviceTag = when {
+            preferences.contains(deviceTagKey) -> preferences.getInt(deviceTagKey, 0)
+            preferences.contains(legacyDeviceTagKey) -> preferences.getInt(legacyDeviceTagKey, 0).also {
+                preferences.edit { putInt(deviceTagKey, it) }
+            }
+            preferences.contains("deviceTag") -> preferences.getInt("deviceTag", 0).also {
+                preferences.edit {
+                    remove("deviceTag")
+                    putInt(deviceTagKey, it)
+                }
+            }
+            else -> deviceTagRandom.nextInt().also {
+                preferences.edit {
+                    putInt(deviceTagKey, it)
+                    putBoolean(initializedKey, false)
+                }
+            }
+        }
+        DeviceRegistration(
+            deviceTag = deviceTag,
+            initialized = preferences.getBoolean(initializedKey, false),
+            lastHistoryEnabled = if (preferences.contains(historyEnabledKey)) {
+                preferences.getBoolean(historyEnabledKey, false)
+            } else null,
+            lastUserRestriction = if (preferences.contains(userRestrictionKey)) {
+                preferences.getInt(userRestrictionKey, 0)
+            } else null,
+            lastMigratedToOdlh = if (preferences.contains(migratedToOdlhKey)) {
+                preferences.getBoolean(migratedToOdlhKey, false)
+            } else null
+        )
+    }
+
+    fun recordServerSettings(context: Context, account: Account, settings: AccountApiSettings) = synchronized(lock) {
+        val suffix = account.reportingPreferenceSuffix
+        context.reportingPreferences.edit {
+            putBoolean(DEVICE_INITIALIZED_KEY_PREFIX + suffix, true)
+            if (settings.historyEnabled == null) {
+                remove(DEVICE_HISTORY_ENABLED_KEY_PREFIX + suffix)
+            } else {
+                putBoolean(DEVICE_HISTORY_ENABLED_KEY_PREFIX + suffix, settings.historyEnabled)
+            }
+            if (settings.userRestriction == null) {
+                remove(DEVICE_USER_RESTRICTION_KEY_PREFIX + suffix)
+            } else {
+                putInt(DEVICE_USER_RESTRICTION_KEY_PREFIX + suffix, settings.userRestriction)
+            }
+            if (settings.migratedToOdlh == null) {
+                remove(DEVICE_MIGRATED_TO_ODLH_KEY_PREFIX + suffix)
+            } else {
+                putBoolean(DEVICE_MIGRATED_TO_ODLH_KEY_PREFIX + suffix, settings.migratedToOdlh)
+            }
+        }
+    }
+}

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/extensions.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/reporting/extensions.kt
@@ -5,4 +5,227 @@
 
 package org.microg.gms.location.reporting
 
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import android.os.PowerManager
+import android.os.UserManager
+import android.provider.Settings
+import androidx.core.location.LocationManagerCompat
+import com.squareup.wire.GrpcClient
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import org.microg.gms.auth.AuthConstants
+import org.microg.gms.common.Constants
+import org.microg.gms.profile.Build
+import org.microg.gms.profile.ProfileManager
+import userlocation.BuildInfo
+import userlocation.DeviceCapabilities
+import userlocation.DeviceDescriptor
+import userlocation.UserLocationReportingServiceClient
+import java.util.concurrent.TimeUnit
+
 const val TAG = "LocationReporting"
+
+private const val SERVICE_HOST = "https://userlocation.googleapis.com"
+private const val AUTH_TOKEN_SCOPE = "oauth2:https://www.googleapis.com/auth/userlocation.reporting"
+private const val CALL_TIMEOUT_SECONDS = 10L
+internal const val DEVICE_STATE_PREFERENCES = "location_reporting_api"
+const val REPORTING_SETTINGS_CHANGED_ACTION = "com.google.android.gms.location.reporting.SETTINGS_CHANGED"
+
+private const val MAPS_PACKAGE_NAME = "com.google.android.apps.maps"
+private const val RESTRICTED_PROFILE_KEY = "restricted_profile"
+private const val WATCH_FEATURE = "android.hardware.type.watch"
+private const val AUTOMOTIVE_FEATURE = "android.hardware.type.automotive"
+private const val TELEVISION_FEATURE = "android.hardware.type.television"
+private const val LOCATION_MODE_KEY = "location_mode"
+private const val WIFI_SCAN_ALWAYS_AVAILABLE_KEY = "wifi_scan_always_enabled"
+private const val BATTERY_SAVER_TRIGGER_LEVEL_KEY = "low_power_trigger_level"
+
+internal const val OPT_IN_RESULT_SUCCESS = 0
+internal const val OPT_IN_RESULT_WRITE_FAILED = 1
+internal const val OPT_IN_RESULT_MISSING_ACCOUNT = 2
+internal const val OPT_IN_RESULT_INVALID_ACCOUNT = 3
+internal const val OPT_IN_RESULT_CALLER_NOT_ALLOWED = 5
+internal const val OPT_IN_RESULT_TAG_TOO_LONG = 11
+
+internal data class ReportingApiSession(
+    val client: UserLocationReportingServiceClient,
+    val deviceTag: Int,
+    val device: DeviceDescriptor
+)
+
+internal data class LocalReportingConditions(
+    val countryAllowed: Boolean,
+    val deviceCapable: Boolean,
+    val restrictedProfile: Boolean,
+    val deviceFormFactorSupported: Boolean,
+    val locationEnabled: Boolean
+) {
+    val allowed: Boolean
+        get() = countryAllowed && deviceCapable && !restrictedProfile && deviceFormFactorSupported
+}
+
+private val baseHttpClient = OkHttpClient.Builder()
+    .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    .build()
+
+private class AuthorizationInterceptor(private val oauthToken: String) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("authorization", "Bearer $oauthToken")
+            .build()
+        return chain.proceed(request)
+    }
+}
+
+private fun reportingServiceClient(oauthToken: String): UserLocationReportingServiceClient {
+    val client = baseHttpClient.newBuilder()
+        .addInterceptor(AuthorizationInterceptor(oauthToken))
+        .build()
+    val grpcClient = GrpcClient.Builder()
+        .client(client)
+        .baseUrl(SERVICE_HOST)
+        .minMessageToCompress(Long.MAX_VALUE)
+        .build()
+    return grpcClient.create(UserLocationReportingServiceClient::class)
+}
+
+internal fun openReportingApiSession(
+    context: Context,
+    account: Account,
+    deviceTag: Int
+): ReportingApiSession? {
+    if (account.type != AuthConstants.DEFAULT_ACCOUNT_TYPE) return null
+    val oauthToken = runCatching {
+        AccountManager.get(context).blockingGetAuthToken(account, AUTH_TOKEN_SCOPE, false)
+    }.getOrNull()?.takeIf { it.isNotBlank() } ?: return null
+    return ReportingApiSession(
+        client = reportingServiceClient(oauthToken),
+        deviceTag = deviceTag,
+        device = buildDeviceDescriptor(context)
+    )
+}
+
+private fun buildDeviceDescriptor(context: Context): DeviceDescriptor {
+    ProfileManager.ensureInitialized(context)
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    return DeviceDescriptor.Builder()
+        .buildFingerprint(Build.FINGERPRINT)
+        .sdkInt(Build.VERSION.SDK_INT)
+        .deviceModel(Build.MODEL)
+        .enum12(0)
+        .gmsVersionCode(Constants.GMS_VERSION_CODE)
+        .gmsApkVersionCode(Constants.GMS_VERSION_CODE)
+        .buildInfo(
+            BuildInfo.Builder()
+                .manufacturer(Build.MANUFACTURER)
+                .brand(Build.BRAND)
+                .product(Build.PRODUCT)
+                .device(Build.DEVICE)
+                .model(Build.MODEL)
+                .buildFlag(activityManager?.isLowRamDevice ?: false)
+                .build()
+        )
+        .moduleVersion(Constants.GMS_VERSION_CODE)
+        .osType(1)
+        .build()
+}
+
+internal fun buildDeviceCapabilities(context: Context, fullyEnabled: Boolean): DeviceCapabilities {
+    val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+    val locationEnabled = locationManager?.let { LocationManagerCompat.isLocationEnabled(it) } ?: false
+    val builder = DeviceCapabilities.Builder().locationEnabled(locationEnabled)
+    if (!fullyEnabled) return builder.build()
+
+    val userManager = context.getSystemService(Context.USER_SERVICE) as? UserManager
+    val restrictedProfile = userManager
+        ?.getApplicationRestrictions(Constants.GMS_PACKAGE_NAME)
+        ?.getString(RESTRICTED_PROFILE_KEY) == "true"
+    val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+    val batterySaverOn = if (android.os.Build.VERSION.SDK_INT >= 21) {
+        powerManager?.isPowerSaveMode ?: false
+    } else {
+        false
+    }
+    val packageManager = context.packageManager
+    val deviceFormFactorSupported = !packageManager.hasSystemFeature(WATCH_FEATURE) &&
+        !packageManager.hasSystemFeature(AUTOMOTIVE_FEATURE) &&
+        !packageManager.hasSystemFeature(TELEVISION_FEATURE)
+    val locationMode = Settings.Secure.getInt(
+        context.contentResolver,
+        LOCATION_MODE_KEY,
+        Settings.Secure.LOCATION_MODE_OFF
+    )
+
+    builder.countryAllowed(true)
+        .deviceCapable(true)
+        .restrictedProfile(restrictedProfile)
+        .deviceFormFactorSupported(deviceFormFactorSupported)
+        .locationMode(locationMode)
+        .batterySaverOn(batterySaverOn)
+        .batterySaverTriggerLevel(
+            Settings.Global.getInt(
+                context.contentResolver,
+                BATTERY_SAVER_TRIGGER_LEVEL_KEY,
+                0
+            )
+        )
+
+    if (packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI)) {
+        builder.wifiScanningEnabled(
+            Settings.Global.getInt(
+                context.contentResolver,
+                WIFI_SCAN_ALWAYS_AVAILABLE_KEY,
+                0
+            ) == 1
+        )
+    }
+    return builder.build()
+}
+
+internal fun getLocalReportingConditions(context: Context): LocalReportingConditions {
+    val capabilities = buildDeviceCapabilities(context, fullyEnabled = true)
+    return LocalReportingConditions(
+        countryAllowed = capabilities.countryAllowed != false,
+        deviceCapable = capabilities.deviceCapable != false,
+        restrictedProfile = capabilities.restrictedProfile == true,
+        deviceFormFactorSupported = capabilities.deviceFormFactorSupported != false,
+        locationEnabled = capabilities.locationEnabled == true
+    )
+}
+
+internal fun isGoogleAccountOnDevice(context: Context, account: Account?): Boolean {
+    if (account?.type != AuthConstants.DEFAULT_ACCOUNT_TYPE) return false
+    return runCatching { context.googleAccounts.contains(account) }.getOrDefault(false)
+}
+
+internal val Context.googleAccounts: Array<Account>
+    get() = AccountManager.get(this).getAccountsByType(AuthConstants.DEFAULT_ACCOUNT_TYPE)
+
+internal val Context.reportingPreferences: SharedPreferences
+    get() = getSharedPreferences(DEVICE_STATE_PREFERENCES, Context.MODE_PRIVATE)
+
+internal val Account.reportingPreferenceSuffix: String
+    get() = "$type:$name"
+
+internal fun notifyReportingSettingsChanged(context: Context, targetPackage: String? = null) {
+    sequenceOf(MAPS_PACKAGE_NAME, Constants.GMS_PACKAGE_NAME, targetPackage)
+        .filterNotNull()
+        .distinct()
+        .forEach { packageName ->
+            context.sendBroadcast(Intent(REPORTING_SETTINGS_CHANGED_ACTION).setPackage(packageName))
+        }
+}
+
+internal fun Boolean?.toReportingStatus(): Int = when (this) {
+    true -> 1
+    false -> -1
+    null -> 0
+}

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/ui/LocationPreferencesFragment.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/ui/LocationPreferencesFragment.kt
@@ -20,6 +20,7 @@ import android.view.*
 import android.view.Menu.NONE
 import android.widget.*
 import androidx.core.content.getSystemService
+import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.core.view.setPadding
 import androidx.lifecycle.lifecycleScope
@@ -56,8 +57,7 @@ class LocationPreferencesFragment : PreferenceFragmentCompat() {
     private lateinit var cellLearning: TwoStatePreference
     private lateinit var nominatim: TwoStatePreference
     private lateinit var database: LocationAppsDatabase
-    private lateinit var timelineEnabled: TwoStatePreference
-    private lateinit var timelineUpload: TwoStatePreference
+    private lateinit var timelineAccounts: Preference
 
     init {
         setHasOptionsMenu(true)
@@ -273,8 +273,7 @@ class LocationPreferencesFragment : PreferenceFragmentCompat() {
         cellIchnaea = preferenceScreen.findPreference("pref_location_cell_mls_enabled") ?: cellIchnaea
         cellLearning = preferenceScreen.findPreference("pref_location_cell_learning_enabled") ?: cellLearning
         nominatim = preferenceScreen.findPreference("pref_geocoder_nominatim_enabled") ?: nominatim
-        timelineEnabled = preferenceScreen.findPreference("pref_location_timeline") ?: timelineEnabled
-        timelineUpload = preferenceScreen.findPreference("pref_location_timeline_upload") ?: timelineUpload
+        timelineAccounts = preferenceScreen.findPreference("pref_location_timeline_accounts") ?: timelineAccounts
 
         locationAppsAll.setOnPreferenceClickListener {
             findNavController().navigate(requireContext(), R.id.openAllLocationApps)
@@ -318,17 +317,10 @@ class LocationPreferencesFragment : PreferenceFragmentCompat() {
         }
         configureChangeListener(cellLearning) { LocationSettings(requireContext()).cellLearning = it }
         configureChangeListener(nominatim) { LocationSettings(requireContext()).geocoderNominatim = it }
-        configureChangeListener(timelineEnabled) {
-            LocationSettings(requireContext()).mapsTimeline = it
-            if (!it) {
-                LocationSettings(requireContext()).mapsTimelineUpload = false
-                timelineUpload.isChecked = false
-                timelineUpload.isEnabled = false
-            } else {
-                timelineUpload.isEnabled = true
-            }
+        timelineAccounts.setOnPreferenceClickListener {
+            findNavController().navigate("x-gms-settings://accounts".toUri())
+            true
         }
-        configureChangeListener(timelineUpload) { LocationSettings(requireContext()).mapsTimelineUpload = it }
 
         networkProviderCategory.isVisible = requireContext().hasNetworkLocationServiceBuiltIn()
         wifiLearning.isVisible =
@@ -364,9 +356,6 @@ class LocationPreferencesFragment : PreferenceFragmentCompat() {
             cellIchnaea.isChecked = LocationSettings(context).cellIchnaea
             cellLearning.isChecked = LocationSettings(context).cellLearning
             nominatim.isChecked = LocationSettings(context).geocoderNominatim
-            timelineEnabled.isChecked = LocationSettings(context).mapsTimeline
-            timelineUpload.isEnabled = LocationSettings(context).mapsTimeline
-            timelineUpload.isChecked = LocationSettings(context).mapsTimelineUpload
             val (apps, showAll) = withContext(Dispatchers.IO) {
                 val apps = database.listAppsByAccessTime()
                 val res = apps.map { app ->

--- a/play-services-location/core/src/main/res/values-zh-rCN/strings.xml
+++ b/play-services-location/core/src/main/res/values-zh-rCN/strings.xml
@@ -50,4 +50,6 @@
     <string name="pref_location_timeline_upload_title">允许同步至服务器</string>
     <string name="pref_location_timeline_upload_summary">启用后，历史位置服务将周期性的将您的位置信息上报至Google服务器，以便其他设备同步显示。</string>
     <string name="pref_location_timeline_title">启动位置历史记录</string>
+    <string name="pref_location_timeline_accounts_title">按 Google 账号管理</string>
+    <string name="pref_location_timeline_accounts_summary">选择账号以管理其时间轴及服务器同步设置。</string>
 </resources>

--- a/play-services-location/core/src/main/res/values/strings.xml
+++ b/play-services-location/core/src/main/res/values/strings.xml
@@ -62,4 +62,6 @@
     <string name="pref_location_timeline_summary">"Periodically record your location information and make it available to Google Maps Timeline."</string>
     <string name="pref_location_timeline_upload_title">Synchronize to Google account</string>
     <string name="pref_location_timeline_upload_summary">"Synchronize location history to Google servers, so it can be displayed on other devices."</string>
+    <string name="pref_location_timeline_accounts_title">Manage by Google account</string>
+    <string name="pref_location_timeline_accounts_summary">Choose an account to manage its Timeline and server synchronization settings.</string>
 </resources>

--- a/play-services-location/core/src/main/res/xml/preferences_location.xml
+++ b/play-services-location/core/src/main/res/xml/preferences_location.xml
@@ -85,17 +85,10 @@
     <PreferenceCategory
         android:title="@string/prefcat_location_timeline_title"
         app:iconSpaceReserved="false">
-        <SwitchPreferenceCompat
-            android:key="pref_location_timeline"
-            android:persistent="false"
-            android:title="@string/pref_location_timeline_title"
-            android:summary="@string/pref_location_timeline_summary"
-            app:iconSpaceReserved="false" />
-        <SwitchPreferenceCompat
-            android:key="pref_location_timeline_upload"
-            android:persistent="false"
-            android:summary="@string/pref_location_timeline_upload_summary"
-            android:title="@string/pref_location_timeline_upload_title"
+        <Preference
+            android:key="pref_location_timeline_accounts"
+            android:summary="@string/pref_location_timeline_accounts_summary"
+            android:title="@string/pref_location_timeline_accounts_title"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Implement the User Location Reporting API to retrieve and update
account-specific Timeline settings.

Move Timeline controls to the Google account details page. Synchronize
Location History with the account while keeping upload permission local
to the current device.

Use the effective account settings for ReportingState, Timeline access,
and ODLH backup scheduling. Add pending opt-in synchronization and retry
handling, and keep settings access in the main process to avoid
cross-process preference inconsistencies.