### PR TITLE
Vending: Fix missing in-app message callback

### DIFF
--- a/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
+++ b/vending-app/src/main/java/org/microg/vending/billing/InAppBillingServiceImpl.kt
@@ -647,7 +647,12 @@ class InAppBillingServiceImpl(private val context: Context) : IInAppBillingServi
     }
 
     override fun showInAppMessages(apiVersion: Int, packageName: String?, extraParams: Bundle?, callback: IInAppBillingServiceCallback?) {
-        Log.d(TAG, "showInAppMessages Not yet implemented")
+        Log.d(TAG, "showInAppMessages $apiVersion packageName:$packageName bundle:${bundleToMap(extraParams)}")
+        try {
+            callback?.callback(null)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to deliver showInAppMessages callback", e)
+        }
     }
 
     override fun getBillingConfig(apiVersion: Int, packageName: String?, bundle: Bundle?, callback: IInAppBillingGetBillingConfigCallback) {


### PR DESCRIPTION
Grok (ai.x.grok) waits indefinitely for the showInAppMessages() callback on its subscription page, preventing the subscription products that have already been retrieved from being displayed.