### PR TITLE
Home: Add HomeInteractionService dummy

### DIFF
--- a/play-services-api/src/main/aidl/com/google/android/gms/home/interaction/OnRequestParams.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/home/interaction/OnRequestParams.aidl
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.home.interaction;
+
+parcelable OnRequestParams;

--- a/play-services-api/src/main/aidl/com/google/android/gms/home/interaction/internal/ICompletionCallback.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/home/interaction/internal/ICompletionCallback.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.home.interaction.internal;
+
+import com.google.android.gms.common.data.DataHolder;
+
+oneway interface ICompletionCallback {
+    void onComplete(in DataHolder dataHolder) = 0;
+}

--- a/play-services-api/src/main/aidl/com/google/android/gms/home/interaction/internal/IInteractionService.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/home/interaction/internal/IInteractionService.aidl
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.home.interaction.internal;
+
+import com.google.android.gms.home.interaction.OnRequestParams;
+
+interface IInteractionService {
+    void onRequest(in OnRequestParams params) = 17;
+}

--- a/play-services-api/src/main/java/com/google/android/gms/home/interaction/OnRequestParams.java
+++ b/play-services-api/src/main/java/com/google/android/gms/home/interaction/OnRequestParams.java
@@ -5,28 +5,32 @@
 
 package com.google.android.gms.home.interaction;
 
-import android.os.IBinder;
 import android.os.Parcel;
 
 import androidx.annotation.NonNull;
 
