### PR TITLE
feat(inappreach): add Gmail storage and account feature support

### DIFF
--- a/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IInAppReachService.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IInAppReachService.aidl
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.inappreach.internal;
+
+import com.google.android.gms.common.api.ApiMetadata;
+import com.google.android.gms.common.api.internal.IStatusCallback;
+import com.google.android.gms.inappreach.internal.IOnAccountHealthAlertsListener;
+import com.google.android.gms.inappreach.internal.IOnAccountMessagesListener;
+import com.google.android.gms.inappreach.internal.IOnAccountDataResponseListener;
+
+interface IInAppReachService {
+    void registerAccountHealthAlerts(IStatusCallback callback, String clientPackageName, IOnAccountHealthAlertsListener listener, in ApiMetadata apiMetadata) = 0;
+    void unregisterAccountHealthAlerts(IStatusCallback callback, String clientPackageName, in ApiMetadata apiMetadata) = 1;
+    void registerAccountMessages(IStatusCallback callback, String clientPackageName, IOnAccountMessagesListener listener, in ApiMetadata apiMetadata) = 6;
+    void unregisterAccountMessages(IStatusCallback callback, String clientPackageName, in ApiMetadata apiMetadata) = 7;
+    void registerAccountDataResponse(IStatusCallback callback, String clientPackageName, IOnAccountDataResponseListener listener, in ApiMetadata apiMetadata) = 10;
+    void unregisterAccountDataResponse(IStatusCallback callback, String clientPackageName, in ApiMetadata apiMetadata) = 11;
+    void registerAccountDataResponseV2(IStatusCallback callback, String clientPackageName, IOnAccountDataResponseListener listener, in ApiMetadata apiMetadata) = 14;
+    void unregisterAccountDataResponseV2(IStatusCallback callback, String clientPackageName, in ApiMetadata apiMetadata) = 15;
+}

--- a/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IOnAccountDataResponseListener.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IOnAccountDataResponseListener.aidl
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.inappreach.internal;
+
+interface IOnAccountDataResponseListener {
+    oneway void onAccountDataResponse(in byte[] response) = 0;
+}

--- a/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IOnAccountHealthAlertsListener.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IOnAccountHealthAlertsListener.aidl
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.inappreach.internal;
+
+interface IOnAccountHealthAlertsListener {
+    oneway void onAccountHealthAlerts(in byte[] response) = 0;
+}

--- a/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IOnAccountMessagesListener.aidl
+++ b/play-services-api/src/main/aidl/com/google/android/gms/inappreach/internal/IOnAccountMessagesListener.aidl
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.android.gms.inappreach.internal;
+
+interface IOnAccountMessagesListener {
+    oneway void onAccountMessages(in byte[] response) = 0;
+}

--- a/play-services-core-proto/src/main/proto/inappreach.proto
+++ b/play-services-core-proto/src/main/proto/inappreach.proto
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+syntax = "proto2";
+
+option java_package = "org.microg.gms.inappreach.proto";
+option java_multiple_files = true;
+
+message AccountDataResponse {
+  map<string, AccountData> accounts = 1;
+}
+
+message AccountData {
+  optional string accountName = 1;
+  optional AccountDataPayload payload = 2;
+}
+
+message AccountDataPayload {
+  optional AccountDataMetadata metadata = 1;
+  repeated StorageCard cards = 2;
+}
+
+message AccountDataMetadata {
+  optional int32 type = 1;
+}
+
+message StorageCard {
+  optional string title = 1;
+  optional int32 type = 2;
+  optional StorageProgress progress = 3;
+  optional StorageActions actions = 5;
+  optional StoragePayloadType payloadType = 6;
+  optional int32 style = 7;
+  optional int32 layout = 11;
+  optional int32 emphasis = 15;
+  optional int32 size = 18;
+}
+
+message StorageProgress {
+  optional float fraction = 1;
+  optional string subtitle = 2;
+}
+
+message StorageActions {
+  optional CallToAction primary = 1;
+  optional CallToAction secondary = 2;
+  optional int32 alignment = 3;
+  optional int32 arrangement = 4;
+}
+
+message StoragePayloadType {
+  optional string typeUrl = 1;
+}
+
+message CallToAction {
+  optional string typeUrl = 1;
+  optional CallToActionDetails details = 2;
+}
+
+message CallToActionDetails {
+  optional CallToActionParameters parameters = 3;
+  optional string label = 4;
+  optional int32 enabled = 6;
+}
+
+message CallToActionParameters {
+  optional int32 action = 3;
+  optional int32 source = 4;
+}

