### PR TITLE
Location: Fix speed calculation for sub-second updates

### DIFF
--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LastLocationCapsule.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LastLocationCapsule.kt
@@ -66,14 +66,21 @@ class LastLocationCapsule(private val context: Context) {
     fun updateCoarseLocation(location: Location) {
         location.elapsedRealtimeNanos = min(location.elapsedRealtimeNanos, SystemClock.elapsedRealtimeNanos())
         location.time = min(location.time, System.currentTimeMillis())
-        if (lastCoarseLocation != null && lastCoarseLocation!!.elapsedMillis + EXTENSION_CLIFF > location.elapsedMillis) {
-            if (!location.hasSpeed()) {
-                location.speed = lastCoarseLocation!!.distanceTo(location) / ((location.elapsedMillis - lastCoarseLocation!!.elapsedMillis) / 1000)
-                LocationCompat.setSpeedAccuracyMetersPerSecond(location, location.speed)
-            }
-            if (!location.hasBearing() && location.speed > 0.5f) {
-                location.bearing = lastCoarseLocation!!.bearingTo(location)
-                LocationCompat.setBearingAccuracyDegrees(location, 180.0f)
+        val previousLocation = lastCoarseLocation
+        if (previousLocation != null) {
+            val elapsedMillis = location.elapsedMillis - previousLocation.elapsedMillis
+            if (elapsedMillis in 1..<EXTENSION_CLIFF) {
+                if (!location.hasSpeed()) {
+                    val speed = previousLocation.distanceTo(location) * 1000f / elapsedMillis
+                    if (speed.isFinite()) {
+                        location.speed = speed
+                        LocationCompat.setSpeedAccuracyMetersPerSecond(location, speed)
+                    }
+                }
+                if (!location.hasBearing() && location.speed > 0.5f) {
+                    location.bearing = previousLocation.bearingTo(location)
+                    LocationCompat.setBearingAccuracyDegrees(location, 180.0f)
+                }
             }
         }
         lastCoarseLocation = newest(lastCoarseLocation, location)

--- a/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LastLocationCapsule.kt
+++ b/play-services-location/core/src/main/kotlin/org/microg/gms/location/manager/LastLocationCapsule.kt
@@ -77,7 +77,7 @@ class LastLocationCapsule(private val context: Context) {
                         LocationCompat.setSpeedAccuracyMetersPerSecond(location, speed)
                     }
                 }
-                if (!location.hasBearing() && location.speed > 0.5f) {
+                if (!location.hasBearing() && location.hasSpeed() && location.speed > 0.5f) {
                     location.bearing = previousLocation.bearingTo(location)
                     LocationCompat.setBearingAccuracyDegrees(location, 180.0f)
                 }


### PR DESCRIPTION
Calculate derived speed using millisecond precision and only set it
for valid time deltas and finite results.

This prevents Infinity or NaN speed values from reaching location clients.