### PR TITLE
Add Gradle publish workflow for GitHub packages

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+    # the publishing section of your build.gradle
+    - name: Publish to GitHub Packages
+      run: ./gradlew publish
+      env:
+        USERNAME: ${{ github.actor }}
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: create-prompt
+description: 'Create a concise, repo-aware task prompt for code work in this repository.'
+argument-hint: What code task should the prompt describe?
+disable-model-invocation: true
+---
+
+Use this skill when you want to generate a focused implementation prompt for the current repository.
+
+Steps:
+1. Identify the desired outcome: feature, bug fix, refactor, or test update.
+2. Specify relevant files, packages, or modules in the repository.
+3. Preserve existing style, conventions, and build/test expectations.
+4. Request a final summary of touched files and the result.
+
+Quality checks:
+- Prompt is specific and actionable.
+- Scope is limited to known repository areas.
+- The request mentions tests if behavior changes.
+- The output is concise and implementation-focused.
+
+Example prompt:
+"Please inspect the current repository and implement/fix the following task:
+- [Describe the feature, bug, or refactor clearly]
+- Include any relevant file paths or modules
+- Preserve existing style and conventions
+- Add or update tests if needed
+- Summarize the final changes and touched files"


### PR DESCRIPTION
This workflow builds a package using Gradle and publishes it to GitHub packages upon release creation.