--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -562,6 +562,12 @@
             </intent-filter>
         </service>
 
+        <service android:name="org.microg.gms.inappreach.InAppReachService">
+            <intent-filter>
+                <action android:name="com.google.android.gms.inappreach.service.START" />
+            </intent-filter>
+        </service>
+
         <service android:name="org.microg.gms.auth.appcert.AppCertService">
             <intent-filter>
                 <action android:name="com.google.android.gms.auth.be.appcert.AppCertService" />
@@ -1421,7 +1427,6 @@
                 <action android:name="com.google.android.gms.googlehelp.service.GoogleHelpService.START" />
                 <action android:name="com.google.android.gms.herrevad.services.LightweightNetworkQualityAndroidService.START" />
                 <action android:name="com.google.android.gms.identity.service.BIND" />
-                <action android:name="com.google.android.gms.inappreach.service.START"/>
                 <action android:name="com.google.android.gms.instantapps.START" />
                 <action android:name="com.google.android.gms.kids.service.START" />
                 <action android:name="com.google.android.gms.learning.internal.dynamitesupport.START" />

--- a/play-services-core/src/main/kotlin/org/microg/gms/inappreach/InAppReachService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/inappreach/InAppReachService.kt
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.inappreach
+
+import com.google.android.gms.common.Feature
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.internal.ConnectionInfo
+import com.google.android.gms.common.internal.GetServiceRequest
+import com.google.android.gms.common.internal.IGmsCallbacks
+import org.microg.gms.BaseService
+import org.microg.gms.common.GmsService
+import org.microg.gms.common.PackageUtils
+
+private const val TAG = "InAppReachService"
+private val FEATURES = arrayOf(
+    Feature("account_health_alerts", 1),
+    Feature("account_messages", 1),
+    Feature("account_data_response", 1),
+    Feature("account_data_response_v2", 1)
+)
+
+class InAppReachService : BaseService(TAG, GmsService.INAPP_REACH) {
+    override fun handleServiceRequest(callback: IGmsCallbacks, request: GetServiceRequest, service: GmsService) {
+        val packageName = PackageUtils.getAndCheckCallingPackage(this, request.packageName)
+            ?: throw IllegalArgumentException("Missing package name")
+        callback.onPostInitCompleteWithConnectionInfo(
+            CommonStatusCodes.SUCCESS,
+            InAppReachServiceImpl(this, packageName, lifecycle).asBinder(),
+            ConnectionInfo().apply { features = FEATURES }
+        )
+    }
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/inappreach/InAppReachServiceImpl.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/inappreach/InAppReachServiceImpl.kt
@@ -1,0 +1,258 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.inappreach
+
+import android.accounts.AccountManager
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.android.volley.RequestQueue
+import com.android.volley.toolbox.JsonObjectRequest
+import com.android.volley.toolbox.Volley
+import com.google.android.gms.R
+import com.google.android.gms.common.api.ApiMetadata
+import com.google.android.gms.common.api.Status
+import com.google.android.gms.common.api.internal.IStatusCallback
+import com.google.android.gms.inappreach.internal.IInAppReachService
+import com.google.android.gms.inappreach.internal.IOnAccountDataResponseListener
+import com.google.android.gms.inappreach.internal.IOnAccountHealthAlertsListener
+import com.google.android.gms.inappreach.internal.IOnAccountMessagesListener
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.json.JSONObject
+import org.microg.gms.auth.AuthConstants
+import org.microg.gms.auth.AuthManager
+import org.microg.gms.common.Constants
+import org.microg.gms.inappreach.proto.AccountData
+import org.microg.gms.inappreach.proto.AccountDataMetadata
+import org.microg.gms.inappreach.proto.AccountDataPayload
+import org.microg.gms.inappreach.proto.AccountDataResponse
+import org.microg.gms.inappreach.proto.CallToAction
+import org.microg.gms.inappreach.proto.CallToActionDetails
+import org.microg.gms.inappreach.proto.CallToActionParameters
+import org.microg.gms.inappreach.proto.StorageActions
+import org.microg.gms.inappreach.proto.StorageCard
+import org.microg.gms.inappreach.proto.StoragePayloadType
+import org.microg.gms.inappreach.proto.StorageProgress
+import org.microg.gms.utils.singleInstanceOf
+import java.util.Locale
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+private const val TAG = "InAppReachService"
+private const val DRIVE_SCOPE = "oauth2:https://www.googleapis.com/auth/drive.metadata.readonly"
+private const val DRIVE_QUOTA_URL = "https://www.googleapis.com/drive/v3/about?fields=storageQuota"
+private const val CALL_TO_ACTION_TYPE = "type.googleapis.com/google.internal.subscriptions.firstparty.v1.CallToAction"
+private const val CALL_TO_ACTION_GET_STORAGE = 1
+private const val CALL_TO_ACTION_CLEAN_UP_STORAGE = 3
+private const val CALL_TO_ACTION_SOURCE = 465
+
+class InAppReachServiceImpl(
+    private val context: Context,
+    private val packageName: String,
+    override val lifecycle: Lifecycle
+) : IInAppReachService.Stub(), LifecycleOwner {
+    private var responseJob: Job? = null
+
+    override fun registerAccountHealthAlerts(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        listener: IOnAccountHealthAlertsListener?,
+        apiMetadata: ApiMetadata?
+    ) = acknowledge(clientPackageName, callback)
+
+    override fun unregisterAccountHealthAlerts(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        apiMetadata: ApiMetadata?
+    ) = acknowledge(clientPackageName, callback)
+
+    override fun registerAccountMessages(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        listener: IOnAccountMessagesListener?,
+        apiMetadata: ApiMetadata?
+    ) = acknowledge(clientPackageName, callback)
+
+    override fun unregisterAccountMessages(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        apiMetadata: ApiMetadata?
+    ) = acknowledge(clientPackageName, callback)
+
+    override fun registerAccountDataResponse(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        listener: IOnAccountDataResponseListener?,
+        apiMetadata: ApiMetadata?
+    ) {
+        require(clientPackageName == packageName) { "Package name mismatch" }
+        responseJob?.cancel()
+        responseJob = listener?.let {
+            lifecycleScope.launch(Dispatchers.IO) {
+                val response = buildAccountDataResponse(context)
+                currentCoroutineContext().ensureActive()
+                notifyAccountDataResponse(it, response)
+            }
+        }
+        notifySuccess(callback)
+    }
+
+    override fun unregisterAccountDataResponse(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        apiMetadata: ApiMetadata?
+    ) {
+        unregister(clientPackageName, callback)
+    }
+
+    override fun registerAccountDataResponseV2(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        listener: IOnAccountDataResponseListener?,
+        apiMetadata: ApiMetadata?
+    ) {
+        registerAccountDataResponse(callback, clientPackageName, listener, apiMetadata)
+    }
+
+    override fun unregisterAccountDataResponseV2(
+        callback: IStatusCallback?,
+        clientPackageName: String?,
+        apiMetadata: ApiMetadata?
+    ) {
+        unregister(clientPackageName, callback)
+    }
+
+    private fun unregister(clientPackageName: String?, callback: IStatusCallback?) {
+        require(clientPackageName == packageName) { "Package name mismatch" }
+        responseJob?.cancel()
+        responseJob = null
+        notifySuccess(callback)
+    }
+
+    private fun acknowledge(clientPackageName: String?, callback: IStatusCallback?) {
+        require(clientPackageName == packageName) { "Package name mismatch" }
+        notifySuccess(callback)
+    }
+}
+
+private suspend fun buildAccountDataResponse(context: Context): ByteArray {
+    val accounts = linkedMapOf<String, AccountData>()
+    for (account in AccountManager.get(context).getAccountsByType(AuthConstants.DEFAULT_ACCOUNT_TYPE)) {
+        currentCoroutineContext().ensureActive()
+        try {
+            val (usage, limit) = getStorageQuota(context, account.name) ?: continue
+            if (limit <= 0) continue
+            accounts[account.name] = AccountData(
+                accountName = account.name,
+                payload = AccountDataPayload(
+                    metadata = AccountDataMetadata(type = 1),
+                    cards = listOf(storageCard(context, usage, limit))
+                )
+            )
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to load storage quota", e)
+        }
+    }
+    return AccountDataResponse.ADAPTER.encode(AccountDataResponse(accounts))
+}
+
+private suspend fun getStorageQuota(
+    context: Context,
+    accountName: String,
+    queue: RequestQueue = singleInstanceOf { Volley.newRequestQueue(context.applicationContext) }
+): Pair<Long, Long>? {
+    val auth = AuthManager(context, accountName, Constants.GMS_PACKAGE_NAME, DRIVE_SCOPE).apply {
+        isGmsApp = true
+    }.requestAuth(false).auth ?: return null
+    val response = suspendCancellableCoroutine<JSONObject> { continuation ->
+        val request = object : JsonObjectRequest(
+            DRIVE_QUOTA_URL,
+            { if (continuation.isActive) continuation.resume(it) },
+            { if (continuation.isActive) continuation.resumeWithException(it) }
+        ) {
+            override fun getHeaders(): MutableMap<String, String> = mutableMapOf(
+                "Authorization" to "Bearer $auth"
+            )
+        }
+        continuation.invokeOnCancellation { request.cancel() }
+        queue.add(request)
+    }
+    val quota = response.getJSONObject("storageQuota")
+    return quota.getLong("usage") to quota.getLong("limit")
+}
+
+private fun storageCard(context: Context, usage: Long, limit: Long): StorageCard {
+    val percent = usage * 100 / limit
+    val total = formatBytes(limit)
+    return StorageCard(
+        title = context.getString(R.string.in_app_reach_storage_usage, percent, total),
+        type = 1,
+        progress = StorageProgress(
+            fraction = (usage.toFloat() / limit).coerceIn(0f, 1f),
+            subtitle = "${formatBytes(usage)}/$total"
+        ),
+        actions = StorageActions(
+            primary = callToAction(CALL_TO_ACTION_GET_STORAGE, context.getString(R.string.in_app_reach_get_storage)),
+            secondary = callToAction(CALL_TO_ACTION_CLEAN_UP_STORAGE, context.getString(R.string.in_app_reach_clean_up_storage)),
+            alignment = 0,
+            arrangement = 1
+        ),
+        payloadType = StoragePayloadType(typeUrl = CALL_TO_ACTION_TYPE),
+        style = 1,
+        layout = 2,
+        emphasis = 1,
+        size = 2
+    )
+}
+
+private fun callToAction(kind: Int, label: String) = CallToAction(
+    typeUrl = CALL_TO_ACTION_TYPE,
+    details = CallToActionDetails(
+        parameters = CallToActionParameters(
+            action = kind,
+            source = CALL_TO_ACTION_SOURCE
+        ),
+        label = label,
+        enabled = 1
+    )
+)
+
+private fun formatBytes(bytes: Long): String = when {
+    bytes >= 1024L * 1024 * 1024 -> formatUnit(bytes, 1024L * 1024 * 1024, "GB")
+    bytes >= 1024L * 1024 -> formatUnit(bytes, 1024L * 1024, "MB")
+    else -> formatUnit(bytes, 1024L, "KB")
+}
+
+private fun formatUnit(bytes: Long, unit: Long, suffix: String): String {
+    val value = bytes.toDouble() / unit
+    return if (value == value.toLong().toDouble()) "${value.toLong()} $suffix"
+    else String.format(Locale.US, "%.2f %s", value, suffix)
+}
+
+private fun notifySuccess(callback: IStatusCallback?) {
+    try {
+        callback?.onResult(Status.SUCCESS)
+    } catch (e: Exception) {
+        Log.w(TAG, "Unable to notify status callback", e)
+    }
+}
+
+private fun notifyAccountDataResponse(listener: IOnAccountDataResponseListener, response: ByteArray) {
+    try {
+        listener.onAccountDataResponse(response)
+    } catch (e: Exception) {
+        Log.w(TAG, "Unable to notify account data response listener", e)
+    }
+}

--- a/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/phenotype/PhenotypeService.kt
@@ -125,6 +125,13 @@ private val CONFIGURATION_OPTIONS = mapOf(
         Flag("45668769", true, 0),
         Flag("45633067", true, 0),
     ),
+    "gmail_android.device#com.google.android.gm" to arrayOf(
+        Flag("45729659", true, 0),
+    ),
+    "com.google.android.libraries.subscriptions#com.google.android.gm" to arrayOf(
+        Flag("45651738", true, 0),
+        Flag("45667364", true, 0),
+    ),
     "com.google.android.apps.photos" to arrayOf(
         Flag("45617431", true, 0),
         // Enable v3 movie editor; legacy MovieEditorActivity NPEs on a missing media extra

--- a/play-services-core/src/main/res/values-zh-rCN/strings.xml
+++ b/play-services-core/src/main/res/values-zh-rCN/strings.xml
@@ -417,4 +417,9 @@ microG GmsCore 内置一套自由的 SafetyNet 实现，但是官方服务器要
     <string name="pref_passkey_manager_transport_bluetooth">蓝牙</string>
     <string name="pref_passkey_manager_transport_hybrid">混合</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <!-- In-app reach -->
+    <string name="in_app_reach_storage_usage">已使用 %1$d%%，共 %2$s</string>
+    <string name="in_app_reach_get_storage">获取存储空间</string>
+    <string name="in_app_reach_clean_up_storage">清理存储空间</string>
 </resources>

--- a/play-services-core/src/main/res/values-zh-rTW/strings.xml
+++ b/play-services-core/src/main/res/values-zh-rTW/strings.xml
@@ -422,4 +422,9 @@
     <string name="pref_passkey_manager_transport_bluetooth">藍牙</string>
     <string name="pref_passkey_manager_transport_hybrid">混合</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <!-- In-app reach -->
+    <string name="in_app_reach_storage_usage">已使用 %1$d%%，共 %2$s</string>
+    <string name="in_app_reach_get_storage">取得儲存空間</string>
+    <string name="in_app_reach_clean_up_storage">清理儲存空間</string>
 </resources>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -475,4 +475,9 @@ Please set up a password, PIN, or pattern lock screen."</string>
     <string name="pref_passkey_manager_transport_bluetooth">Bluetooth</string>
     <string name="pref_passkey_manager_transport_hybrid">Hybrid</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <!-- In-app reach -->
+    <string name="in_app_reach_storage_usage">%1$d%% of %2$s used</string>
+    <string name="in_app_reach_get_storage">Get storage</string>
+    <string name="in_app_reach_clean_up_storage">Clean up storage</string>
 </resources>


### PR DESCRIPTION
Gmail could not display storage usage and purchase/cleanup actions in the
account menu because GmsCore did not provide the InAppReach API.

Missing account health and account message features were also interpreted
by Gmail as an outdated Google Play services installation, causing an
update notification on startup.

If payment is unavailable, need to use: https://github.com/microg/GmsCore/pull/3684