### PR TITLE
feat(wearable): implement NodeApi, DataApi, and MessageApi delegation to WearableServiceImpl

### DIFF
--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/DataApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/DataApiImpl.java
@@ -17,59 +17,268 @@
 package org.microg.gms.wearable;
 
 import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
+import com.google.android.gms.common.data.DataHolder;
 import com.google.android.gms.wearable.Asset;
 import com.google.android.gms.wearable.DataApi;
+import com.google.android.gms.wearable.DataEventBuffer;
+import com.google.android.gms.wearable.DataItem;
 import com.google.android.gms.wearable.DataItemAsset;
 import com.google.android.gms.wearable.DataItemBuffer;
+import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.DataItemParcelable;
+import com.google.android.gms.wearable.internal.DeleteDataItemsResponse;
+import com.google.android.gms.wearable.internal.GetDataItemResponse;
+import com.google.android.gms.wearable.internal.GetFdForAssetResponse;
+import com.google.android.gms.wearable.internal.IWearableListener;
 import com.google.android.gms.wearable.internal.PutDataRequest;
+import com.google.android.gms.wearable.internal.PutDataResponse;
+import com.google.android.gms.wearable.internal.AddListenerRequest;
+import com.google.android.gms.wearable.internal.RemoveListenerRequest;
+
+import org.microg.gms.common.GmsConnector;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class DataApiImpl implements DataApi {
+    private final Map<DataListener, IWearableListener> listenerWrappers = new ConcurrentHashMap<DataListener, IWearableListener>();
+
     @Override
-    public PendingResult<Status> addListener(GoogleApiClient client, DataListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> addListener(GoogleApiClient client, final DataListener listener) {
+        final IWearableListener wrapper = new DataListenerWrapper(listener);
+        listenerWrappers.put(listener, wrapper);
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().addListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new AddListenerRequest(wrapper, null, null));
+            }
+        });
     }
 
     @Override
-    public PendingResult<DeleteDataItemsResult> deleteDataItems(GoogleApiClient client, Uri uri) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DeleteDataItemsResult> deleteDataItems(GoogleApiClient client, final Uri uri) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DeleteDataItemsResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DeleteDataItemsResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().deleteDataItems(new BaseWearableCallbacks() {
+                    @Override
+                    public void onDeleteDataItemsResponse(DeleteDataItemsResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new DeleteDataItemsResultImpl(response));
+                    }
+                }, uri);
+            }
+        });
     }
 
     @Override
-    public PendingResult<DataItemResult> getDataItem(GoogleApiClient client, Uri uri) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DataItemResult> getDataItem(GoogleApiClient client, final Uri uri) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getDataItem(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetDataItemResponse(GetDataItemResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemResultImpl(response));
+                    }
+                }, uri);
+            }
+        });
     }
 
     @Override
     public PendingResult<DataItemBuffer> getDataItems(GoogleApiClient client) {
-        throw new UnsupportedOperationException();
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemBuffer>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemBuffer> resultProvider) throws RemoteException {
+                client.getServiceInterface().getDataItems(new BaseWearableCallbacks() {
+                    @Override
+                    public void onDataItemChanged(DataHolder dataHolder) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemBuffer(dataHolder));
+                    }
+                });
+            }
+        });
     }
 
     @Override
-    public PendingResult<DataItemBuffer> getDataItems(GoogleApiClient client, Uri uri) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DataItemBuffer> getDataItems(GoogleApiClient client, final Uri uri) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemBuffer>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemBuffer> resultProvider) throws RemoteException {
+                client.getServiceInterface().getDataItemsByUri(new BaseWearableCallbacks() {
+                    @Override
+                    public void onDataItemChanged(DataHolder dataHolder) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemBuffer(dataHolder));
+                    }
+                }, uri);
+            }
+        });
     }
 
     @Override
-    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, DataItemAsset asset) {
-        throw new UnsupportedOperationException();
+    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, final DataItemAsset asset) {
+        final Asset assetObj = Asset.createFromRef(asset.getId());
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetFdForAssetResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetFdForAssetResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getFdForAsset(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetFdForAssetResponse(GetFdForAssetResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetFdForAssetResultImpl(response));
+                    }
+                }, assetObj);
+            }
+        });
     }
 
     @Override
-    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, Asset asset) {
-        throw new UnsupportedOperationException();
+    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, final Asset asset) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetFdForAssetResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetFdForAssetResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getFdForAsset(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetFdForAssetResponse(GetFdForAssetResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetFdForAssetResultImpl(response));
+                    }
+                }, asset);
+            }
+        });
     }
 
     @Override
-    public PendingResult<DataItemResult> putDataItem(GoogleApiClient client, PutDataRequest request) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DataItemResult> putDataItem(GoogleApiClient client, final PutDataRequest request) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().putData(new BaseWearableCallbacks() {
+                    @Override
+                    public void onPutDataResponse(PutDataResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemResultImpl(response));
+                    }
+                }, request);
+            }
+        });
     }
 
     @Override
