### PR TITLE
Add RCS Asterism and Constellation AIDL services and PhoneInfo real-telephony provider

### DIFF
--- a/play-services-base/core/src/main/java/org/microg/gms/common/PhoneInfo.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/common/PhoneInfo.java
@@ -16,20 +16,40 @@
 
 package org.microg.gms.common;
 
-import java.util.Random;
+import org.microg.gms.common.telephony.TelephonyInfoProvider;
 
+/**
+ * Immutable snapshot of telephony information used for check-in and
+ * phone-number verification flows.
+ *
+ * All values are sourced from a {@link TelephonyInfoProvider}. When data is
+ * unavailable (missing permission, no SIM, no telephony stack), the fields are
+ * empty strings. No carrier identifiers are hardcoded.
+ */
 public class PhoneInfo {
-    public String cellOperator = "26207";
-    public String roaming = "mobile-notroaming";
-    public String simOperator = "26207";
-    public String imsi = randomImsi();
+    public final String cellOperator;
+    public final String roaming;
+    public final String simOperator;
+    public final String imsi;
 
-    private String randomImsi() {
-        Random random = new Random();
-        StringBuilder sb = new StringBuilder(simOperator);
-        while (sb.length() < 15) {
-            sb.append(random.nextInt(10));
-        }
-        return sb.toString();
+    /**
+     * Construct with empty values for callers that cannot provide a provider.
+     */
+    public PhoneInfo() {
+        this.cellOperator = "";
+        this.roaming = "";
+        this.simOperator = "";
+        this.imsi = "";
+    }
+
+    public PhoneInfo(TelephonyInfoProvider provider) {
+        this.cellOperator = nonNull(provider.getNetworkOperatorNumeric());
+        this.roaming = nonNull(provider.getRoamingState());
+        this.simOperator = nonNull(provider.getSimOperatorNumeric());
+        this.imsi = nonNull(provider.getSubscriberId());
+    }
+
+    private static String nonNull(String value) {
+        return value != null ? value : "";
     }
 }

--- a/play-services-base/core/src/main/java/org/microg/gms/common/Utils.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/common/Utils.java
@@ -20,6 +20,8 @@ import android.content.Context;
 import android.util.Log;
 import android.widget.Toast;
 
+import org.microg.gms.common.telephony.SystemTelephonyInfoProvider;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,7 +40,7 @@ public class Utils {
     }
 
     public static PhoneInfo getPhoneInfo(Context context) {
-        return new PhoneInfo();
+        return new PhoneInfo(new SystemTelephonyInfoProvider(context));
     }
 
     public static boolean hasSelfPermissionOrNotify(Context context, String permission) {

--- a/play-services-base/core/src/main/java/org/microg/gms/common/telephony/SystemTelephonyInfoProvider.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/common/telephony/SystemTelephonyInfoProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.common.telephony;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.telephony.ServiceState;
+import android.telephony.TelephonyManager;
+
+import androidx.core.content.ContextCompat;
+
+/**
+ * Reads real telephony information from the Android framework.
+ *
+ * No carrier identifiers are hardcoded. When a permission is missing or the
+ * information is unavailable, an empty string is returned.
+ */
+public class SystemTelephonyInfoProvider implements TelephonyInfoProvider {
+    private final Context context;
+    private final TelephonyManager telephonyManager;
+
+    public SystemTelephonyInfoProvider(Context context) {
+        this.context = context.getApplicationContext();
+        this.telephonyManager = (TelephonyManager) this.context.getSystemService(Context.TELEPHONY_SERVICE);
+    }
+
+    @Override
+    public String getSimOperatorNumeric() {
+        if (telephonyManager == null) return "";
+        String value = telephonyManager.getSimOperator();
+        return value != null ? value : "";
+    }
+
+    @Override
+    public String getNetworkOperatorNumeric() {
+        if (telephonyManager == null) return "";
+        String value = telephonyManager.getNetworkOperator();
+        return value != null ? value : "";
+    }
+
+    @Override
+    public String getSubscriberId() {
+        if (telephonyManager == null) return "";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (!hasPermission("android.permission.READ_PRIVILEGED_PHONE_STATE")) return "";
+        } else {
+            if (!hasPermission(Manifest.permission.READ_PHONE_STATE)) return "";
+        }
+        try {
+            String value = telephonyManager.getSubscriberId();
+            return value != null ? value : "";
+        } catch (SecurityException e) {
+            return "";
+        }
+    }
+
+    @Override
+    public String getRoamingState() {
+        if (telephonyManager == null) return "";
+        boolean isRoaming = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            ServiceState serviceState = telephonyManager.getServiceState();
+            if (serviceState != null) {
+                isRoaming = serviceState.getRoaming();
+            }
+        } else {
+            String sim = getSimOperatorNumeric();
+            String network = getNetworkOperatorNumeric();
+            isRoaming = !sim.isEmpty() && !network.isEmpty() && !sim.equals(network);
+        }
+        return isRoaming ? "mobile-roaming" : "mobile-notroaming";
+    }
+
+    private boolean hasPermission(String permission) {
+        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
+    }
+}

--- a/play-services-base/core/src/main/java/org/microg/gms/common/telephony/TelephonyInfoProvider.java
+++ b/play-services-base/core/src/main/java/org/microg/gms/common/telephony/TelephonyInfoProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.common.telephony;
+
+/**
+ * Abstraction over the system telephony stack.
+ *
+ * Implementations are responsible for permission checks, multi-SIM handling,
+ * and graceful fallback when no telephony data is available.
+ */
+public interface TelephonyInfoProvider {
+    /**
+     * MCC+MNC of the SIM operator, e.g. "26207".
+     * Returns an empty string when unavailable.
+     */
+    String getSimOperatorNumeric();
+
+    /**
+     * MCC+MNC of the current registered network/cell operator.
+     * Returns an empty string when unavailable.
+     */
+    String getNetworkOperatorNumeric();
+
+    /**
+     * IMSI of the active SIM, or empty string if permission is missing.
+     */
+    String getSubscriberId();
+
+    /**
+     * Roaming state as a checkin-friendly string.
+     * Returns "mobile-notroaming" or "mobile-roaming" when determinable,
+     * otherwise an empty string.
+     */
+    String getRoamingState();
+}

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -1372,7 +1372,6 @@
                 <action android:name="com.google.android.gms.ads.service.HTTP" />
                 <action android:name="com.google.android.gms.appstate.service.START" />
                 <action android:name="com.google.android.gms.appusage.service.START" />
-                <action android:name="com.google.android.gms.asterism.service.START" />
                 <action android:name="com.google.android.gms.audiomodem.service.AudioModemService.START" />
                 <action android:name="com.google.android.gms.auth.account.authapi.START" />
                 <action android:name="com.google.android.gms.auth.account.authenticator.auto.service.START" />
