### PR TITLE
DroidGuard: fix ServiceCallProxy Binder forwarding

### DIFF
--- a/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/ServiceCallProxy.kt
+++ b/play-services-droidguard/core/src/main/kotlin/org/microg/gms/droidguard/core/ServiceCallProxy.kt
@@ -76,7 +76,7 @@ object ServiceCallProxy {
                             null
                         }
 
-                        else -> method.invoke(originalService, args)
+                        else -> method.invoke(originalService, *(args ?: emptyArray()))
                     }
                 }) as IBinder
             originalServices[systemServiceName] = originalService


### PR DESCRIPTION
Expand reflection arguments correctly when forwarding.
To fix the issue where Zedge(net.zedge.android) prompts that a newer version of Zedge is required.