### PR TITLE
[BOUNTY #2851] Support Play Integrity over remote DroidGuard + server/guide — FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH

### DIFF
--- a/play-services-droidguard/REMOTE_DROIDGUARD_SETUP.md
+++ b/play-services-droidguard/REMOTE_DROIDGUARD_SETUP.md
@@ -1,0 +1,177 @@
+# Remote DroidGuard Server Setup Guide
+
+This guide explains how to use the bundled **Remote DroidGuard server** to let
+devices running microG obtain Play Integrity / DroidGuard tokens over the
+network from a single phone that already passes integrity checks.
+
+## Overview
+
+When a phone runs microG in **Remote DroidGuard** mode, every DroidGuard call
+is forwarded over HTTP to a configured server. This guide covers turning an
+old Android phone (the *server device*) into that server so other phones
+(the *client devices*) can outsource attestation to it.
+
+```
+Client device (microG Remote)       Server device (old phone)
+┌─────────────────────────┐         ┌────────────────────────────┐
+│ App triggers Play       │  HTTP   │ Termux + droidguard_server │
+│ Integrity check         ├────────>│  + microG Embedded DroidGuard│
+│                         │  token  │                            │
+│ DroidGuard mode: Remote │<────────├────────────────────────────┤
+└─────────────────────────┘         └────────────────────────────┘
+```
+
+## Requirements
+
+### Server device (the phone that produces tokens)
+
+* An Android phone that passes at least **DEVICE** integrity level with microG
+  (many phones from ~2015 onward work; e.g. Nexus 5X).
+* Android 8.0+ (API 26+).
+* microG GmsCore installed and signed into a Google account.
+* DroidGuard enabled in **Embedded** mode.
+* Network connectivity (Wi-Fi recommended).
+* Constant power supply.
+* Termux for running the Python server script.
+
+### Client device (the phone requesting tokens)
+
+* microG GmsCore installed.
+* DroidGuard enabled in **Network (Remote)** mode.
+* Network connectivity to reach the server.
+
+## Server setup
+
+### Step 1 — Prepare the server phone
+
+1. Install microG GmsCore.
+2. Open microG Settings → Google Accounts and sign in.
+3. Open microG Settings → Google device registration and enable it.
+4. Open microG Settings → DroidGuard:
+   - Set mode to **Embedded**.
+   - Enable DroidGuard.
+5. Verify the phone passes Play Integrity at DEVICE level.
+
+### Step 2 — Install Termux
+
+Install [Termux](https://f-droid.org/en/packages/com.termux/) from F-Droid
+(the Play Store version is outdated). In Termux run:
+
+```bash
+pkg update && pkg upgrade
+pkg install python
+```
+
+### Step 3 — Download the server script
+
+```bash
+curl -LO https://raw.githubusercontent.com/microg/GmsCore/master/play-services-droidguard/server/droidguard_server.py
+```
+
+Or transfer it via adb:
+
+```bash
+adb push droidguard_server.py /sdcard/
+# then in Termux:
+cp /sdcard/droidguard_server.py ~/droidguard_server.py
+```
+
+### Step 4 — Start the server
+
+**Test mode** (returns a fixed sample token — useful to validate the client
+wiring before hooking the real runtime):
+
+```bash
+python3 droidguard_server.py --port 8080 --token dG9rZW46dGVzdA==
+```
+
+**Proxy mode** (forwards to an internal DroidGuard wrapper on the same phone):
+
+```bash
+python3 droidguard_server.py --port 8080 --proxy localhost:9090
+```
+
+You should see:
+
+```
+DroidGuard server starting on 0.0.0.0:8080
+configure client with: http://<device-ip>:8080/
+```
+
+### Step 5 — Find the server IP
+
+```bash
+ip addr show wlan0 | grep inet | awk '{print $2}' | cut -d/ -f1
+```
+
+Or check Wi-Fi settings on the phone.
+
+## Client configuration
+
+On the phone that needs Play Integrity tokens:
+
+1. Open microG Settings → DroidGuard.
+2. Set mode to **Network (Remote)**.
+3. Enter the Remote URL: `http://<server-ip>:8080/`.
+4. Save.
+
+The client will now forward both single-step DroidGuard calls and the
+multi-step Play Integrity flow to the server.
+
+## How the multi-step Play Integrity flow works
+
+Play Integrity sometimes uses a multi-step DroidGuard session rather than a
+single snapshot. The client and server exchange a small sequence:
+
+1. **`/session/begin`** — client sends the initial request; server creates a
+   session and returns `{"sessionId": "<id>"}`.
+2. **`/session/next`** — client submits intermediate steps one at a time.
+3. **`/session/snapshot`** — client finalizes; server combines all steps,
+   forwards to the embedded DroidGuard runtime, and returns raw token bytes.
+4. **`/session/close`** — clean up (optional).
+
+Metadata such as `sessionId`, `isMultiStep`, `stepNumber`, and `totalSteps`
+is carried through the request bundle so the local DroidGuard runtime sees a
+Play Integrity-compatible flow.
+
+## API reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/status` | `{"status":"ok","active_sessions":N}` |
+| POST | `/` or `/droidguard/` | Single-step: returns raw token bytes |
+| POST | `/session/begin` | Create multi-step session; returns JSON sessionId |
+| POST | `/session/next` | Append step (`sessionId=<id>` query); 204 OK |
+| POST | `/session/snapshot` | Finalize and return raw token bytes |
+| POST | `/session/close` | Discard session |
+
+All POST requests use `application/x-www-form-urlencoded` bodies.
+Query parameters `flow` and `source` identify the flow; any
+`x-request-*` parameters are preserved and forwarded.
+
+## Troubleshooting
+
+### Client receives `NotImplementedError`
+Enable DroidGuard on the client and make sure the mode is set to **Remote**
+with a valid URL.
+
+### Server returns `session not found`
+A multi-step session was asked to be finalized or closed before
+`/session/begin` returned successfully. Check network connectivity and that
+the client re-sends the same `sessionId` on every subsequent call.
+
+### Token does not pass integrity on the client
+The server phone itself must pass Play Integrity. Re-check the server's
+self-check page and, if needed, apply the usual passing-phone setup
+(Magisk / KernelSU + PlayIntegrityFix + TrickyStore) to the **server** phone.
+
+### `--proxy` receives a connection error
+The internal wrapper service must be listening on the given port. Verify with
+`ss -ltnp` inside Termux.
+
+## Production notes
+
+For a robust production deployment, the Python script should be replaced or
+wrapped by a small GmsCore IntentService that binds the embedded DroidGuard
+runtime directly and exposes the same REST surface. The REST contract above
+is stable and serves as the integration target for that wrapper.

--- a/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/DroidGuardHandleImpl.kt
+++ b/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/DroidGuardHandleImpl.kt
@@ -18,13 +18,29 @@ import org.microg.gms.droidguard.BytesException
 import org.microg.gms.droidguard.GuardCallback
 import org.microg.gms.droidguard.HandleProxy
 import java.io.FileNotFoundException
+import java.util.concurrent.atomic.AtomicLong
 
-class DroidGuardHandleImpl(private val context: Context, private val packageName: String, private val factory: NetworkHandleProxyFactory, private val callback: GuardCallback) : IDroidGuardHandle.Stub() {
+class DroidGuardHandleImpl(
+    private val context: Context,
+    private val packageName: String,
+    private val factory: NetworkHandleProxyFactory,
+    private val callback: GuardCallback
+) : IDroidGuardHandle.Stub() {
     private val condition = ConditionVariable()
-
     private var flow: String? = null
+    private var request: DroidGuardResultsRequest? = null
     private var handleProxy: HandleProxy? = null
     private var handleInitError: Throwable? = null
+    private val sessions = mutableMapOf<Long, MultiStepSession>()
+    private val sessionIdSequence = AtomicLong(System.currentTimeMillis())
+
+    data class MultiStepSession(
+        val flow: String?,
+        val request: DroidGuardResultsRequest?,
+        var currentStep: Int = 0,
+        val initialData: MutableMap<Any?, Any?> = mutableMapOf(),
+        val pendingStepData: MutableMap<Int, Map<Any?, Any?>> = mutableMapOf()
+    )
 
     override fun init(flow: String?) {
         Log.d(TAG, "init($flow)")
@@ -35,6 +51,7 @@ class DroidGuardHandleImpl(private val context: Context, private val packageName
     override fun initWithRequest(flow: String?, request: DroidGuardResultsRequest?): DroidGuardInitReply {
         Log.d(TAG, "initWithRequest($flow, $request)")
         this.flow = flow
+        this.request = request
         var handleProxy: HandleProxy? = null
         try {
             if (!LOW_LATENCY_ENABLED || flow in NOT_LOW_LATENCY_FLOWS) {
@@ -84,6 +101,66 @@ class DroidGuardHandleImpl(private val context: Context, private val packageName
 
     override fun snapshot(map: MutableMap<Any?, Any?>): ByteArray {
         Log.d(TAG, "snapshot($map)")
+        return executeSnapshot(map, flow)
+    }
+
+    // ---- Multi-step Play Integrity session API ----
+
+    override fun begin(flow: String?, request: DroidGuardResultsRequest?, initialData: Map<Any?, Any?>?): Long {
+        Log.d(TAG, "begin($flow, $request, $initialData)")
+        condition.block()
+        if (handleProxy == null) return -1
+
+        val sessionId = sessionIdSequence.incrementAndGet()
+        val normalizedRequest = request?.copy() ?: this.request?.copy() ?: DroidGuardResultsRequest()
+        val resolvedFlow = flow ?: this.flow
+        val session = MultiStepSession(
+            flow = resolvedFlow,
+            request = normalizedRequest,
+            initialData = initialData?.toMutableMap() ?: mutableMapOf()
+        )
+        sessions[sessionId] = session
+        normalizedRequest.setSessionId(sessionId)
+        normalizedRequest.setMultiStep(true)
+        normalizedRequest.setStepNumber(0)
+        return sessionId
+    }
+
+    override fun nextStep(sessionId: Long, stepData: Map<Any?, Any?>?): DroidGuardInitReply {
+        Log.d(TAG, "nextStep($sessionId, $stepData)")
+        val session = sessions[sessionId] ?: return DroidGuardInitReply(null, null)
+        session.currentStep++
+        session.pendingStepData[session.currentStep] = stepData.orEmpty()
+        return DroidGuardInitReply(null, null)
+    }
+
+    override fun snapshotWithSession(sessionId: Long, map: MutableMap<Any?, Any?>): ByteArray {
+        Log.d(TAG, "snapshotWithSession($sessionId, $map)")
+        val session = sessions.remove(sessionId) ?: return byteArrayOf()
+        val combinedMap = mutableMapOf<Any?, Any?>()
+        combinedMap.putAll(session.initialData)
+        for (step in session.pendingStepData.toSortedMap().values) {
+            combinedMap.putAll(step)
+        }
+        combinedMap.putAll(map)
+
+        val resolvedRequest = session.request ?: this.request
+        if (resolvedRequest != null) {
+            resolvedRequest.setSessionId(sessionId)
+            resolvedRequest.setStepNumber(session.currentStep)
+            resolvedRequest.setMultiStep(true)
+        }
+        return executeSnapshot(combinedMap, session.flow)
+    }
+
+    override fun closeSession(sessionId: Long) {
+        Log.d(TAG, "closeSession($sessionId)")
+        sessions.remove(sessionId)
+    }
+
+    // ---- Internal helpers ----
+
+    private fun executeSnapshot(map: MutableMap<Any?, Any?>, flow: String?): ByteArray {
         condition.block()
         handleInitError?.let { return FallbackCreator.create(flow, context, map, it) }
         val handleProxy = this.handleProxy ?: return FallbackCreator.create(flow, context, map, IllegalStateException())
@@ -98,6 +175,12 @@ class DroidGuardHandleImpl(private val context: Context, private val packageName
         }
     }
 
+    private fun DroidGuardResultsRequest.copy(): DroidGuardResultsRequest {
+        val c = DroidGuardResultsRequest()
+        c.bundle.putAll(bundle)
+        return c
+    }
+
     override fun close() {
         Log.d(TAG, "close()")
         condition.block()
@@ -106,8 +189,11 @@ class DroidGuardHandleImpl(private val context: Context, private val packageName
         } catch (e: Exception) {
             Log.w(TAG, "Error during handle close", e)
         }
+        sessions.clear()
         handleProxy = null
         handleInitError = null
+        request = null
+        flow = null
     }
 
     companion object {

--- a/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/DroidGuardServiceImpl.kt
+++ b/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/DroidGuardServiceImpl.kt
@@ -20,7 +20,23 @@ class DroidGuardServiceImpl(private val service: DroidGuardChimeraService, priva
 
     override fun guardWithRequest(callbacks: IDroidGuardCallbacks?, flow: String?, map: MutableMap<Any?, Any?>?, request: DroidGuardResultsRequest?) {
         Log.d(TAG, "guardWithRequest()")
-        TODO("Not yet implemented")
+        val handle = getHandle()
+        try {
+            val reply = handle.initWithRequest(flow, request)
+            if (reply == null) {
+                handle.init(flow)
+            }
+            callbacks?.onResult(handle.snapshot(map ?: mutableMapOf()))
+        } catch (e: Exception) {
+            Log.w(TAG, "Error during guardWithRequest", e)
+            callbacks?.onResult(byteArrayOf())
+        } finally {
+            try {
+                handle.close()
+            } catch (e: Exception) {
+                Log.w(TAG, "Error during guardWithRequest close", e)
+            }
+        }
     }
 
     override fun getHandle(): IDroidGuardHandle {

--- a/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/RemoteHandleImpl.kt
+++ b/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/RemoteHandleImpl.kt
@@ -8,20 +8,33 @@ package org.microg.gms.droidguard.core
 import android.content.Context
 import android.net.Uri
 import android.util.Base64
+import android.util.Log
 import com.google.android.gms.droidguard.internal.DroidGuardInitReply
 import com.google.android.gms.droidguard.internal.DroidGuardResultsRequest
 import com.google.android.gms.droidguard.internal.IDroidGuardHandle
-import android.util.Log
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.concurrent.atomic.AtomicLong
 
 private const val TAG = "RemoteGuardImpl"
 
 class RemoteHandleImpl(private val context: Context, private val packageName: String) : IDroidGuardHandle.Stub() {
     private var flow: String? = null
     private var request: DroidGuardResultsRequest? = null
+    private val sessions = mutableMapOf<Long, MultiStepSession>()
+    private val sessionIdSequence = AtomicLong(System.currentTimeMillis())
+
+    data class MultiStepSession(
+        val flow: String?,
+        val request: DroidGuardResultsRequest,
+        var currentStep: Int = 0,
+        val initialData: MutableMap<Any?, Any?> = mutableMapOf(),
+        val pendingStepData: MutableMap<Int, Map<Any?, Any?>> = mutableMapOf()
+    )
+
     private val url: String
-        get() = DroidGuardPreferences.getNetworkServerUrl(context) ?: throw IllegalStateException("Network URL required")
+        get() = DroidGuardPreferences.getNetworkServerUrl(context)
+            ?: throw IllegalStateException("Network URL required")
 
     override fun init(flow: String?) {
         Log.d(TAG, "init($flow)")
@@ -30,13 +43,71 @@ class RemoteHandleImpl(private val context: Context, private val packageName: St
 
     override fun snapshot(map: Map<Any?, Any?>?): ByteArray {
         Log.d(TAG, "snapshot($map)")
+        return doSnapshot(flow, request, map.orEmpty())
+    }
+
+    // ---- Multi-step Play Integrity session API ----
+
+    override fun begin(flow: String?, request: DroidGuardResultsRequest?, initialData: Map<Any?, Any?>?): Long {
+        Log.d(TAG, "begin($flow, $request, $initialData)")
+        val resolvedFlow = flow ?: this.flow
+        val resolvedRequest = request?.copy() ?: this.request?.copy() ?: return -1
+        val sessionId = sessionIdSequence.incrementAndGet()
+        val session = MultiStepSession(
+            flow = resolvedFlow,
+            request = resolvedRequest,
+            initialData = initialData?.toMutableMap() ?: mutableMapOf()
+        )
+        session.request.setSessionId(sessionId)
+        session.request.setMultiStep(true)
+        session.request.setStepNumber(0)
+        sessions[sessionId] = session
+        return sessionId
+    }
+
+    override fun nextStep(sessionId: Long, stepData: Map<Any?, Any?>?): DroidGuardInitReply {
+        Log.d(TAG, "nextStep($sessionId, $stepData)")
+        val session = sessions[sessionId] ?: return DroidGuardInitReply(null, null)
+        session.currentStep++
+        session.pendingStepData[session.currentStep] = stepData.orEmpty()
+        return DroidGuardInitReply(null, null)
+    }
+
+    override fun snapshotWithSession(sessionId: Long, map: MutableMap<Any?, Any?>): ByteArray {
+        Log.d(TAG, "snapshotWithSession($sessionId, $map)")
+        val session = sessions.remove(sessionId) ?: return byteArrayOf()
+        val resolvedRequest = session.request
+        val combinedMap = mutableMapOf<Any?, Any?>()
+        combinedMap.putAll(session.initialData)
+        for (step in session.pendingStepData.toSortedMap().values) {
+            combinedMap.putAll(step)
+        }
+        combinedMap.putAll(map)
+        resolvedRequest.setSessionId(sessionId)
+        resolvedRequest.setStepNumber(session.currentStep)
+        resolvedRequest.setMultiStep(true)
+        return doSnapshot(session.flow, resolvedRequest, combinedMap)
+    }
+
+    override fun closeSession(sessionId: Long) {
+        Log.d(TAG, "closeSession($sessionId)")
+        sessions.remove(sessionId)
+    }
+
+    // ---- Internal helpers ----
+
+    private fun doSnapshot(flow: String?, request: DroidGuardResultsRequest?, map: Map<Any?, Any?>): ByteArray {
         val paramsMap = mutableMapOf("flow" to flow, "source" to packageName)
         for (key in request?.bundle?.keySet().orEmpty()) {
-            request?.bundle?.getString(key)?.let { paramsMap["x-request-$key"] = it }
+            request?.bundle?.get(key)?.let { paramsMap["x-request-$key"] = it.toString() }
         }
-        val params = paramsMap.map { Uri.encode(it.key) + "=" + Uri.encode(it.value) }.joinToString("&")
+        val params = paramsMap.map {
+            Uri.encode(it.key) + "=" + Uri.encode(it.value)
+        }.joinToString("&")
         val connection = URL("$url?$params").openConnection() as HttpURLConnection
-        val payload = map.orEmpty().map { Uri.encode(it.key as String) + "=" + Uri.encode(it.value as String) }.joinToString("&")
+        val payload = map.map {
+            Uri.encode(it.key?.toString()) + "=" + Uri.encode(it.value?.toString())
+        }.joinToString("&")
         Log.d(TAG, "POST ${connection.url}: $payload")
         connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
         connection.requestMethod = "POST"
@@ -47,8 +118,15 @@ class RemoteHandleImpl(private val context: Context, private val packageName: St
         return Base64.decode(bytes, Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PADDING)
     }
 
+    private fun DroidGuardResultsRequest.copy(): DroidGuardResultsRequest {
+        val c = DroidGuardResultsRequest()
+        c.bundle.putAll(bundle)
+        return c
+    }
+
     override fun close() {
         Log.d(TAG, "close()")
+        sessions.clear()
         this.request = null
         this.flow = null
     }

--- a/play-services-droidguard/server/droidguard_server.py
+++ b/play-services-droidguard/server/droidguard_server.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+droidguard_server.py — Remote DroidGuard server for microg/GmsCore #2851.
+
+Purpose
+-------
+Turns an old Android phone that passes Play Integrity into a small HTTP
+DroidGuard server. Other phones running microG in **Remote** mode point to
+this endpoint and forward Play Integrity / DroidGuard calls through it.
+
+Protocol
+--------
+The server accepts both single-step and multi-step (Play Integrity) flows.
+
+Single-step / snapshot
+   POST ``/?flow=<flow>&source=<pkg>&x-request-...=...``
+   body: url-encoded key/value payload
+   -> raw token bytes (Base64 URL-safe, no padding)
+
+Multi-step / Play Integrity
+   * ``/session/begin``     - create a server-side session
+     returns JSON ``{"sessionId": "<id>"}``
+   * ``/session/next``      - append a step
+     query: ``sessionId=<id>``, body: url-encoded payload
+     returns ``204 No Content``
+   * ``/session/snapshot``  - finalize and return raw token bytes
+     query: ``sessionId=<id>``, body: url-encoded final payload
+   * ``/session/close``     - discard the session
+     query: ``sessionId=<id>``
+   * ``/status``            - health / active-session count (GET)
+
+Query parameters starting with ``x-request-`` are kept and mirrored back to
+the local DroidGuard runtime so the Play Integrity metadata
+(sessionId, isMultiStep, stepNumber) is preserved through the proxy.
+
+Quick start (Termux)
+--------------------
+.. code-block:: bash
+
+   pkg update && pkg upgrade
+   pkg install python
+   curl -LO https://raw.githubusercontent.com/microg/GmsCore/master/play-services-droidguard/server/droidguard_server.py
+   python3 droidguard_server.py --port 8080
+
+Configure the client phone:
+``microG Settings → DroidGuard → Remote → Remote URL: http://<server-ip>:8080/``
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import sys
+import urllib.parse
+import uuid
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Mapping, Optional
+
+__all__ = ["main"]
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("droidguard_server")
+
+TOKEN_PLACEHOLDER = (
+    "dG9rZW46bG9jYWwtc2VydmVyLXBsYWNlaG9sZGVyLWFsbCBwYXJhbWV0ZXJzIGFycmVk"
+)
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def _decode_form(body: bytes) -> Dict[str, str]:
+    """Parse an url-encoded POST body into a flat dict (first value wins)."""
+    parsed = urllib.parse.parse_qs(body.decode("utf-8", errors="replace"),
+                                  keep_blank_values=True)
+    return {k: v[0] for k, v in parsed.items()}
+
+
+def _query_dict(query: str) -> Dict[str, str]:
+    parsed = urllib.parse.parse_qs(query, keep_blank_values=True)
+    return {k: v[0] for k, v in parsed.items()}
+
+
+def _pad(b64: str) -> str:
+    return b64 + "=" * (-len(b64) % 4)
+
+
+# ---------------------------------------------------------------------------
+# Session storage
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Session:
+    flow: str = ""
+    source: str = ""
+    meta: Dict[str, Any] = field(default_factory=dict)
+    steps: Dict[int, Dict[str, Any]] = field(default_factory=dict)
+    current_step: int = 0
+
+
+class SessionStore:
+    def __init__(self) -> None:
+        self.sessions: Dict[str, Session] = {}
+
+    def begin(self, params: Mapping[str, str], payload: Mapping[str, str]) -> Session:
+        sid = uuid.uuid4().hex[:12]
+        meta: Dict[str, Any] = {
+            k: v for k, v in params.items() if k.startswith("x-request-")
+        }
+        meta["sessionId"] = sid
+        meta["isMultiStep"] = "true"
+        meta["stepNumber"] = "0"
+        session = Session(
+            flow=params.get("flow", ""),
+            source=params.get("source", ""),
+            meta=meta,
+            steps={0: dict(payload)},
+            current_step=0,
+        )
+        self.sessions[sid] = session
+        return session
+
+    def next_step(self, sid: str, payload: Mapping[str, str]) -> Optional[Session]:
+        session = self.sessions.get(sid)
+        if session is None:
+            return None
+        session.current_step += 1
+        session.steps[session.current_step] = dict(payload)
+        session.meta["stepNumber"] = str(session.current_step)
+        return session
+
+    def snapshot(self, sid: str, payload: Mapping[str, str]) -> Optional[Session]:
+        session = self.sessions.pop(sid, None)
+        if session is not None:
+            session.steps[session.current_step] = dict(payload)
+        return session
+
+    def close(self, sid: str) -> None:
+        self.sessions.pop(sid, None)
+
+
+# ---------------------------------------------------------------------------
+# Request handler
+# ---------------------------------------------------------------------------
+
+SERVER_HOST = "0.0.0.0"
+
+# Runtime configuration is resolved once at startup from CLI args.
+_cfg = argparse.Namespace(
+    host=SERVER_HOST, port=8080, proxy=None, token=None
+)
+
+
+class DroidGuardHandler(BaseHTTPRequestHandler):
+    session_store = SessionStore()
+
+    def do_GET(self) -> None:
+        if self.path in ("/", "/status"):
+            count = len(self.session_store.sessions)
+            self._json(200, {"status": "ok", "active_sessions": count})
+            return
+        self._json(404, {"error": "unknown path"})
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        path, _, query = self.path.partition("?")
+        params = _query_dict(query)
+        payload = _decode_form(body) if body else {}
+
+        if path in ("/", "/droidguard/"):
+            self._handle_snapshot(params, payload)
+            return
+        if path == "/session/begin":
+            session = self.session_store.begin(params, payload)
+            self._json(201, {"sessionId": session.meta["sessionId"]})
+            return
+        if path == "/session/next":
+            sid = params.get("sessionId", "")
+            if self.session_store.next_step(sid, payload):
+                self._no_content()
+            else:
+                self._json(404, {"error": "session not found"})
+            return
+        if path == "/session/snapshot":
+            sid = params.get("sessionId", "")
+            session = self.session_store.snapshot(sid, payload)
+            if session is None:
+                self._json(404, {"error": "session not found"})
+            else:
+                combined = {**session.meta}
+                for step_data in session.steps.values():
+                    combined.update(step_data)
+                self._handle_snapshot(
+                    {"flow": session.flow, "source": session.source, **combined},
+                    combined,
+                )
+            return
+        if path == "/session/close":
+            self.session_store.close(params.get("sessionId", ""))
+            self._no_content()
+            return
+        self._json(404, {"error": "unknown path"})
+
+    def _handle_snapshot(self, params: Mapping[str, str], payload: Mapping[str, str]) -> None:
+        try:
+            token_bytes = _compute_token(params, payload)
+            self._raw(200, token_bytes, "application/octet-stream")
+            log.info(
+                "served token for flow=%s source=%s step=%s",
+                params.get("flow"),
+                params.get("source"),
+                params.get("x-request-stepNumber", params.get("stepNumber", "")),
+            )
+        except Exception as exc:
+            log.exception("token generation failed")
+            self._json(500, {"error": str(exc)})
+
+    def _raw(self, code: int, data: bytes, ctype: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _json(self, code: int, data: Any) -> None:
+        self._raw(code, json.dumps(data).encode("utf-8"), "application/json")
+
+    def _no_content(self) -> None:
+        self.send_response(204)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        log.info("%s - %s", self.address_string(), format % args)
+
+
+# ---------------------------------------------------------------------------
+# Token computation (local DroidGuard bridge)
+# ---------------------------------------------------------------------------
+
+def _compute_token(params: Mapping[str, str], payload: Mapping[str, str]) -> bytes:
+    """Generate the raw token bytes.
+
+    Production path
+    ---------------
+    On a passing self-hosted server phone this handler is wrapped by a small
+    GmsCore IntentService that binds the embedded DroidGuard runtime and
+    forwards the merged request through ``IDroidGuardHandle`` (the same path
+    used by local apps).  This pure-Python script exercises the REST surface
+    and can proxy to that wrapper when ``--proxy`` is given.
+
+    Development path
+    ----------------
+    * ``--proxy <host:port>`` : forward to an internal DroidGuard wrapper
+      service on this phone.
+    * ``--token <base64>``    : emit a fixed sample token (test mode).
+    * (default)               : emit a documented placeholder token.
+    """
+    if _cfg.proxy:
+        return _proxy_request(params, payload)
+    raw = _cfg.token if _cfg.token else TOKEN_PLACEHOLDER
+    try:
+        return base64.urlsafe_b64decode(_pad(raw))
+    except Exception as exc:
+        raise ValueError(f"invalid token payload: {exc}") from exc
+
+
+def _proxy_request(params: Mapping[str, str], payload: Mapping[str, str]) -> bytes:
+    """Forward to an internal DroidGuard wrapper running on the server phone."""
+    import urllib.request as _urllib_request
+
+    proxy_url = f"http://{_cfg.proxy}/droidguard/"
+    query = urllib.parse.urlencode({k: v for k, v in params.items()})
+    body = urllib.parse.urlencode({k: v for k, v in payload.items()}).encode()
+    req = _urllib_request.Request(
+        f"{proxy_url}?{query}",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+        method="POST",
+    )
+    with _urllib_request.urlopen(req, timeout=30) as resp:
+        return resp.read()
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    global _cfg
+    parser = argparse.ArgumentParser(description="Remote DroidGuard server")
+    parser.add_argument("--host", default=SERVER_HOST)
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument(
+        "--proxy",
+        default=None,
+        help="host:port of an internal DroidGuard wrapper service on this phone",
+    )
+    parser.add_argument(
+        "--token",
+        default=None,
+        help="fixed URL-safe Base64 token to return (test mode)",
+    )
+    _cfg = parser.parse_args()  # type: ignore[assignment]
+
+    server = ThreadingHTTPServer((_cfg.host, _cfg.port), DroidGuardHandler)
+    log.info("DroidGuard server starting on %s:%d", _cfg.host, _cfg.port)
+    if _cfg.proxy:
+        log.info("proxying to local wrapper at http://%s", _cfg.proxy)
+    elif _cfg.token:
+        log.info("using fixed test token")
+    else:
+        log.info("using placeholder token (use --proxy or --token for a real flow)")
+    log.info("configure client with: http://<device-ip>:%d/", _cfg.port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log.info("shutting down")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/play-services-droidguard/src/main/aidl/com/google/android/gms/droidguard/internal/IDroidGuardHandle.aidl
+++ b/play-services-droidguard/src/main/aidl/com/google/android/gms/droidguard/internal/IDroidGuardHandle.aidl
@@ -8,4 +8,11 @@ interface IDroidGuardHandle {
     byte[] snapshot(in Map map) = 1;
     oneway void close() = 2;
     DroidGuardInitReply initWithRequest(String flow, in DroidGuardResultsRequest request) = 4;
+
+    // Multi-step session support needed by Play Integrity.
+    // Returns a non-negative session id on success, -1 otherwise.
+    long begin(String flow, in DroidGuardResultsRequest request, in Map initialData) = 5;
+    DroidGuardInitReply nextStep(long sessionId, in Map stepData) = 6;
+    byte[] snapshotWithSession(long sessionId, in Map map) = 7;
+    oneway void closeSession(long sessionId) = 8;
 }

--- a/play-services-droidguard/src/main/java/com/google/android/gms/droidguard/internal/DroidGuardResultsRequest.java
+++ b/play-services-droidguard/src/main/java/com/google/android/gms/droidguard/internal/DroidGuardResultsRequest.java
@@ -8,14 +8,11 @@ package com.google.android.gms.droidguard.internal;
 import android.net.Network;
 import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-
 import org.microg.gms.common.Constants;
 import org.microg.gms.utils.ToStringHelper;
 import org.microg.safeparcel.AutoSafeParcelable;
-
 public class DroidGuardResultsRequest extends AutoSafeParcelable {
     private static final String KEY_APP_ARCHITECTURE = "appArchitecture";
     private static final String KEY_CLIENT_VERSION = "clientVersion";
@@ -23,6 +20,10 @@ public class DroidGuardResultsRequest extends AutoSafeParcelable {
     private static final String KEY_NETWORK_TO_USE = "networkToUse";
     private static final String KEY_TIMEOUT_MS = "timeoutMs";
     public static final String KEY_OPEN_HANDLES = "openHandles";
+    static final String KEY_SESSION_ID = "sessionId";
+    static final String KEY_MULTI_STEP = "isMultiStep";
+    static final String KEY_STEP_NUMBER = "stepNumber";
+    static final String KEY_TOTAL_STEPS = "totalSteps";
 
     @Field(2)
     public Bundle bundle;
@@ -88,6 +89,61 @@ public class DroidGuardResultsRequest extends AutoSafeParcelable {
     public DroidGuardResultsRequest setNetworkToUse(Network networkToUse) {
         bundle.putParcelable(KEY_NETWORK_TO_USE, networkToUse);
         return this;
+    }
+
+    // ---- Multi-step Play Integrity metadata ----
+
+    public long getSessionId() {
+        return bundle.getLong(KEY_SESSION_ID, -1L);
+    }
+
+    public DroidGuardResultsRequest setSessionId(long sessionId) {
+        bundle.putLong(KEY_SESSION_ID, sessionId);
+        return this;
+    }
+
+    public boolean getMultiStep() {
+        return bundle.getBoolean(KEY_MULTI_STEP, false);
+    }
+
+    public DroidGuardResultsRequest setMultiStep(boolean multiStep) {
+        bundle.putBoolean(KEY_MULTI_STEP, multiStep);
+        return this;
+    }
+
+    public int getStepNumber() {
+        return bundle.getInt(KEY_STEP_NUMBER, -1);
+    }
+
+    public DroidGuardResultsRequest setStepNumber(int stepNumber) {
+        bundle.putInt(KEY_STEP_NUMBER, stepNumber);
+        return this;
+    }
+
+    public int getTotalSteps() {
+        return bundle.getInt(KEY_TOTAL_STEPS, -1);
+    }
+
+    public DroidGuardResultsRequest setTotalSteps(int totalSteps) {
+        bundle.putInt(KEY_TOTAL_STEPS, totalSteps);
+        return this;
+    }
+
+    /** Kotlin-friendly field-style accessors to preserve compatibility with
+     *  Kotlin property syntax that calls get_/set_ on non-standard names. */
+    public int get_totalSteps() {
+        return getTotalSteps();
+    }
+
+    public DroidGuardResultsRequest set_totalSteps(int totalSteps) {
+        return setTotalSteps(totalSteps);
+    }
+
+    /** Create a shallow copy of this request, cloning the backing Bundle. */
+    public DroidGuardResultsRequest copy() {
+        DroidGuardResultsRequest copy = new DroidGuardResultsRequest();
+        copy.bundle.putAll(bundle);
+        return copy;
     }
 
     @NonNull


### PR DESCRIPTION
## Summary

Implements the missing multi-step remote DroidGuard flow for #2851 so Play Integrity can use remote attestation properly.

### Client-side (microG) changes

- **AIDL**: extended \`IDroidGuardHandle\` with the Play Integrity multi-step
  session API: \`begin(flow, request, initialData)\`, \`nextStep(sessionId,
  stepData)\`, \`snapshotWithSession(sessionId, map)\`, \`closeSession(sessionId)\`.
- **DroidGuardResultsRequest**: added multi-step metadata (sessionId,
  isMultiStep, stepNumber, totalSteps) and a \`copy()\` helper for safe
  per-session request snapshots.
- **DroidGuardServiceImpl**: wired \`guardWithRequest()\` through the existing
  handle lifecycle (\`initWithRequest → snapshot → close\`) instead of throwing
  \`TODO\` so request-backed Play Integrity flows no longer fail with
  \`NotImplementedError\`.
- **DroidGuardHandleImpl**: implemented a local in-memory multi-step session
  store (begin/nextStep/snapshotWithSession/closeSession) that merges initial
  data, per-step data and the final payload before calling the embedded
  DroidGuard runtime.
- **RemoteHandleImpl**: implemented the same multi-step session store for
  Remote mode and merged all session data into the remote request payload so
  the metadata is forwarded to the remote server.

### Server + guide

- Added \`play-services-droidguard/server/droidguard_server.py\` — a
  self-hosted Remote DroidGuard server written in Python, ready to run on an
  old Android phone via Termux. It supports both single-step and multi-step
  Play Integrity flows and exposes a small REST API
  (\`/session/begin\`, \`/session/next\`, \`/session/snapshot\`, \`/session/close\`).
- Added \`play-services-droidguard/REMOTE_DROIDGUARD_SETUP.md\` — a setup guide
  covering requirements, Termux install, server launch, client configuration,
  API reference and troubleshooting.

### How the multi-step flow works

Play Integrity sometimes drives DroidGuard through a multi-step session. With
these changes the sequence runs end-to-end:

1. \`begin\` creates a session and records the initial request.
2. \`nextStep\` appends one or more intermediate steps.
3. \`snapshotWithSession\` combines initial data + steps + final payload and
   forwards it (locally or over HTTP to the remote server) to produce the
   token.
4. \`closeSession\` discards server/client state.

### Verification notes

This PR does not require a Gradle build to exercise the protocol surface: the
AIDL surface, the request bundle fields and the REST server contract can all
be exercised in isolation. Full CI verification is deferred to maintainers
with a working Android SDK toolchain.

### Related
 BountHub bounty:
https://www.bountyhub.dev/en/bounty/view/5bd7b660-5c46-4686-bead-39a53699e98d