@@ -1504,6 +1503,14 @@
                 <action
                     android:name="com.google.android.gms.wearable.BIND_LISTENER"
                     tools:ignore="WearableBindListener" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name="org.microg.gms.asterism.AsterismApiService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.android.gms.asterism.service.START" />
             </intent-filter>
         </service>
     </application>

--- a/play-services-core/src/main/aidl/com/google/android/gms/asterism/GetAsterismConsentRequest.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/asterism/GetAsterismConsentRequest.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.asterism;
+parcelable GetAsterismConsentRequest;

--- a/play-services-core/src/main/aidl/com/google/android/gms/asterism/GetAsterismConsentResponse.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/asterism/GetAsterismConsentResponse.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.asterism;
+parcelable GetAsterismConsentResponse;

--- a/play-services-core/src/main/aidl/com/google/android/gms/asterism/SetAsterismConsentRequest.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/asterism/SetAsterismConsentRequest.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.asterism;
+parcelable SetAsterismConsentRequest;

--- a/play-services-core/src/main/aidl/com/google/android/gms/asterism/SetAsterismConsentResponse.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/asterism/SetAsterismConsentResponse.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.asterism;
+parcelable SetAsterismConsentResponse;

--- a/play-services-core/src/main/aidl/com/google/android/gms/asterism/internal/IAsterismApiService.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/asterism/internal/IAsterismApiService.aidl
@@ -1,0 +1,11 @@
+package com.google.android.gms.asterism.internal;
+
+import com.google.android.gms.asterism.internal.IAsterismCallbacks;
+import com.google.android.gms.asterism.GetAsterismConsentRequest;
+import com.google.android.gms.asterism.SetAsterismConsentRequest;
+
+interface IAsterismApiService {
+    void getAsterismConsent(IAsterismCallbacks cb, in GetAsterismConsentRequest request);
+    void setAsterismConsent(IAsterismCallbacks cb, in SetAsterismConsentRequest request);
+    void getIsPnvrConstellationDevice(IAsterismCallbacks cb);
+}

--- a/play-services-core/src/main/aidl/com/google/android/gms/asterism/internal/IAsterismCallbacks.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/asterism/internal/IAsterismCallbacks.aidl
@@ -1,0 +1,11 @@
+package com.google.android.gms.asterism.internal;
+
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.asterism.GetAsterismConsentResponse;
+import com.google.android.gms.asterism.SetAsterismConsentResponse;
+
+interface IAsterismCallbacks {
+    void onConsentFetched(in Status status, in GetAsterismConsentResponse response);
+    void onConsentRegistered(in Status status, in SetAsterismConsentResponse response);
+    void onIsPnvrConstellationDevice(in Status status, boolean isPnvrDevice);
+}

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/ApiMetadata.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/ApiMetadata.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable ApiMetadata;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetIidTokenRequest.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetIidTokenRequest.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable GetIidTokenRequest;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetIidTokenResponse.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetIidTokenResponse.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable GetIidTokenResponse;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetPnvCapabilitiesRequest.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetPnvCapabilitiesRequest.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable GetPnvCapabilitiesRequest;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetPnvCapabilitiesResponse.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/GetPnvCapabilitiesResponse.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable GetPnvCapabilitiesResponse;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/PhoneNumberInfo.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/PhoneNumberInfo.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable PhoneNumberInfo;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/VerifyPhoneNumberRequest.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/VerifyPhoneNumberRequest.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable VerifyPhoneNumberRequest;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/VerifyPhoneNumberResponse.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/VerifyPhoneNumberResponse.aidl
@@ -1,0 +1,2 @@
+package com.google.android.gms.constellation;
+parcelable VerifyPhoneNumberResponse;

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/internal/IConstellationApiService.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/internal/IConstellationApiService.aidl
@@ -1,0 +1,17 @@
+package com.google.android.gms.constellation.internal;
+
+import android.os.Bundle;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.constellation.ApiMetadata;
+import com.google.android.gms.constellation.VerifyPhoneNumberRequest;
+import com.google.android.gms.constellation.GetIidTokenRequest;
+import com.google.android.gms.constellation.GetPnvCapabilitiesRequest;
+import com.google.android.gms.constellation.internal.IConstellationCallbacks;
+
+interface IConstellationApiService {
+    void verifyPhoneNumberV1(IConstellationCallbacks cb, in Bundle params, in ApiMetadata apiMetadata);
+    void verifyPhoneNumberSingleUse(IConstellationCallbacks cb, in Bundle params, in ApiMetadata apiMetadata);
+    void verifyPhoneNumber(IConstellationCallbacks cb, in VerifyPhoneNumberRequest request, in ApiMetadata apiMetadata);
+    void getIidToken(IConstellationCallbacks cb, in GetIidTokenRequest request, in ApiMetadata apiMetadata);
+    void getPnvCapabilities(IConstellationCallbacks cb, in GetPnvCapabilitiesRequest request, in ApiMetadata apiMetadata);
+}

--- a/play-services-core/src/main/aidl/com/google/android/gms/constellation/internal/IConstellationCallbacks.aidl
+++ b/play-services-core/src/main/aidl/com/google/android/gms/constellation/internal/IConstellationCallbacks.aidl
@@ -1,0 +1,15 @@
+package com.google.android.gms.constellation.internal;
+
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.constellation.ApiMetadata;
+import com.google.android.gms.constellation.PhoneNumberInfo;
+import com.google.android.gms.constellation.VerifyPhoneNumberResponse;
+import com.google.android.gms.constellation.GetIidTokenResponse;
+import com.google.android.gms.constellation.GetPnvCapabilitiesResponse;
+
+oneway interface IConstellationCallbacks {
+    void onPhoneNumberVerified(in Status status, in List<PhoneNumberInfo> phoneNumberInfos, in ApiMetadata apiMetadata);
+    void onPhoneNumberVerificationsCompleted(in Status status, in VerifyPhoneNumberResponse response, in ApiMetadata apiMetadata);
+    void onIidTokenGenerated(in Status status, in GetIidTokenResponse response, in ApiMetadata apiMetadata);
+    void onGetPnvCapabilitiesCompleted(in Status status, in GetPnvCapabilitiesResponse response, in ApiMetadata apiMetadata);
+}

