### PR TITLE
fix(playintegrity): align IRequestDialogCallback transaction id with Play Core

### DIFF
--- a/vending-app/src/main/aidl/com/google/android/play/core/integrity/protocol/IRequestDialogCallback.aidl
+++ b/vending-app/src/main/aidl/com/google/android/play/core/integrity/protocol/IRequestDialogCallback.aidl
@@ -6,5 +6,5 @@
 package com.google.android.play.core.integrity.protocol;
 
 interface IRequestDialogCallback {
-    void onRequestDialog(in Bundle bundle);
+    void onRequestDialog(in Bundle bundle) = 1;
 }


### PR DESCRIPTION
# Description

Align IRequestDialogCallback transaction id with Play Core

Play Core dispatches onRequestDialog on binder code 2 while the implicit AIDL id resolved to code 1, so the integrity dialog callback was silently dropped and apps waiting on it stayed stuck on their integrity check screen forever.

This has been tested with the Car4Way app.

| Before | After |
|:---:|:---:|
| <img width="250" alt="Stuck on Checking app integrity" src="https://github.com/user-attachments/assets/68aaf0c4-5921-4491-9625-f79ea980984b" /> | <img width="250" alt="Error shown with a Try again button" src="https://github.com/user-attachments/assets/555fead7-4a32-4e4f-bec2-250f3293b4ee" /> |
| The app is stuck on the integrity check screen | The callback is executed |
