### PR TITLE
feat(maps): implement addTileOverlay via MapLibre raster source

### DIFF
--- a/play-services-maps/core/mapbox/build.gradle
+++ b/play-services-maps/core/mapbox/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     }
     implementation 'org.maplibre.gl:android-sdk-turf:5.9.0'
 
+    compileOnly 'com.squareup.okhttp3:okhttp:4.10.0'
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }
 

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/GoogleMap.kt
@@ -119,6 +119,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
 
     var groundId = 0L
     var tileId = 0L
+    val tileOverlays = mutableMapOf<String, TileOverlayImpl>()
 
     var storedMapType: Int = options.mapType
     var mapStyle: MapStyleOptions? = null
@@ -354,8 +355,11 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
     }
 
     override fun addTileOverlay(options: TileOverlayOptions): ITileOverlayDelegate? {
-        Log.d(TAG, "unimplemented Method: addTileOverlay")
-        return TileOverlayImpl(this, "t${tileId++}", options)
+        val id = "t${tileId++}"
+        val tileOverlay = TileOverlayImpl(this, id, options)
+        tileOverlays[id] = tileOverlay
+        map?.getStyle { tileOverlay.addToStyle(it) }
+        return tileOverlay
     }
 
     override fun addCircle(options: CircleOptions): ICircleDelegate {
@@ -417,6 +421,7 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
             lines?.let { runCatching { lineManager?.update(it) } }
             fills?.let { runCatching { fillManager?.update(it) } }
             symbols?.let { runCatching { symbolManager?.update(it) } }
+            tileOverlays.values.forEach { overlay -> overlay.addToStyle(it) }
         }
 
         map?.setStyle(
@@ -811,6 +816,8 @@ class GoogleMapImpl(context: Context, var options: GoogleMapOptions) : AbstractG
 
                 pendingBitmaps.forEach { map -> it.addImage(map.key, map.value) }
                 pendingBitmaps.clear()
+
+                tileOverlays.values.forEach { overlay -> overlay.addToStyle(it) }
 
                 map.locationComponent.apply {
                     activateLocationComponent(LocationComponentActivationOptions.builder(mapContext, it)

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/TileProviderHttpAdapter.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/TileProviderHttpAdapter.kt
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.maps.mapbox
+
+import android.util.Log
+import com.google.android.gms.maps.model.TileProvider
+import com.mapbox.mapboxsdk.module.http.HttpRequestUtil
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.util.concurrent.ConcurrentHashMap
+
+object TileProviderHttpAdapter {
+
+    private const val TAG = "GmsMapTileAdapter"
+    private const val SENTINEL_HOST = "tileoverlay.microg.invalid"
+    private const val TILE_PATH_SEGMENTS = 4
+    private const val HTTP_OK = 200
+    private const val HTTP_NOT_FOUND = 404
+
+    private val providersByOverlayKey = ConcurrentHashMap<String, TileProvider>()
+    private val pngMediaType = "image/png".toMediaTypeOrNull()
+
+    @Volatile
+    private var interceptorInstalled = false
+
+    fun tileUrlTemplate(overlayKey: String): String = "https://$SENTINEL_HOST/$overlayKey/{z}/{x}/{y}"
+
+    @Synchronized
+    fun register(overlayKey: String, provider: TileProvider) {
+        ensureInterceptorInstalled()
+        providersByOverlayKey[overlayKey] = provider
+    }
+
+    fun unregister(overlayKey: String) {
+        providersByOverlayKey.remove(overlayKey)
+    }
+
+    private fun ensureInterceptorInstalled() {
+        if (interceptorInstalled) {
+            return
+        }
+
+        interceptorInstalled = true
+        HttpRequestUtil.setOkHttpClient(
+            OkHttpClient.Builder()
+                .addInterceptor(SentinelTileInterceptor())
+                .build()
+        )
+    }
+
+    private fun fetchTileBytes(overlayKey: String, x: Int, y: Int, zoom: Int): ByteArray? {
+        val provider = providersByOverlayKey[overlayKey] ?: return null
+
+        return try {
+            provider.getTile(x, y, zoom)?.data
+        } catch (e: Exception) {
+            Log.w(TAG, "getTile failed for $overlayKey/$zoom/$x/$y", e)
+            null
+        }
+    }
+
+    private class SentinelTileInterceptor : Interceptor {
+
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request()
+            if (request.url.host != SENTINEL_HOST) {
+                return chain.proceed(request)
+            }
+
+            val tileBytes = resolveTileBytes(request.url.pathSegments)
+            return tileResponse(request, tileBytes)
+        }
+
+        private fun resolveTileBytes(pathSegments: List<String>): ByteArray? {
+            if (pathSegments.size != TILE_PATH_SEGMENTS) {
+                return null
+            }
+
+            val overlayKey = pathSegments[0]
+            val zoom = pathSegments[1].toIntOrNull() ?: return null
+            val x = pathSegments[2].toIntOrNull() ?: return null
+            val y = pathSegments[3].toIntOrNull() ?: return null
+
+            return fetchTileBytes(overlayKey, x, y, zoom)
+        }
+
+        private fun tileResponse(request: Request, tileBytes: ByteArray?): Response {
+            val builder = Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+
+            return if (tileBytes != null) {
+                builder.code(HTTP_OK).message("OK").body(tileBytes.toResponseBody(pngMediaType)).build()
+            } else {
+                builder.code(HTTP_NOT_FOUND).message("No tile").body(ByteArray(0).toResponseBody(pngMediaType)).build()
+            }
+        }
+    }
+}

--- a/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/model/TileOverlay.kt
+++ b/play-services-maps/core/mapbox/src/main/kotlin/org/microg/gms/maps/mapbox/model/TileOverlay.kt
@@ -6,24 +6,78 @@
 package org.microg.gms.maps.mapbox.model
 
 import android.os.Parcel
-import android.util.Log
 import com.google.android.gms.maps.model.TileOverlayOptions
+import com.google.android.gms.maps.model.TileProvider
 import com.google.android.gms.maps.model.internal.ITileOverlayDelegate
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.layers.Property
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory
+import com.mapbox.mapboxsdk.style.layers.RasterLayer
+import com.mapbox.mapboxsdk.style.sources.RasterSource
+import com.mapbox.mapboxsdk.style.sources.TileSet
 import org.microg.gms.maps.mapbox.GoogleMapImpl
+import org.microg.gms.maps.mapbox.TileProviderHttpAdapter
 import org.microg.gms.utils.warnOnTransactionIssues
 
 class TileOverlayImpl(private val map: GoogleMapImpl, private val id: String, options: TileOverlayOptions) : ITileOverlayDelegate.Stub() {
+
     private var zIndex = options.zIndex
     private var visible = options.isVisible
     private var fadeIn = options.fadeIn
     private var transparency = options.transparency
+    private val tileProvider: TileProvider? = runCatching { options.tileProvider }.getOrNull()
+
+    private val sourceId = "gms-tileoverlay-src-$id"
+    private val layerId = "gms-tileoverlay-layer-$id"
+
+    init {
+        tileProvider?.let { TileProviderHttpAdapter.register(id, it) }
+    }
+
+    fun addToStyle(style: Style) {
+        if (tileProvider == null || style.getLayer(layerId) != null) {
+            return
+        }
+
+        if (style.getSource(sourceId) == null) {
+            val tileSet = TileSet("2.1.0", TileProviderHttpAdapter.tileUrlTemplate(id))
+            style.addSource(RasterSource(sourceId, tileSet, TILE_SIZE))
+        }
+
+        style.addLayer(
+            RasterLayer(layerId, sourceId).withProperties(
+                PropertyFactory.rasterOpacity(opacity()),
+                PropertyFactory.visibility(visibilityValue()),
+                PropertyFactory.rasterFadeDuration(if (fadeIn) FADE_DURATION_MS else 0f)
+            )
+        )
+    }
+
+    private fun opacity(): Float = 1f - transparency
+
+    private fun visibilityValue(): String = if (visible) Property.VISIBLE else Property.NONE
+
+    private fun updateLayer(block: (RasterLayer) -> Unit) {
+        map.map?.getStyle { style ->
+            (style.getLayer(layerId) as? RasterLayer)?.let(block)
+        }
+    }
 
     override fun remove() {
-        Log.d(TAG, "Not yet implemented: remove")
+        TileProviderHttpAdapter.unregister(id)
+        map.tileOverlays.remove(id)
+        map.map?.getStyle { style ->
+            style.removeLayer(layerId)
+            style.removeSource(sourceId)
+        }
     }
 
     override fun clearTileCache() {
-        Log.d(TAG, "Not yet implemented: clearTileCache")
+        map.map?.getStyle { style ->
+            style.removeLayer(layerId)
+            style.removeSource(sourceId)
+            addToStyle(style)
+        }
     }
 
     override fun getId(): String = id
@@ -36,6 +90,7 @@ class TileOverlayImpl(private val map: GoogleMapImpl, private val id: String, op
 
     override fun setVisible(visible: Boolean) {
         this.visible = visible
+        updateLayer { it.setProperties(PropertyFactory.visibility(visibilityValue())) }
     }
 
     override fun isVisible(): Boolean = visible
@@ -52,6 +107,7 @@ class TileOverlayImpl(private val map: GoogleMapImpl, private val id: String, op
 
     override fun setTransparency(transparency: Float) {
         this.transparency = transparency
+        updateLayer { it.setProperties(PropertyFactory.rasterOpacity(opacity())) }
     }
 
     override fun getTransparency(): Float = transparency
@@ -60,5 +116,7 @@ class TileOverlayImpl(private val map: GoogleMapImpl, private val id: String, op
 
     companion object {
         private const val TAG = "TileOverlay"
+        private const val TILE_SIZE = 256
+        private const val FADE_DURATION_MS = 300f
     }
 }


### PR DESCRIPTION
This is an implementation of the missing addTileOverlay() method.

A RasterSource is now pointed at a sentinel URL so MapLibre requests the overlay tiles over HTTP. 

An OkHttp interceptor catches those requests and answers them from the app's TileProvider.getTile, so the tiles render as if downloaded.

For instance, we are now able to display the rain radar in a weather map:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bd72f45b-fadc-4222-b401-c4e8b15ec83f" />