+import com.google.android.gms.common.api.internal.IStatusCallback;
 import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
 import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
 import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+import com.google.android.gms.home.interaction.internal.ICompletionCallback;
 
 @SafeParcelable.Class
 public class OnRequestParams extends AbstractSafeParcelable {
+    /**
+     * Serialized protobuf of the request
+     */
     @Field(1)
     public byte[] request;
     @Field(2)
-    public IBinder eventCallback;
+    public IStatusCallback statusCallback;
     @Field(3)
-    public IBinder completionCallback;
+    public ICompletionCallback completionCallback;
 
     @Constructor
-    public OnRequestParams(@Param(1) byte[] request, @Param(2) IBinder eventCallback, @Param(3) IBinder completionCallback) {
+    public OnRequestParams(@Param(1) byte[] request, @Param(2) IStatusCallback statusCallback, @Param(3) ICompletionCallback completionCallback) {
         this.request = request;
-        this.eventCallback = eventCallback;
+        this.statusCallback = statusCallback;
         this.completionCallback = completionCallback;
     }
 

--- a/play-services-api/src/main/java/com/google/android/gms/home/interaction/OnRequestParams.java
+++ b/play-services-api/src/main/java/com/google/android/gms/home/interaction/OnRequestParams.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.home.interaction;
+
+import android.os.IBinder;
+import android.os.Parcel;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.common.internal.safeparcel.AbstractSafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
+import com.google.android.gms.common.internal.safeparcel.SafeParcelableCreatorAndWriter;
+
+@SafeParcelable.Class
+public class OnRequestParams extends AbstractSafeParcelable {
+    @Field(1)
+    public byte[] request;
+    @Field(2)
+    public IBinder eventCallback;
+    @Field(3)
+    public IBinder completionCallback;
+
+    @Constructor
+    public OnRequestParams(@Param(1) byte[] request, @Param(2) IBinder eventCallback, @Param(3) IBinder completionCallback) {
+        this.request = request;
+        this.eventCallback = eventCallback;
+        this.completionCallback = completionCallback;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        CREATOR.writeToParcel(this, dest, flags);
+    }
+
+    public static final SafeParcelableCreatorAndWriter<OnRequestParams> CREATOR = findCreator(OnRequestParams.class);
+}

--- a/play-services-basement/src/main/java/org/microg/gms/common/GmsService.java
+++ b/play-services-basement/src/main/java/org/microg/gms/common/GmsService.java
@@ -355,7 +355,7 @@ public enum GmsService {
     APP_ERROR(334, "com.google.android.gms.apperrors.service.START_APP_ERROR"),
     ADID(335),
 
-    HOME(336),
+    HOME(336, "com.google.android.gms.home.interaction.START"),
 
     MLBENCHMARK(339),
     MLBENCHMARK_INSTALLER(340),

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -1362,6 +1362,14 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name="org.microg.gms.home.HomeInteractionService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.home.interaction.START" />
+            </intent-filter>
+        </service>
+
         <service android:name="org.microg.gms.DummyService">
             <intent-filter>
                 <action android:name="com.google.android.contextmanager.service.ContextManagerService.START" />

--- a/play-services-core/src/main/kotlin/org/microg/gms/home/HomeInteractionService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/home/HomeInteractionService.kt
@@ -14,12 +14,10 @@ import com.google.android.gms.common.internal.ConnectionInfo
 import com.google.android.gms.common.internal.GetServiceRequest
 import com.google.android.gms.common.internal.IGmsCallbacks
 import com.google.android.gms.home.interaction.OnRequestParams
-import com.google.android.gms.home.interaction.internal.ICompletionCallback
 import com.google.android.gms.home.interaction.internal.IInteractionService
 import org.microg.gms.BaseService
 import org.microg.gms.common.GmsService
 import org.microg.gms.common.PackageUtils
-import java.util.HashMap
 
 private const val TAG = "HomeInteractionSvc"
 private const val RESPONSE_COLUMN = "InteractionClientResponse"
@@ -47,10 +45,10 @@ class HomeInteractionService : BaseService(TAG, GmsService.HOME) {
 
 class HomeInteractionServiceImpl : IInteractionService.Stub() {
     override fun onRequest(params: OnRequestParams?) {
-        val callback = ICompletionCallback.Stub.asInterface(params?.completionCallback) ?: return
-        val row = HashMap<String, Any>().apply { put(RESPONSE_COLUMN, byteArrayOf()) }
-        val response = DataHolder.builder(arrayOf(RESPONSE_COLUMN)).withRow(row).build(CommonStatusCodes.SUCCESS)
-        runCatching { callback.onComplete(response) }
+        val response = DataHolder.builder(arrayOf(RESPONSE_COLUMN))
+            .withRow(hashMapOf(RESPONSE_COLUMN to byteArrayOf()))
+            .build(CommonStatusCodes.SUCCESS)
+        runCatching { params?.completionCallback?.onComplete(response) }
             .onFailure { Log.w(TAG, "Failed to complete interaction request", it) }
     }
 }

--- a/play-services-core/src/main/kotlin/org/microg/gms/home/HomeInteractionService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/home/HomeInteractionService.kt
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.home
+
+import android.util.Log
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.Feature
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.data.DataHolder
+import com.google.android.gms.common.internal.ConnectionInfo
+import com.google.android.gms.common.internal.GetServiceRequest
+import com.google.android.gms.common.internal.IGmsCallbacks
+import com.google.android.gms.home.interaction.OnRequestParams
+import com.google.android.gms.home.interaction.internal.ICompletionCallback
+import com.google.android.gms.home.interaction.internal.IInteractionService
+import org.microg.gms.BaseService
+import org.microg.gms.common.GmsService
+import org.microg.gms.common.PackageUtils
+import java.util.HashMap
+
+private const val TAG = "HomeInteractionSvc"
+private const val RESPONSE_COLUMN = "InteractionClientResponse"
+
+private val FEATURES = arrayOf(
+    Feature("home_interaction", 1),
+    Feature("home_wifi_presence", 1),
+    Feature("home_send_commands_large", 1),
+    Feature("home_consume_batch_notifications", 1),
+    Feature("home_client_session_handshake", 1),
+    Feature("home_matter_commission_device_headless", 1),
+    Feature("home_cursor_window_for_interaction_client", 1),
+)
+
+class HomeInteractionService : BaseService(TAG, GmsService.HOME) {
+    override fun handleServiceRequest(callback: IGmsCallbacks, request: GetServiceRequest, service: GmsService) {
+        PackageUtils.getAndCheckCallingPackage(this, request.packageName)
+        callback.onPostInitCompleteWithConnectionInfo(
+            ConnectionResult.SUCCESS,
+            HomeInteractionServiceImpl().asBinder(),
+            ConnectionInfo().apply { features = FEATURES },
+        )
+    }
+}
+
+class HomeInteractionServiceImpl : IInteractionService.Stub() {
+    override fun onRequest(params: OnRequestParams?) {
+        val callback = ICompletionCallback.Stub.asInterface(params?.completionCallback) ?: return
+        val row = HashMap<String, Any>().apply { put(RESPONSE_COLUMN, byteArrayOf()) }
+        val response = DataHolder.builder(arrayOf(RESPONSE_COLUMN)).withRow(row).build(CommonStatusCodes.SUCCESS)
+        runCatching { callback.onComplete(response) }
+            .onFailure { Log.w(TAG, "Failed to complete interaction request", it) }
+    }
+}


### PR DESCRIPTION
Register service ID 336 and the home.interaction.START action, and add the matching SafeParcelable and Binder interfaces.
Advertise the required client features and return an empty successful response to prevent Google Home account switches from failing with API_DISABLED.