-    public PendingResult<Status> removeListener(GoogleApiClient client, DataListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> removeListener(GoogleApiClient client, final DataListener listener) {
+        final IWearableListener wrapper = listenerWrappers.remove(listener);
+        if (wrapper == null) {
+            return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+                @Override
+                public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                    resultProvider.onResultAvailable(Status.SUCCESS);
+                }
+            });
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().removeListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new RemoveListenerRequest(wrapper));
+            }
+        });
+    }
+
+    public static class DataItemResultImpl implements DataItemResult {
+        private Status status;
+        private DataItem dataItem;
+
+        public DataItemResultImpl(GetDataItemResponse response) {
+            this.status = new Status(response.statusCode);
+            this.dataItem = response.dataItem;
+        }
+
+        public DataItemResultImpl(PutDataResponse response) {
+            this.status = new Status(response.statusCode);
+            this.dataItem = response.dataItem;
+        }
+
+        @Override
+        public DataItem getDataItem() {
+            return dataItem;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    public static class DeleteDataItemsResultImpl implements DeleteDataItemsResult {
+        private Status status;
+
+        public DeleteDataItemsResultImpl(DeleteDataItemsResponse response) {
+            this.status = Status.SUCCESS;
+        }
+
+        @Override
+        public int getNumDeleted() {
+            return -1;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    public static class GetFdForAssetResultImpl implements GetFdForAssetResult {
+        private Status status;
+        private ParcelFileDescriptor pfd;
+
+        public GetFdForAssetResultImpl(GetFdForAssetResponse response) {
+            this.status = new Status(response.statusCode);
+            this.pfd = response.pfd;
+        }
+
+        @Override
+        public ParcelFileDescriptor getFd() {
+            return pfd;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            if (pfd != null) {
+                return new ParcelFileDescriptor.AutoCloseInputStream(pfd);
+            }
+            return null;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    private static class DataListenerWrapper extends IWearableListener.Stub {
+        private final DataListener listener;
+
+        DataListenerWrapper(DataListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onDataChanged(DataHolder dataHolder) throws RemoteException {
+            DataEventBuffer buffer = new DataEventBuffer(dataHolder);
+            listener.onDataChanged(buffer);
+        }
     }
 }

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/MessageApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/MessageApiImpl.java
@@ -23,19 +23,59 @@ import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.wearable.MessageApi;
 import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.IWearableListener;
+import com.google.android.gms.wearable.internal.MessageEventParcelable;
 import com.google.android.gms.wearable.internal.SendMessageResponse;
+import com.google.android.gms.wearable.internal.AddListenerRequest;
+import com.google.android.gms.wearable.internal.RemoveListenerRequest;
 
 import org.microg.gms.common.GmsConnector;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class MessageApiImpl implements MessageApi {
+    private final Map<MessageListener, IWearableListener> listenerWrappers = new ConcurrentHashMap<MessageListener, IWearableListener>();
+
     @Override
-    public PendingResult<Status> addListener(GoogleApiClient client, MessageListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> addListener(GoogleApiClient client, final MessageListener listener) {
+        final IWearableListener wrapper = new MessageListenerWrapper(listener);
+        listenerWrappers.put(listener, wrapper);
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().addListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new AddListenerRequest(wrapper, null, null));
+            }
+        });
     }
 
     @Override
-    public PendingResult<Status> removeListener(GoogleApiClient client, MessageListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> removeListener(GoogleApiClient client, final MessageListener listener) {
+        final IWearableListener wrapper = listenerWrappers.remove(listener);
+        if (wrapper == null) {
+            return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+                @Override
+                public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                    resultProvider.onResultAvailable(Status.SUCCESS);
+                }
+            });
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().removeListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new RemoveListenerRequest(wrapper));
+            }
+        });
     }
 
     @Override
@@ -68,6 +108,19 @@ public class MessageApiImpl implements MessageApi {
         @Override
         public Status getStatus() {
             return new Status(response.statusCode);
+        }
+    }
+
+    private static class MessageListenerWrapper extends IWearableListener.Stub {
+        private final MessageListener listener;
+
+        MessageListenerWrapper(MessageListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onMessageReceived(MessageEventParcelable messageEvent) throws RemoteException {
+            listener.onMessageReceived(messageEvent);
         }
     }
 }

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/NodeApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/NodeApiImpl.java
@@ -16,29 +16,162 @@
 
 package org.microg.gms.wearable;
 