--- a/play-services-core/src/main/java/com/google/android/gms/asterism/GetAsterismConsentRequest.java
+++ b/play-services-core/src/main/java/com/google/android/gms/asterism/GetAsterismConsentRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.asterism;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class GetAsterismConsentRequest extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<GetAsterismConsentRequest> CREATOR = findCreator(GetAsterismConsentRequest.class);
+
+    @SafeParcelable.Field(1)
+    public final int requestCode;
+
+    @SafeParcelable.Field(2)
+    public final int asterismClientValue;
+
+    @SafeParcelable.Constructor
+    public GetAsterismConsentRequest(
+            @SafeParcelable.Param(1) int requestCode,
+            @SafeParcelable.Param(2) int asterismClientValue) {
+        this.requestCode = requestCode;
+        this.asterismClientValue = asterismClientValue;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/asterism/GetAsterismConsentResponse.java
+++ b/play-services-core/src/main/java/com/google/android/gms/asterism/GetAsterismConsentResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.asterism;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class GetAsterismConsentResponse extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<GetAsterismConsentResponse> CREATOR = findCreator(GetAsterismConsentResponse.class);
+
+    @SafeParcelable.Field(1)
+    public final int requestCode;
+
+    @SafeParcelable.Field(2)
+    public final int consentStateValue;
+
+    @SafeParcelable.Field(3)
+    @Nullable
+    public final String gmscoreIidToken;
+
+    @SafeParcelable.Field(4)
+    @Nullable
+    public final String fid;
+
+    @SafeParcelable.Field(5)
+    public final int consentTypeValue;
+
+    @SafeParcelable.Constructor
+    public GetAsterismConsentResponse(
+            @SafeParcelable.Param(1) int requestCode,
+            @SafeParcelable.Param(2) int consentStateValue,
+            @SafeParcelable.Param(3) @Nullable String gmscoreIidToken,
+            @SafeParcelable.Param(4) @Nullable String fid,
+            @SafeParcelable.Param(5) int consentTypeValue) {
+        this.requestCode = requestCode;
+        this.consentStateValue = consentStateValue;
+        this.gmscoreIidToken = gmscoreIidToken;
+        this.fid = fid;
+        this.consentTypeValue = consentTypeValue;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/asterism/SetAsterismConsentRequest.java
+++ b/play-services-core/src/main/java/com/google/android/gms/asterism/SetAsterismConsentRequest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.asterism;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class SetAsterismConsentRequest extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<SetAsterismConsentRequest> CREATOR = findCreator(SetAsterismConsentRequest.class);
+
+    @SafeParcelable.Field(1)
+    public final int requestCode;
+
+    @SafeParcelable.Field(2)
+    public final int asterismClientValue;
+
+    @SafeParcelable.Field(3)
+    public final int flowContextValue;
+
+    @SafeParcelable.Field(4)
+    @Nullable
+    public final int[] tosResourceIds;
+
+    @SafeParcelable.Field(5)
+    @Nullable
+    public final Long timestamp;
+
+    @SafeParcelable.Field(6)
+    public final int consentValue;
+
+    @SafeParcelable.Field(7)
+    @Nullable
+    public final Bundle extras;
+
+    @SafeParcelable.Field(8)
+    public final int statusValue;
+
+    @SafeParcelable.Field(9)
+    @Nullable
+    public final String clientVersion;
+
+    @SafeParcelable.Field(10)
+    @Nullable
+    public final String language;
+
+    @SafeParcelable.Field(11)
+    @Nullable
+    public final String field11;
+
+    @SafeParcelable.Field(12)
+    @Nullable
+    public final String field12;
+
+    @SafeParcelable.Field(13)
+    @Nullable
+    public final String field13;
+
+    @SafeParcelable.Field(14)
+    @Nullable
+    public final String accountName;
+
+    @SafeParcelable.Field(15)
+    @Nullable
+    public final String consentVariant;
+
+    @SafeParcelable.Field(16)
+    @Nullable
+    public final String consentTrigger;
+
+    @SafeParcelable.Field(17)
+    public final int consentVersionValue;
+
+    @SafeParcelable.Field(18)
+    public final int deviceConsentSourceValue;
+
+    @SafeParcelable.Field(19)
+    public final int deviceConsentVersionValue;
+
+    @SafeParcelable.Constructor
+    public SetAsterismConsentRequest(
+            @SafeParcelable.Param(1) int requestCode,
+            @SafeParcelable.Param(2) int asterismClientValue,
+            @SafeParcelable.Param(3) int flowContextValue,
+            @SafeParcelable.Param(4) @Nullable int[] tosResourceIds,
+            @SafeParcelable.Param(5) @Nullable Long timestamp,
+            @SafeParcelable.Param(6) int consentValue,
+            @SafeParcelable.Param(7) @Nullable Bundle extras,
+            @SafeParcelable.Param(8) int statusValue,
+            @SafeParcelable.Param(9) @Nullable String clientVersion,
+            @SafeParcelable.Param(10) @Nullable String language,
+            @SafeParcelable.Param(11) @Nullable String field11,
+            @SafeParcelable.Param(12) @Nullable String field12,
+            @SafeParcelable.Param(13) @Nullable String field13,
+            @SafeParcelable.Param(14) @Nullable String accountName,
+            @SafeParcelable.Param(15) @Nullable String consentVariant,
+            @SafeParcelable.Param(16) @Nullable String consentTrigger,
+            @SafeParcelable.Param(17) int consentVersionValue,
+            @SafeParcelable.Param(18) int deviceConsentSourceValue,
+            @SafeParcelable.Param(19) int deviceConsentVersionValue) {
+        this.requestCode = requestCode;
+        this.asterismClientValue = asterismClientValue;
+        this.flowContextValue = flowContextValue;
+        this.tosResourceIds = tosResourceIds;
+        this.timestamp = timestamp;
+        this.consentValue = consentValue;
+        this.extras = extras;
+        this.statusValue = statusValue;
+        this.clientVersion = clientVersion;
+        this.language = language;
+        this.field11 = field11;
+        this.field12 = field12;
+        this.field13 = field13;
+        this.accountName = accountName;
+        this.consentVariant = consentVariant;
+        this.consentTrigger = consentTrigger;
+        this.consentVersionValue = consentVersionValue;
+        this.deviceConsentSourceValue = deviceConsentSourceValue;
+        this.deviceConsentVersionValue = deviceConsentVersionValue;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/asterism/SetAsterismConsentResponse.java
+++ b/play-services-core/src/main/java/com/google/android/gms/asterism/SetAsterismConsentResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.asterism;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class SetAsterismConsentResponse extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<SetAsterismConsentResponse> CREATOR = findCreator(SetAsterismConsentResponse.class);
+
+    @SafeParcelable.Field(1)
+    public final int requestCode;
+
+    @SafeParcelable.Field(2)
+    @Nullable
+    public final String gmscoreIidToken;
+
+    @SafeParcelable.Field(3)
+    @Nullable
+    public final String fid;
+
+    @SafeParcelable.Constructor
+    public SetAsterismConsentResponse(
+            @SafeParcelable.Param(1) int requestCode,
+            @SafeParcelable.Param(2) @Nullable String gmscoreIidToken,
+            @SafeParcelable.Param(3) @Nullable String fid) {
+        this.requestCode = requestCode;
+        this.gmscoreIidToken = gmscoreIidToken;
+        this.fid = fid;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/ApiMetadata.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/ApiMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+/**
+ * Opaque metadata passed alongside Constellation API calls.
+ *
+ * The exact fields are not yet resolved; this placeholder allows the AIDL
+ * contract to compile and the callback signatures to be type-safe.
+ */
+@SafeParcelable.Class
+public class ApiMetadata extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<ApiMetadata> CREATOR = findCreator(ApiMetadata.class);
+
+    @SafeParcelable.Constructor
+    public ApiMetadata() {
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/GetIidTokenRequest.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/GetIidTokenRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class GetIidTokenRequest extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<GetIidTokenRequest> CREATOR = findCreator(GetIidTokenRequest.class);
+
+    @SafeParcelable.Field(1)
+    @Nullable
+    public final Long projectNumber;
+
+    @SafeParcelable.Constructor
+    public GetIidTokenRequest(@SafeParcelable.Param(1) @Nullable Long projectNumber) {
+        this.projectNumber = projectNumber;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/GetIidTokenResponse.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/GetIidTokenResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class GetIidTokenResponse extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<GetIidTokenResponse> CREATOR = findCreator(GetIidTokenResponse.class);
+
+    @SafeParcelable.Field(1)
+    @Nullable
+    public final String iidToken;
+
+    @SafeParcelable.Field(2)
+    @Nullable
+    public final String fid;
+
+    @SafeParcelable.Field(3)
+    @Nullable
+    public final byte[] signature;
+
+    @SafeParcelable.Field(4)
+    public final long timestamp;
+
+    @SafeParcelable.Constructor
+    public GetIidTokenResponse(
+            @SafeParcelable.Param(1) @Nullable String iidToken,
+            @SafeParcelable.Param(2) @Nullable String fid,
+            @SafeParcelable.Param(3) @Nullable byte[] signature,
+            @SafeParcelable.Param(4) long timestamp) {
+        this.iidToken = iidToken;
+        this.fid = fid;
+        this.signature = signature;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/GetPnvCapabilitiesRequest.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/GetPnvCapabilitiesRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+import java.util.List;
+
+@SafeParcelable.Class
+public class GetPnvCapabilitiesRequest extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<GetPnvCapabilitiesRequest> CREATOR = findCreator(GetPnvCapabilitiesRequest.class);
+
+    @SafeParcelable.Field(1)
+    @Nullable
+    public final String policyId;
+
+    @SafeParcelable.Field(2)
+    @Nullable
+    public final List<Integer> verificationTypes;
+
+    @SafeParcelable.Field(3)
+    @Nullable
+    public final List<Integer> simSlotIndices;
+
+    @SafeParcelable.Constructor
+    public GetPnvCapabilitiesRequest(
+            @SafeParcelable.Param(1) @Nullable String policyId,
+            @SafeParcelable.Param(2) @Nullable List<Integer> verificationTypes,
+            @SafeParcelable.Param(3) @Nullable List<Integer> simSlotIndices) {
+        this.policyId = policyId;
+        this.verificationTypes = verificationTypes;
+        this.simSlotIndices = simSlotIndices;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/GetPnvCapabilitiesResponse.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/GetPnvCapabilitiesResponse.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+import java.util.List;
+
+@SafeParcelable.Class
+public class GetPnvCapabilitiesResponse extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<GetPnvCapabilitiesResponse> CREATOR = findCreator(GetPnvCapabilitiesResponse.class);
+
+    @SafeParcelable.Field(1)
+    @Nullable
+    public final List<SimCapability> simCapabilities;
+
+    @SafeParcelable.Constructor
+    public GetPnvCapabilitiesResponse(
+            @SafeParcelable.Param(1) @Nullable List<SimCapability> simCapabilities) {
+        this.simCapabilities = simCapabilities;
+    }
+
+    @SafeParcelable.Class
+    public static class SimCapability extends AbstractSafeParcelable {
+        public static SafeParcelableCreatorAndWriter<SimCapability> CREATOR = findCreator(SimCapability.class);
+
+        @SafeParcelable.Field(1)
+        public final int slotValue;
+
+        @SafeParcelable.Field(2)
+        @Nullable
+        public final String subscriberIdDigest;
+
+        @SafeParcelable.Field(3)
+        public final int carrierId;
+
+        @SafeParcelable.Field(4)
+        @Nullable
+        public final String operatorName;
+
+        @SafeParcelable.Field(5)
+        @Nullable
+        public final List<VerificationCapability> verificationCapabilities;
+
+        @SafeParcelable.Constructor
+        public SimCapability(
+                @SafeParcelable.Param(1) int slotValue,
+                @SafeParcelable.Param(2) @Nullable String subscriberIdDigest,
+                @SafeParcelable.Param(3) int carrierId,
+                @SafeParcelable.Param(4) @Nullable String operatorName,
+                @SafeParcelable.Param(5) @Nullable List<VerificationCapability> verificationCapabilities) {
+            this.slotValue = slotValue;
+            this.subscriberIdDigest = subscriberIdDigest;
+            this.carrierId = carrierId;
+            this.operatorName = operatorName;
+            this.verificationCapabilities = verificationCapabilities;
+        }
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            CREATOR.writeToParcel(this, dest, flags);
+        }
+    }
+
+    @SafeParcelable.Class
+    public static class VerificationCapability extends AbstractSafeParcelable {
+        public static SafeParcelableCreatorAndWriter<VerificationCapability> CREATOR = findCreator(VerificationCapability.class);
+
+        @SafeParcelable.Field(1)
+        public final int verificationMethod;
+
+        @SafeParcelable.Field(2)
+        public final int statusValue;
+
+        @SafeParcelable.Constructor
+        public VerificationCapability(
+                @SafeParcelable.Param(1) int verificationMethod,
+                @SafeParcelable.Param(2) int statusValue) {
+            this.verificationMethod = verificationMethod;
+            this.statusValue = statusValue;
+        }
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            CREATOR.writeToParcel(this, dest, flags);
+        }
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/PhoneNumberInfo.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/PhoneNumberInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class PhoneNumberInfo extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<PhoneNumberInfo> CREATOR = findCreator(PhoneNumberInfo.class);
+
+    @SafeParcelable.Field(1)
+    public final int version;
+
+    @SafeParcelable.Field(2)
+    @Nullable
+    public final String phoneNumber;
+
+    @SafeParcelable.Field(3)
+    public final long verificationTime;
+
+    @SafeParcelable.Field(4)
+    @Nullable
+    public final Bundle extras;
+
+    @SafeParcelable.Constructor
+    public PhoneNumberInfo(
+            @SafeParcelable.Param(1) int version,
+            @SafeParcelable.Param(2) @Nullable String phoneNumber,
+            @SafeParcelable.Param(3) long verificationTime,
+            @SafeParcelable.Param(4) @Nullable Bundle extras) {
+        this.version = version;
+        this.phoneNumber = phoneNumber;
+        this.verificationTime = verificationTime;
+        this.extras = extras;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/VerifyPhoneNumberRequest.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/VerifyPhoneNumberRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+import java.util.List;
+
+@SafeParcelable.Class
+public class VerifyPhoneNumberRequest extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<VerifyPhoneNumberRequest> CREATOR = findCreator(VerifyPhoneNumberRequest.class);
+
+    @SafeParcelable.Field(1)
+    @Nullable
+    public final String policyId;
+
+    @SafeParcelable.Field(2)
+    public final long timeout;
+
+    @SafeParcelable.Field(3)
+    @Nullable
+    public final Bundle idTokenRequest;
+
+    @SafeParcelable.Field(4)
+    @Nullable
+    public final Bundle extras;
+
+    @SafeParcelable.Field(5)
+    @Nullable
+    public final List<Bundle> targetedSims;
+
+    @SafeParcelable.Field(6)
+    public final boolean includeUnverified;
+
+    @SafeParcelable.Field(7)
+    public final int apiVersion;
+
+    @SafeParcelable.Field(8)
+    @Nullable
+    public final List<Integer> verificationMethodsValues;
+
+    @SafeParcelable.Constructor
+    public VerifyPhoneNumberRequest(
+            @SafeParcelable.Param(1) @Nullable String policyId,
+            @SafeParcelable.Param(2) long timeout,
+            @SafeParcelable.Param(3) @Nullable Bundle idTokenRequest,
+            @SafeParcelable.Param(4) @Nullable Bundle extras,
+            @SafeParcelable.Param(5) @Nullable List<Bundle> targetedSims,
+            @SafeParcelable.Param(6) boolean includeUnverified,
+            @SafeParcelable.Param(7) int apiVersion,
+            @SafeParcelable.Param(8) @Nullable List<Integer> verificationMethodsValues) {
+        this.policyId = policyId;
+        this.timeout = timeout;
+        this.idTokenRequest = idTokenRequest;
+        this.extras = extras;
+        this.targetedSims = targetedSims;
+        this.includeUnverified = includeUnverified;
+        this.apiVersion = apiVersion;
+        this.verificationMethodsValues = verificationMethodsValues;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/com/google/android/gms/constellation/VerifyPhoneNumberResponse.java
+++ b/play-services-core/src/main/java/com/google/android/gms/constellation/VerifyPhoneNumberResponse.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.constellation;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class VerifyPhoneNumberResponse extends AbstractSafeParcelable {
+    public static SafeParcelableCreatorAndWriter<VerifyPhoneNumberResponse> CREATOR = findCreator(VerifyPhoneNumberResponse.class);
+
+    @SafeParcelable.Field(1)
+    @Nullable
+    public final PhoneNumberVerification[] verifications;
+
+    @SafeParcelable.Field(2)
+    @Nullable
+    public final Bundle extras;
+
+    @SafeParcelable.Constructor
+    public VerifyPhoneNumberResponse(
+            @SafeParcelable.Param(1) @Nullable PhoneNumberVerification[] verifications,
+            @SafeParcelable.Param(2) @Nullable Bundle extras) {
+        this.verifications = verifications;
+        this.extras = extras;
+    }
+
+    @SafeParcelable.Class
+    public static class PhoneNumberVerification extends AbstractSafeParcelable {
+        public static SafeParcelableCreatorAndWriter<PhoneNumberVerification> CREATOR = findCreator(PhoneNumberVerification.class);
+
+        @SafeParcelable.Field(1)
+        @Nullable
+        public final String phoneNumber;
+
+        @SafeParcelable.Field(2)
+        public final long timestampMillis;
+
+        @SafeParcelable.Field(3)
+        public final int verificationMethod;
+
+        @SafeParcelable.Field(4)
+        public final int simSlot;
+
+        @SafeParcelable.Field(5)
+        @Nullable
+        public final String verificationToken;
+
+        @SafeParcelable.Field(6)
+        @Nullable
+        public final Bundle extras;
+
+        @SafeParcelable.Field(7)
+        public final int verificationStatus;
+
+        @SafeParcelable.Field(8)
+        public final long retryAfterSeconds;
+
+        @SafeParcelable.Constructor
+        public PhoneNumberVerification(
+                @SafeParcelable.Param(1) @Nullable String phoneNumber,
+                @SafeParcelable.Param(2) long timestampMillis,
+                @SafeParcelable.Param(3) int verificationMethod,
+                @SafeParcelable.Param(4) int simSlot,
+                @SafeParcelable.Param(5) @Nullable String verificationToken,
+                @SafeParcelable.Param(6) @Nullable Bundle extras,
+                @SafeParcelable.Param(7) int verificationStatus,
+                @SafeParcelable.Param(8) long retryAfterSeconds) {
+            this.phoneNumber = phoneNumber;
+            this.timestampMillis = timestampMillis;
+            this.verificationMethod = verificationMethod;
+            this.simSlot = simSlot;
+            this.verificationToken = verificationToken;
+            this.extras = extras;
+            this.verificationStatus = verificationStatus;
+            this.retryAfterSeconds = retryAfterSeconds;
+        }
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            CREATOR.writeToParcel(this, dest, flags);
+        }
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/AsterismApiService.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/AsterismApiService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.asterism;
+
+import android.os.RemoteException;
+
+import com.google.android.gms.common.Feature;
+import com.google.android.gms.common.internal.ConnectionInfo;
+import com.google.android.gms.common.internal.GetServiceRequest;
+import com.google.android.gms.common.internal.IGmsCallbacks;
+
+import org.microg.gms.BaseService;
+import org.microg.gms.common.GmsService;
+import org.microg.gms.common.PackageUtils;
+import org.microg.gms.asterism.consent.AsterismConsentRepository;
+import org.microg.gms.asterism.consent.InMemoryAsterismConsentRepository;
+
+/**
+ * Entry point for the Asterism RCS consent service.
+ *
+ * Binds the {@code com.google.android.gms.asterism.service.START} action and
+ * returns an {@link com.google.android.gms.asterism.internal.IAsterismApiService}
+ * binder to callers that are signed with a Google platform/app key.
+ */
+public class AsterismApiService extends BaseService {
+    private static final String TAG = "AsterismApiService";
+
+    private final AsterismConsentRepository consentRepository = new InMemoryAsterismConsentRepository();
+
+    public AsterismApiService() {
+        super(TAG, GmsService.ASTERISM);
+    }
+
+    @Override
+    public void handleServiceRequest(IGmsCallbacks callback, GetServiceRequest request, GmsService service) throws RemoteException {
+        String packageName = PackageUtils.getAndCheckCallingPackage(this, request.packageName);
+        if (!PackageUtils.isGooglePackage(this, packageName)) {
+            throw new SecurityException(packageName + " is not a Google package");
+        }
+
+        ConnectionInfo connectionInfo = new ConnectionInfo();
+        connectionInfo.features = FeatureRegistry.ASTERISM_FEATURES;
+
+        callback.onPostInitCompleteWithConnectionInfo(0,
+                new AsterismApiServiceImpl(this, consentRepository).asBinder(),
+                connectionInfo);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/AsterismApiServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/AsterismApiServiceImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.asterism;
+
+import android.content.Context;
+import android.os.RemoteException;
+
+import com.google.android.gms.asterism.GetAsterismConsentRequest;
+import com.google.android.gms.asterism.GetAsterismConsentResponse;
+import com.google.android.gms.asterism.SetAsterismConsentRequest;
+import com.google.android.gms.asterism.SetAsterismConsentResponse;
+import com.google.android.gms.asterism.internal.IAsterismApiService;
+import com.google.android.gms.asterism.internal.IAsterismCallbacks;
+import com.google.android.gms.common.api.Status;
+
+import org.microg.gms.asterism.consent.AsterismConsent;
+import org.microg.gms.asterism.consent.AsterismConsentRepository;
+
+/**
+ * Implementation of the Asterism AIDL contract.
+ *
+ * Consent records are backed by the supplied {@link AsterismConsentRepository}.
+ * Server synchronization and the exact consent-state mapping are still
+ * TODO_PROTOCOL_DISCOVERY and are tracked in Implementation_Delta_Report.md.
+ */
+public class AsterismApiServiceImpl extends IAsterismApiService.Stub {
+    private final Context context;
+    private final AsterismConsentRepository consentRepository;
+
+    public AsterismApiServiceImpl(Context context, AsterismConsentRepository consentRepository) {
+        this.context = context;
+        this.consentRepository = consentRepository;
+    }
+
+    @Override
+    public void getAsterismConsent(IAsterismCallbacks cb, GetAsterismConsentRequest request) throws RemoteException {
+        AsterismConsent consent = consentRepository.get(request.requestCode);
+        GetAsterismConsentResponse response;
+        if (consent == null) {
+            // No local consent record yet; return UNKNOWN state rather than guessing.
+            response = new GetAsterismConsentResponse(
+                    request.requestCode, 0, null, null, 0);
+            cb.onConsentFetched(Status.INTERNAL_ERROR, response);
+            return;
+        }
+
+        // Local best-effort mapping. The server-backed semantics for these fields
+        // are still under protocol discovery.
+        response = new GetAsterismConsentResponse(
+                request.requestCode,
+                consent.consentValue,
+                null,
+                null,
+                0);
+        cb.onConsentFetched(Status.SUCCESS, response);
+    }
+
+    @Override
+    public void setAsterismConsent(IAsterismCallbacks cb, SetAsterismConsentRequest request) throws RemoteException {
+        AsterismConsent consent = new AsterismConsent(
+                request.consentValue,
+                request.consentVersionValue,
+                request.deviceConsentSourceValue,
+                request.deviceConsentVersionValue);
+        consentRepository.set(request.requestCode, consent);
+
+        SetAsterismConsentResponse response = new SetAsterismConsentResponse(
+                request.requestCode, null, null);
+        cb.onConsentRegistered(Status.SUCCESS, response);
+    }
+
+    @Override
+    public void getIsPnvrConstellationDevice(IAsterismCallbacks cb) throws RemoteException {
+        // PNVR detection requires protocol discovery (TODO_PROTOCOL_DISCOVERY).
+        cb.onIsPnvrConstellationDevice(Status.INTERNAL_ERROR, false);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/FeatureRegistry.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/FeatureRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.asterism;
+
+import com.google.android.gms.common.Feature;
+
+/**
+ * Capability features advertised to Asterism/Constellation clients.
+ *
+ * Values are taken from the Protocol Mapping Register. The server may use
+ * these features to gate consent flows and verification methods.
+ */
+public final class FeatureRegistry {
+    private FeatureRegistry() {}
+
+    public static final Feature[] ASTERISM_FEATURES = new Feature[] {
+            new Feature("asterism_consent", 3),
+            new Feature("one_time_verification", 1),
+            new Feature("carrier_auth", 1),
+            new Feature("verify_phone_number", 2),
+            new Feature("get_iid_token", 1),
+            new Feature("get_pnv_capabilities", 1)
+    };
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/consent/AsterismConsent.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/consent/AsterismConsent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.asterism.consent;
+
+/**
+ * Local snapshot of the consent values supplied by a client.
+ *
+ * This is intentionally separate from the SafeParcelable request/response types
+ * and contains only the fields that represent the user's consent decision.
+ */
+public final class AsterismConsent {
+    public final int consentValue;
+    public final int consentVersionValue;
+    public final int deviceConsentSourceValue;
+    public final int deviceConsentVersionValue;
+
+    public AsterismConsent(int consentValue, int consentVersionValue,
+                           int deviceConsentSourceValue, int deviceConsentVersionValue) {
+        this.consentValue = consentValue;
+        this.consentVersionValue = consentVersionValue;
+        this.deviceConsentSourceValue = deviceConsentSourceValue;
+        this.deviceConsentVersionValue = deviceConsentVersionValue;
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/consent/AsterismConsentRepository.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/consent/AsterismConsentRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.asterism.consent;
+
+/**
+ * Storage abstraction for Asterism consent records.
+ *
+ * Implementations decide how records are persisted (in-memory, SharedPreferences,
+ * or a server-backed cache). Callers receive the stored {@link AsterismConsent}
+ * keyed by the request code supplied by the client.
+ */
+public interface AsterismConsentRepository {
+    AsterismConsent get(int requestCode);
+    void set(int requestCode, AsterismConsent consent);
+}

--- a/play-services-core/src/main/java/org/microg/gms/asterism/consent/InMemoryAsterismConsentRepository.java
+++ b/play-services-core/src/main/java/org/microg/gms/asterism/consent/InMemoryAsterismConsentRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.asterism.consent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of {@link AsterismConsentRepository}.
+ *
+ * This is intended for the first implementation pass. A durable implementation
+ * (SharedPreferences or server-backed) can be substituted without changing the
+ * service contract.
+ */
+public class InMemoryAsterismConsentRepository implements AsterismConsentRepository {
+    private final Map<Integer, AsterismConsent> store = new ConcurrentHashMap<>();
+
+    @Override
+    public AsterismConsent get(int requestCode) {
+        return store.get(requestCode);
+    }
+
+    @Override
+    public void set(int requestCode, AsterismConsent consent) {
+        store.put(requestCode, consent);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationApiService.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationApiService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation;
+
+import android.os.RemoteException;
+
+import com.google.android.gms.common.internal.ConnectionInfo;
+import com.google.android.gms.common.internal.GetServiceRequest;
+import com.google.android.gms.common.internal.IGmsCallbacks;
+
+import org.microg.gms.BaseService;
+import org.microg.gms.common.GmsService;
+import org.microg.gms.common.PackageUtils;
+import org.microg.gms.constellation.iid.IidTokenProvider;
+import org.microg.gms.constellation.iid.UnimplementedIidTokenProvider;
+import org.microg.gms.constellation.pnv.PnvCapabilityProvider;
+import org.microg.gms.constellation.pnv.UnimplementedPnvCapabilityProvider;
+import org.microg.gms.constellation.verification.VerificationCoordinator;
+
+/**
+ * Entry point for the Constellation phone-number verification service.
+ *
+ * Binds the {@code com.google.android.gms.constellation.service.START} action
+ * and returns an {@link com.google.android.gms.constellation.internal.IConstellationApiService}
+ * binder to callers signed with a Google platform/app key.
+ */
+public class ConstellationApiService extends BaseService {
+    private static final String TAG = "ConstellationApiService";
+
+    private final VerificationCoordinator verificationCoordinator = new VerificationCoordinator();
+    private final IidTokenProvider iidTokenProvider = new UnimplementedIidTokenProvider();
+    private final PnvCapabilityProvider pnvCapabilityProvider = new UnimplementedPnvCapabilityProvider();
+
+    public ConstellationApiService() {
+        super(TAG, GmsService.CONSTELLATION);
+    }
+
+    @Override
+    public void handleServiceRequest(IGmsCallbacks callback, GetServiceRequest request, GmsService service) throws RemoteException {
+        String packageName = PackageUtils.getAndCheckCallingPackage(this, request.packageName);
+        if (!PackageUtils.isGooglePackage(this, packageName)) {
+            throw new SecurityException(packageName + " is not a Google package");
+        }
+
+        ConnectionInfo connectionInfo = new ConnectionInfo();
+        connectionInfo.features = FeatureRegistry.CONSTELLATION_FEATURES;
+
+        callback.onPostInitCompleteWithConnectionInfo(0,
+                new ConstellationApiServiceImpl(this, verificationCoordinator, iidTokenProvider, pnvCapabilityProvider).asBinder(),
+                connectionInfo);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationApiServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/ConstellationApiServiceImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.RemoteException;
+
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.constellation.ApiMetadata;
+import com.google.android.gms.constellation.GetIidTokenRequest;
+import com.google.android.gms.constellation.GetIidTokenResponse;
+import com.google.android.gms.constellation.GetPnvCapabilitiesRequest;
+import com.google.android.gms.constellation.GetPnvCapabilitiesResponse;
+import com.google.android.gms.constellation.VerifyPhoneNumberRequest;
+import com.google.android.gms.constellation.internal.IConstellationApiService;
+import com.google.android.gms.constellation.internal.IConstellationCallbacks;
+
+import org.microg.gms.constellation.iid.IidTokenProvider;
+import org.microg.gms.constellation.pnv.PnvCapabilityProvider;
+import org.microg.gms.constellation.verification.VerificationCoordinator;
+
+/**
+ * Implementation of the Constellation AIDL contract.
+ *
+ * Phone-number verification, IID token generation, and PNV capability mapping
+ * are delegated to pluggable providers. The concrete providers are stubs while
+ * the server-side protocol details remain TODO_PROTOCOL_DISCOVERY.
+ */
+public class ConstellationApiServiceImpl extends IConstellationApiService.Stub {
+    private final Context context;
+    private final VerificationCoordinator verificationCoordinator;
+    private final IidTokenProvider iidTokenProvider;
+    private final PnvCapabilityProvider pnvCapabilityProvider;
+
+    public ConstellationApiServiceImpl(Context context,
+                                       VerificationCoordinator verificationCoordinator,
+                                       IidTokenProvider iidTokenProvider,
+                                       PnvCapabilityProvider pnvCapabilityProvider) {
+        this.context = context;
+        this.verificationCoordinator = verificationCoordinator;
+        this.iidTokenProvider = iidTokenProvider;
+        this.pnvCapabilityProvider = pnvCapabilityProvider;
+    }
+
+    @Override
+    public void verifyPhoneNumberV1(IConstellationCallbacks cb, Bundle params, ApiMetadata apiMetadata) throws RemoteException {
+        verificationCoordinator.verifyPhoneNumberV1(cb, params, apiMetadata);
+    }
+
+    @Override
+    public void verifyPhoneNumberSingleUse(IConstellationCallbacks cb, Bundle params, ApiMetadata apiMetadata) throws RemoteException {
+        verificationCoordinator.verifyPhoneNumberSingleUse(cb, params, apiMetadata);
+    }
+
+    @Override
+    public void verifyPhoneNumber(IConstellationCallbacks cb, VerifyPhoneNumberRequest request, ApiMetadata apiMetadata) throws RemoteException {
+        verificationCoordinator.verifyPhoneNumber(cb, request, apiMetadata);
+    }
+
+    @Override
+    public void getIidToken(IConstellationCallbacks cb, GetIidTokenRequest request, ApiMetadata apiMetadata) throws RemoteException {
+        GetIidTokenResponse response = iidTokenProvider.getIidToken(request.projectNumber);
+        cb.onIidTokenGenerated(Status.INTERNAL_ERROR, response, apiMetadata);
+    }
+
+    @Override
+    public void getPnvCapabilities(IConstellationCallbacks cb, GetPnvCapabilitiesRequest request, ApiMetadata apiMetadata) throws RemoteException {
+        GetPnvCapabilitiesResponse response = pnvCapabilityProvider.getCapabilities(request);
+        cb.onGetPnvCapabilitiesCompleted(Status.INTERNAL_ERROR, response, apiMetadata);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/FeatureRegistry.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/FeatureRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation;
+
+import com.google.android.gms.common.Feature;
+
+/**
+ * Capability features advertised to Constellation clients.
+ *
+ * These features are the same as those advertised by Asterism because the
+ * underlying RCS phone-number verification capabilities are shared.
+ */
+public final class FeatureRegistry {
+    private FeatureRegistry() {}
+
+    public static final Feature[] CONSTELLATION_FEATURES = new Feature[] {
+            new Feature("asterism_consent", 3),
+            new Feature("one_time_verification", 1),
+            new Feature("carrier_auth", 1),
+            new Feature("verify_phone_number", 2),
+            new Feature("get_iid_token", 1),
+            new Feature("get_pnv_capabilities", 1)
+    };
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/iid/IidTokenProvider.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/iid/IidTokenProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation.iid;
+
+import com.google.android.gms.constellation.GetIidTokenResponse;
+
+/**
+ * Abstraction for IID (Instance ID) token provisioning.
+ *
+ * Implementations are responsible for generating or fetching the token, FID,
+ * and signature. This interface hides the underlying gRPC/HTTP details from
+ * {@link org.microg.gms.constellation.ConstellationApiServiceImpl}.
+ */
+public interface IidTokenProvider {
+    GetIidTokenResponse getIidToken(Long projectNumber);
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/iid/UnimplementedIidTokenProvider.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/iid/UnimplementedIidTokenProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation.iid;
+
+import com.google.android.gms.constellation.GetIidTokenResponse;
+
+/**
+ * Stub IID token provider that returns an empty response.
+ *
+ * This is a compile-safe placeholder until the IID token generation and
+ * signing flow is resolved (TODO_PROTOCOL_DISCOVERY).
+ */
+public class UnimplementedIidTokenProvider implements IidTokenProvider {
+    @Override
+    public GetIidTokenResponse getIidToken(Long projectNumber) {
+        return new GetIidTokenResponse(null, null, null, 0L);
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/pnv/PnvCapabilityProvider.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/pnv/PnvCapabilityProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation.pnv;
+
+import com.google.android.gms.constellation.GetPnvCapabilitiesRequest;
+import com.google.android.gms.constellation.GetPnvCapabilitiesResponse;
+
+/**
+ * Abstraction for Phone Number Verification capability reporting.
+ *
+ * Implementations inspect the device's SIM/telephony state and map it to the
+ * verification methods supported by each SIM slot.
+ */
+public interface PnvCapabilityProvider {
+    GetPnvCapabilitiesResponse getCapabilities(GetPnvCapabilitiesRequest request);
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/pnv/UnimplementedPnvCapabilityProvider.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/pnv/UnimplementedPnvCapabilityProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation.pnv;
+
+import com.google.android.gms.constellation.GetPnvCapabilitiesRequest;
+import com.google.android.gms.constellation.GetPnvCapabilitiesResponse;
+
+import java.util.Collections;
+
+/**
+ * Compile-safe placeholder until carrier capability mapping is implemented.
+ *
+ * Marked TODO_PROTOCOL_DISCOVERY: the exact capability bit/enum mapping for
+ * each carrier is not yet resolved.
+ */
+public class UnimplementedPnvCapabilityProvider implements PnvCapabilityProvider {
+    @Override
+    public GetPnvCapabilitiesResponse getCapabilities(GetPnvCapabilitiesRequest request) {
+        return new GetPnvCapabilitiesResponse(Collections.emptyList());
+    }
+}

--- a/play-services-core/src/main/java/org/microg/gms/constellation/verification/VerificationCoordinator.java
+++ b/play-services-core/src/main/java/org/microg/gms/constellation/verification/VerificationCoordinator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2013-2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.constellation.verification;
+
+import android.os.Bundle;
+import android.os.RemoteException;
+
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.constellation.ApiMetadata;
+import com.google.android.gms.constellation.PhoneNumberInfo;
+import com.google.android.gms.constellation.VerifyPhoneNumberRequest;
+import com.google.android.gms.constellation.VerifyPhoneNumberResponse;
+import com.google.android.gms.constellation.internal.IConstellationCallbacks;
+
+import java.util.Collections;
+
+/**
+ * Coordinates phone number verification attempts across SMS, TS.43, carrier-ID,
+ * flash-call, and other methods.
+ *
+ * The full orchestration is TODO_PROTOCOL_DISCOVERY; the coordinator currently
+ * reports INTERNAL_ERROR so callers do not hang while the protocol is resolved.
+ */
+public class VerificationCoordinator {
+
+    /**
+     * Legacy v1 entry point that accepts an opaque Bundle.
+     */
+    public void verifyPhoneNumberV1(IConstellationCallbacks cb, Bundle params, ApiMetadata apiMetadata) throws RemoteException {
+        cb.onPhoneNumberVerified(Status.INTERNAL_ERROR, Collections.<PhoneNumberInfo>emptyList(), apiMetadata);
+    }
+
+    /**
+     * Single-use verification entry point that accepts an opaque Bundle.
+     */
+    public void verifyPhoneNumberSingleUse(IConstellationCallbacks cb, Bundle params, ApiMetadata apiMetadata) throws RemoteException {
+        cb.onPhoneNumberVerificationsCompleted(Status.INTERNAL_ERROR,
+                new VerifyPhoneNumberResponse(new VerifyPhoneNumberResponse.PhoneNumberVerification[0], null),
+                apiMetadata);
+    }
+
+    /**
+     * Structured verification entry point.
+     */
+    public void verifyPhoneNumber(IConstellationCallbacks cb, VerifyPhoneNumberRequest request, ApiMetadata apiMetadata) throws RemoteException {
+        cb.onPhoneNumberVerificationsCompleted(Status.INTERNAL_ERROR,
+                new VerifyPhoneNumberResponse(new VerifyPhoneNumberResponse.PhoneNumberVerification[0], null),
+                apiMetadata);
+    }
+}


### PR DESCRIPTION
This PR implements the clean-room AIDL/service surfaces needed for Google Messages RCS provisioning through microG.\n\nIncluded changes:\n- TelephonyInfoProvider interface and SystemTelephonyInfoProvider for real PhoneInfo values (replaces hardcoded/random data).\n- AsterismApiService with consent parcelables, AIDL callbacks, and an in-memory consent repository.\n- ConstellationApiService with phone-number verification, IID token, and PNV capability AIDL/parcelable structures.\n- Provider abstractions for VerificationCoordinator, IidTokenProvider, and PnvCapabilityProvider so the server-side protocol work can be plugged in later.\n\nFixes #2994\n\nKnown limitations (documented in the companion repository and to be addressed in follow-ups):\n- Runtime binding to Google Messages has not been validated yet; the only available test device (Nothing Phone 2a) has a locked bootloader and system-privileged com.google.android.gms at /product/priv-app/GmsCore.\n- The verification/IID/PNV providers currently return stub INTERNAL_ERROR responses; the carrier/TS.43 server protocols still need to be discovered.\n\nThe implementation is intentionally minimal and clean-room, authored from the protocol mapping register and public microG patterns, with no code copied from upstream PRs.