### PR TITLE
FIDO: fix infinite PIN verification loop when UV is discouraged …

### DIFF
--- a/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
+++ b/play-services-fido/core/src/main/kotlin/org/microg/gms/fido/core/transport/TransportHandler.kt
@@ -232,7 +232,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                         throw MissingPinException()
                     }
 
-                    if (requiresPin && pin != null && SDK_INT >= 23) {
+                    if (pin != null && SDK_INT >= 23) {
                         pinToken = ctap2getPinToken(connection, pin)
                     }
 
@@ -466,7 +466,7 @@ abstract class TransportHandler(val transport: Transport, val callback: Transpor
                         throw MissingPinException()
                     }
 
-                    if (requiresPin && pin != null && SDK_INT >= 23) {
+                    if (pin != null && SDK_INT >= 23) {
                         pinToken = ctap2getPinToken(connection, pin)
                     }
 


### PR DESCRIPTION
[Duplicate PIN verification issue with Yubikey 5c NFC on Android 15](https://github.com/microg/GmsCore/issues/3564)

Fixed an infinite PIN prompt loop. Tested successfully on YubiKey 5C NFC v5.7.1 