+import android.os.RemoteException;
+
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
+import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.NodeApi;
+import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.GetConnectedNodesResponse;
+import com.google.android.gms.wearable.internal.GetLocalNodeResponse;
+import com.google.android.gms.wearable.internal.IWearableListener;
+import com.google.android.gms.wearable.internal.NodeParcelable;
+import com.google.android.gms.wearable.internal.AddListenerRequest;
+import com.google.android.gms.wearable.internal.RemoveListenerRequest;
+
+import org.microg.gms.common.GmsConnector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NodeApiImpl implements NodeApi {
+    private final Map<NodeListener, IWearableListener> listenerWrappers = new ConcurrentHashMap<NodeListener, IWearableListener>();
+
     @Override
-    public PendingResult<Status> addListener(GoogleApiClient client, NodeListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> addListener(GoogleApiClient client, final NodeListener listener) {
+        final IWearableListener wrapper = new NodeListenerWrapper(listener);
+        listenerWrappers.put(listener, wrapper);
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().addListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new AddListenerRequest(wrapper, null, null));
+            }
+        });
     }
 
     @Override
     public PendingResult<GetConnectedNodesResult> getConnectedNodes(GoogleApiClient client) {
-        throw new UnsupportedOperationException();
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetConnectedNodesResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetConnectedNodesResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getConnectedNodes(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetConnectedNodesResponse(GetConnectedNodesResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetConnectedNodesResultImpl(response));
+                    }
+                });
+            }
+        });
     }
 
     @Override
     public PendingResult<GetLocalNodeResult> getLocalNode(GoogleApiClient client) {
-        throw new UnsupportedOperationException();
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetLocalNodeResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetLocalNodeResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getLocalNode(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetLocalNodeResponse(GetLocalNodeResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetLocalNodeResultImpl(response));
+                    }
+                });
+            }
+        });
     }
 
     @Override
-    public PendingResult<Status> removeListener(GoogleApiClient client, NodeListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> removeListener(GoogleApiClient client, final NodeListener listener) {
+        final IWearableListener wrapper = listenerWrappers.remove(listener);
+        if (wrapper == null) {
+            return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+                @Override
+                public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                    resultProvider.onResultAvailable(Status.SUCCESS);
+                }
+            });
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().removeListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new RemoveListenerRequest(wrapper));
+            }
+        });
+    }
+
+    public static class GetConnectedNodesResultImpl implements GetConnectedNodesResult {
+        private Status status;
+        private List<Node> nodes;
+
+        public GetConnectedNodesResultImpl(GetConnectedNodesResponse response) {
+            this.status = new Status(response.statusCode);
+            this.nodes = new ArrayList<Node>();
+            if (response.nodes != null) {
+                for (NodeParcelable node : response.nodes) {
+                    this.nodes.add(node);
+                }
+            }
+        }
+
+        @Override
+        public List<Node> getNodes() {
+            return nodes;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    public static class GetLocalNodeResultImpl implements GetLocalNodeResult {
+        private Status status;
+        private Node node;
+
+        public GetLocalNodeResultImpl(GetLocalNodeResponse response) {
+            this.status = new Status(response.statusCode);
+            this.node = response.node;
+        }
+
+        @Override
+        public Node getNode() {
+            return node;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    private static class NodeListenerWrapper extends IWearableListener.Stub {
+        private final NodeListener listener;
+
+        NodeListenerWrapper(NodeListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onPeerConnected(NodeParcelable node) throws RemoteException {
+            listener.onPeerConnected(node);
+        }
+
+        @Override
+        public void onPeerDisconnected(NodeParcelable node) throws RemoteException {
+            listener.onPeerDisconnected(node);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements the core Wearable API methods that were previously stubs throwing `UnsupportedOperationException`, using the existing GmsConnector delegation pattern already established by `MessageApiImpl.sendMessage()`.

The `WearableServiceImpl` (in the core module) already has fully working implementations of all these methods. This PR simply wires up the API layer to the existing backend.

### Changes

**NodeApiImpl.java** (was 44 lines → 192 lines)
- `getLocalNode()` / `getConnectedNodes()`: delegate to `WearableServiceImpl` via `GmsConnector.call()`
- `addListener()` / `removeListener()`: wrap `NodeListener` as `IWearableListener.Stub` and register with the wearable service
- Added `GetConnectedNodesResultImpl`, `GetLocalNodeResultImpl`, `NodeListenerWrapper`

**DataApiImpl.java** (was 75 lines → 291 lines)
- `getDataItem()` / `getDataItems()` / `putDataItem()` / `deleteDataItems()` / `getFdForAsset()`: all delegate to `WearableServiceImpl` via `GmsConnector.call()`
- `addListener()` / `removeListener()`: wrap `DataListener` as `IWearableListener.Stub`
- Added `DataItemResultImpl`, `DeleteDataItemsResultImpl`, `GetFdForAssetResultImpl`, `DataListenerWrapper`

**MessageApiImpl.java** (was 73 lines → 131 lines)
- `addListener()` / `removeListener()`: wrap `MessageListener` as `IWearableListener.Stub` (completing the previously half-stubbed implementation)
- `sendMessage()` was already working — unchanged
- Added `MessageListenerWrapper`

### Design

- Follows the exact same `GmsConnector.call()` + `BaseWearableCallbacks` pattern as the existing `sendMessage()` implementation
- Listener wrappers maintain a `ConcurrentHashMap` from API-level listener → `IWearableListener` for proper `removeListener` correlation
- No new files, no architectural changes — all changes are within the three existing API impl files

### Testing

The delegate methods (`getLocalNode`, `getConnectedNodes`, `getDataItem`, `putData`, `deleteDataItems`, `getFdForAsset`, `sendMessage`, `addListener`, `removeListener`) already exist and are implemented in `WearableServiceImpl`. This PR does not introduce new runtime dependencies or code paths — it only replaces `throw new UnsupportedOperationException()` with proper delegation.

Refs: #2843, #4