### PR TITLE
feat(wearable): add ANCS notification attributes parser and model

### DIFF
--- a/play-services-wearable/core/build.gradle
+++ b/play-services-wearable/core/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     implementation project(':play-services-wearable')
 
     implementation "org.microg:wearable:$wearableVersion"
+
+    testImplementation 'junit:junit:4.13.2'
 }
 
 android {

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/companion/WearableCompanionBridge.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/companion/WearableCompanionBridge.java
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.companion;
+
+import org.microg.gms.wearable.notification.AncsNotifications;
+import org.microg.wearable.WearableConnection;
+import org.microg.wearable.proto.RootMessage;
+import org.microg.wearable.proto.SetDataItem;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import okio.ByteString;
+
+/**
+ * Phone-side Wear OS companion bridge.
+ *
+ * <p>The companion link is a length-prefixed protobuf channel (see
+ * {@code org.microg.wearable.WearableConnection}); the phone currently exposes it over TCP (port
+ * 5601) and, with the Wear OS foundation work, also over Bluetooth RFCOMM (Flow / Flow15). This
+ * bridge sits on the phone side of that link and performs the two remaining companion functions:
+ *
+ * <ol>
+ *   <li><b>Notification echo (ANCS):</b> turns each parsed ANCS notification (see
+ *   {@link AncsNotifications}) into a Wear data-layer {@link SetDataItem} on a reserved URI, and
+ *   pushes it to every connected wear node via the already-established connection. A wear-side
+ *   app subscribed through {@code WearableListenerService#onDataChanged} then renders it. The
+ *   raw ANCS frame is preserved in the payload so the wear side can re-parse with the same model.</li>
+ * </ol>
+ *
+ * <p>This class is deliberately transport-agnostic: callers pass an already-connected
+ * {@link WearableConnection}, so the identical code path serves TCP, Bluetooth and (for tests)
+ * in-memory loopback links. Unit-testing an ephemeral loopback pair exercises the full wire
+ * handshake ({@code Connect} exchange) and one notification round-trip without any wearable
+ * hardware.
+ */
+public final class WearableCompanionBridge {
+
+    /** Reserved data-layer path for versioned ANCS notification envelopes. */
+    public static final String ANCS_NOTIFICATION_V1_PATH = "/notification/ancs/v1";
+
+    /** Version byte of the envelope written by {@link #envelope}. */
+    public static final int ANCS_ENVELOPE_VERSION = 1;
+
+    /** Upper bound for a single ANCS payload carried on the data layer. */
+    public static final long MAX_ANCS_PAYLOAD = 16 * 1024;
+
+    private WearableCompanionBridge() {
+    }
+
+    /**
+     * Builds the data-layer URI a wear app should subscribe to see the given notification.
+     *
+     * @param nodeId local node id of the phone (source of the notification).
+     * @param notificationUid ANCS notification uid carried by the payload.
+     */
+    public static String buildAncsUri(String nodeId, long notificationUid) {
+        return "wear://" + nodeId + ANCS_NOTIFICATION_V1_PATH + "/" + notificationUid;
+    }
+
+    /**
+     * Serializes one notification into the versioned envelope carried on the data layer.
+     *
+     * <pre>
+     *   [0]            Version (0x01)
+     *   [1 .. 4]       ANCS notification uid (little-endian, 4 bytes)
+     *   [5 .. ]        Raw ANCS Notification Attributes frame (see AncsNotifications)
+     * </pre>
+     *
+     * @return the envelope, or {@code null} if the raw frame does not fit in
+     * {@link #MAX_ANCS_PAYLOAD}.
+     */
+    public static byte[] envelope(AncsNotifications.Notification notification, byte[] rawFrame) {
+        if (notification == null || rawFrame == null || rawFrame.length == 0) {
+            return null;
+        }
+        int payloadLength = 5 + rawFrame.length;
+        if (payloadLength > MAX_ANCS_PAYLOAD) {
+            return null;
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream(payloadLength);
+        out.write(ANCS_ENVELOPE_VERSION);
+        writeUInt32(out, notification.getNotificationUid());
+        out.write(rawFrame, 0, rawFrame.length);
+        return out.toByteArray();
+    }
+
+    /**
+     * Builds the data-layer item that carries one notification to a connected wear node.
+     *
+     * @param nodeId source node id (phone local node id).
+     * @param seqId monotonic sequence id expected by the wear side (see {@code SetDataItem.seqId}).
+     * @param packageName package that owns the notification (used for access control).
+     */
+    public static SetDataItem toSetDataItem(
+            String nodeId, long seqId, String packageName,
+            AncsNotifications.Notification notification, byte[] rawFrame) {
+        byte[] payload = envelope(notification, rawFrame);
+        if (payload == null) {
+            return null;
+        }
+        return new SetDataItem.Builder()
+                .packageName(packageName)
+                .uri(buildAncsUri(nodeId, notification.getNotificationUid()))
+                .data(ByteString.of(payload))
+                .seqId(seqId)
+                .deleted(false)
+                .source(nodeId)
+                .build();
+    }
+
+    /**
+     * Pushes one notification onto an active companion connection, using the raw ANCS frame that
+     * produced {@code notification} so the baseband payload is preserved verbatim.
+     *
+     * @return the seq id written, or {@code -1} if the payload was oversized or the write failed.
+     */
+    public static long pushNotification(
+            WearableConnection connection, String nodeId, long seqId, String packageName,
+            AncsNotifications.Notification notification, byte[] rawFrame) {
+        SetDataItem item = toSetDataItem(nodeId, seqId, packageName, notification, rawFrame);
+        if (item == null) {
+            return -1;
+        }
+        try {
+            connection.writeMessage(new RootMessage.Builder().setDataItem(item).build());
+            return seqId;
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Re-loads an {@link AncsNotification} from a data-layer envelope written by
+     * {@link #envelope}. Returns {@code null} for unknown versions or truncated payloads.
+     */
+    public static AncsNotifications.Notification fromEnvelope(byte[] payload) {
+        if (payload == null || payload.length < 5 || payload[0] != ANCS_ENVELOPE_VERSION) {
+            return null;
+        }
+        long uid = readUInt32(payload, 1);
+        byte[] rawFrame = new byte[payload.length - 5];
+        System.arraycopy(payload, 5, rawFrame, 0, rawFrame.length);
+        try {
+            AncsNotifications.Notification notification = AncsNotifications.parse(rawFrame);
+            if (notification.getNotificationUid() != uid) {
+                return null;
+            }
+            return notification;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static void writeUInt32(ByteArrayOutputStream out, long value) {
+        out.write((int) (value & 0xFF));
+        out.write((int) ((value >>> 8) & 0xFF));
+        out.write((int) ((value >>> 16) & 0xFF));
+        out.write((int) ((value >>> 24) & 0xFF));
+    }
+
+    private static long readUInt32(byte[] src, int offset) {
+        return (src[offset] & 0xFFL) | ((src[offset + 1] & 0xFFL) << 8)
+                | ((src[offset + 2] & 0xFFL) << 16) | ((src[offset + 3] & 0xFFL) << 24);
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/notification/AncsNotifications.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/notification/AncsNotifications.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.wearable.notification;
+
+import com.google.android.gms.wearable.AncsNotification;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Parser and model for ANCS (Apple Notification Center Service) notification
+ * attributes, the wire protocol used by Wear Apps to mirror phone notifications
+ * on a companion device.
+ * <p>
+ * This is the first block of the notification bridge for
+ * <a href="https://github.com/microg/GmsCore/issues/2843">WearOS support</a>:
+ * it turns a "Get Notification Attributes" Data Source frame into a structured
+ * value object that can be routed through {@code WearableListenerService#onNotificationReceived}.
+ * <p>
+ * Frame layout (see ANCS specification, *Notification attributes*):
+ * <pre>
+ *   [0]        Command ID (0x02 = Notification Attributes)
+ *   [1 .. 4]   Notification UID (4 bytes, little-endian)
+ *   then, per requested attribute:
+ *   [n]        Attribute ID (1 byte)
+ *   [n+1 ..]   Attribute length (2 bytes, little-endian)
+ *   [...]      Attribute value
+ * </pre>
+ * Not-yet-requested attributes are ignored by the device, so a frame may carry a
+ * subset of the supported attributes; truncated or oversized frames are rejected
+ * instead of producing partial state.
+ */
+public final class AncsNotifications {
+
+    public static final int COMMAND_GET_NOTIFICATION_ATTRIBUTES = 0x02;
+
+    public static final int ATTR_APP_IDENTIFIER = 0x00;
+    public static final int ATTR_TITLE = 0x01;
+    public static final int ATTR_SUBTITLE = 0x02;
+    public static final int ATTR_MESSAGE = 0x03;
+    /** 4-byte little-endian counter, unlike the other (string) attributes. */
+    public static final int ATTR_MESSAGE_SIZE = 0x04;
+    public static final int ATTR_DATE = 0x05;
+    public static final int ATTR_POSITIVE_ACTION_LABEL = 0x06;
+    public static final int ATTR_NEGATIVE_ACTION_LABEL = 0x07;
+
+    private AncsNotifications() {
+    }
+
+    /**
+     * Parses one complete "Notification Attributes" frame from the ANCS Data Source.
+     *
+     * @throws IllegalArgumentException if the frame is truncated, malformed or too large.
+     */
+    public static Notification parse(byte[] frame) {
+        Notification result = new Notification();
+        if (frame == null || frame.length < 5) {
+            throw new IllegalArgumentException("ANCS notification attributes frame is too short");
+        }
+        if ((frame[0] & 0xFF) != COMMAND_GET_NOTIFICATION_ATTRIBUTES) {
+            throw new IllegalArgumentException("Unexpected ANCS command id: 0x" + Integer.toHexString(frame[0] & 0xFF));
+        }
+        result.notificationUid = readUInt32(frame, 1);
+        for (int i = 5; i < frame.length; ) {
+            int attributeId = frame[i] & 0xFF;
+            if (i + 3 > frame.length) {
+                throw new IllegalArgumentException("Truncated ANCS attribute header at offset " + i);
+            }
+            int length = readUInt16(frame, i + 1);
+            int valueOffset = i + 3;
+            if (valueOffset + length > frame.length) {
+                throw new IllegalArgumentException("Truncated ANCS attribute value at offset " + valueOffset);
+            }
+            if (attributeId == ATTR_MESSAGE_SIZE) {
+                if (length != 4) {
+                    throw new IllegalArgumentException("MESSAGE_SIZE attribute must carry 4 bytes, got " + length);
+                }
+                result.messageSize = readUInt32(frame, valueOffset);
+            } else {
+                String value = new String(frame, valueOffset, length, StandardCharsets.UTF_8);
+                switch (attributeId) {
+                    case ATTR_APP_IDENTIFIER:
+                        result.appIdentifier = stripTerminator(value);
+                        break;
+                    case ATTR_TITLE:
+                        result.title = value;
+                        break;
+                    case ATTR_SUBTITLE:
+                        result.subtitle = value;
+                        break;
+                    case ATTR_MESSAGE:
+                        result.message = value;
+                        break;
+                    case ATTR_DATE:
+                        result.date = stripTerminator(value);
+                        break;
+                    case ATTR_POSITIVE_ACTION_LABEL:
+                        result.positiveActionLabel = value;
+                        break;
+                    case ATTR_NEGATIVE_ACTION_LABEL:
+                        result.negativeActionLabel = value;
+                        break;
+                    default:
+                        // Unknown future attribute: skip value, keep parsing.
+                        break;
+                }
+            }
+            i = valueOffset + length;
+        }
+        return result;
+    }
+
+    /** Builds a Control Point request to read the wanted attributes of a notification. */
+    public static byte[] readAttributesRequest(long notificationUid, int... attributeIds) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(8 + attributeIds.length);
+        out.write(COMMAND_GET_NOTIFICATION_ATTRIBUTES);
+        writeUInt32(out, notificationUid);
+        for (int attributeId : attributeIds) {
+            out.write(attributeId & 0xFF);
+        }
+        return out.toByteArray();
+    }
+
+    private static int readUInt16(byte[] src, int offset) {
+        return (src[offset] & 0xFF) | ((src[offset + 1] & 0xFF) << 8);
+    }
+
+    private static long readUInt32(byte[] src, int offset) {
+        return (src[offset] & 0xFFL) | ((src[offset + 1] & 0xFFL) << 8)
+                | ((src[offset + 2] & 0xFFL) << 16) | ((src[offset + 3] & 0xFFL) << 24);
+    }
+
+    private static void writeUInt32(ByteArrayOutputStream out, long value) {
+        out.write((int) (value & 0xFF));
+        out.write((int) ((value >>> 8) & 0xFF));
+        out.write((int) ((value >>> 16) & 0xFF));
+        out.write((int) ((value >>> 24) & 0xFF));
+    }
+
+    private static String stripTerminator(String value) {
+        int index = value.indexOf('\0');
+        return index < 0 ? value : value.substring(0, index);
+    }
+
+    /**
+     * Structured view of a parsed ANCS notification. Field values match the ANCS
+     * attribute semantics; unknown future attributes are skipped by the parser.
+     */
+    public static class Notification implements AncsNotification {
+        private long notificationUid;
+        private String appIdentifier;
+        private String title;
+        private String subtitle;
+        private String message;
+        private long messageSize;
+        private String date;
+        private String positiveActionLabel;
+        private String negativeActionLabel;
+
+        public long getNotificationUid() {
+            return notificationUid;
+        }
+
+        public String getAppIdentifier() {
+            return appIdentifier;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getSubtitle() {
+            return subtitle;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public long getMessageSize() {
+            return messageSize;
+        }
+
+        public String getDate() {
+            return date;
+        }
+
+        public String getPositiveActionLabel() {
+            return positiveActionLabel;
+        }
+
+        public String getNegativeActionLabel() {
+            return negativeActionLabel;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder("AncsNotification{uid=").append(notificationUid);
+            sb.append(", app=").append(appIdentifier);
+            sb.append(", title='").append(title).append('\'');
+            if (subtitle != null) {
+                sb.append(", subtitle='").append(subtitle).append('\'');
+            }
+            if (message != null) {
+                sb.append(", message='").append(message).append('\'');
+            }
+            if (date != null) {
+                sb.append(", date='").append(date).append('\'');
+            }
+            return sb.append('}').toString();
+        }
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/companion/WearableCompanionBridgeTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/companion/WearableCompanionBridgeTest.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.companion;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+import org.microg.gms.wearable.notification.AncsNotifications;
+import org.microg.wearable.proto.RootMessage;
+
+import java.io.ByteArrayOutputStream;
+
+public class WearableCompanionBridgeTest extends TestCase {
+
+    private static void append(int attributeId, byte[] value, ByteArrayOutputStream out) {
+        out.write(attributeId);
+        out.write(value.length & 0xFF);
+        out.write((value.length >>> 8) & 0xFF);
+        out.write(value, 0, value.length);
+    }
+
+    private static byte[] ancsFrame(long uid, String app, String title) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES);
+        out.write((int) (uid & 0xFF));
+        out.write((int) ((uid >>> 8) & 0xFF));
+        out.write((int) ((uid >>> 16) & 0xFF));
+        out.write((int) ((uid >>> 24) & 0xFF));
+        append(AncsNotifications.ATTR_APP_IDENTIFIER,
+                (app + "\0").getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        append(AncsNotifications.ATTR_TITLE, title.getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        return out.toByteArray();
+    }
+
+    public void testEnvelopeAndRoundTrip() throws Exception {
+        byte[] rawFrame = ancsFrame(42L, "org.microg.telegram", "New message");
+        AncsNotifications.Notification notification = AncsNotifications.parse(rawFrame);
+
+        byte[] envelope = WearableCompanionBridge.envelope(notification, rawFrame);
+        Assert.assertNotNull(envelope);
+        assertEquals(WearableCompanionBridge.ANCS_ENVELOPE_VERSION, envelope[0] & 0xFF);
+        assertEquals(42L,
+                (envelope[1] & 0xFFL) | ((envelope[2] & 0xFFL) << 8)
+                        | ((envelope[3] & 0xFFL) << 16) | ((envelope[4] & 0xFFL) << 24));
+
+        // Round-trip through the envelope back to a parsed notification.
+        AncsNotifications.Notification roundTripped =
+                WearableCompanionBridge.fromEnvelope(envelope);
+        Assert.assertNotNull(roundTripped);
+        assertEquals(42L, roundTripped.getNotificationUid());
+        assertEquals("org.microg.telegram", roundTripped.getAppIdentifier());
+        assertEquals("New message", roundTripped.getTitle());
+    }
+
+    public void testRejectsUnknownEnvelopeVersion() throws Exception {
+        byte[] rawFrame = ancsFrame(1L, "a", "b");
+        byte[] envelope = WearableCompanionBridge.envelope(
+                AncsNotifications.parse(rawFrame), rawFrame);
+        envelope[0] = (byte) 0x63;
+        Assert.assertNull(WearableCompanionBridge.fromEnvelope(envelope));
+    }
+
+    public void testRejectsOversizedPayload() throws Exception {
+        byte[] rawFrame = ancsFrame(1L, "a", new String(new char[20 * 1024]).replace('\0', 'x'));
+        byte[] oversized = WearableCompanionBridge.envelope(
+                AncsNotifications.parse(rawFrame), rawFrame);
+        Assert.assertNull(oversized); // exceeds MAX_ANCS_PAYLOAD
+    }
+
+    public void testEnvelopeRoundTripBackToSetDataItem() throws Exception {
+        byte[] rawFrame = ancsFrame(7L, "org.microg.sms", "SMS");
+        AncsNotifications.Notification notification = AncsNotifications.parse(rawFrame);
+
+        // Phone serializes the SetDataItem exactly as it would be written on the wire.
+        org.microg.wearable.proto.SetDataItem item = WearableCompanionBridge.toSetDataItem(
+                "phone-node", 3L, "com.example.app", notification, rawFrame);
+        Assert.assertNotNull(item);
+        String uri = item.uri;
+        Assert.assertTrue(uri, uri.startsWith(
+                "wear://phone-node" + WearableCompanionBridge.ANCS_NOTIFICATION_V1_PATH));
+        assertEquals("com.example.app", item.packageName);
+        assertEquals(3L, (long) item.seqId);
+        assertEquals(Boolean.FALSE, item.deleted);
+        assertEquals("phone-node", item.source);
+
+        // Wear side decodes the SetDataItem and recovers the same notification from the envelope.
+        byte[] payload = item.data.toByteArray();
+        AncsNotifications.Notification echoed = WearableCompanionBridge.fromEnvelope(payload);
+        Assert.assertNotNull(echoed);
+        assertEquals(7L, echoed.getNotificationUid());
+        assertEquals("org.microg.sms", echoed.getAppIdentifier());
+        assertEquals("SMS", echoed.getTitle());
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/companion/WearableCompanionHandshakeTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/companion/WearableCompanionHandshakeTest.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.companion;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+import org.microg.gms.wearable.notification.AncsNotifications;
+import org.microg.wearable.ServerMessageListener;
+import org.microg.wearable.SocketConnectionThread;
+import org.microg.wearable.WearableConnection;
+import org.microg.wearable.proto.Connect;
+import org.microg.wearable.proto.SetDataItem;
+
+import java.io.ByteArrayOutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Complementary-handshake verification over a real loopback transport, without wearable
+ * hardware. Both ends run the same {@link SocketConnectionThread} server/client code the
+ * companion link uses (int32 length prefix + MessagePiece protobuf framing), so the exercised
+ * bytes are identical to a TCP companion session. Bluetooth RFCOMM wraps the same connection.
+ */
+public class WearableCompanionHandshakeTest extends TestCase {
+
+    private static byte[] ancsFrame(long uid, String app, String title) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES);
+        out.write((int) (uid & 0xFF));
+        out.write((int) ((uid >>> 8) & 0xFF));
+        out.write((int) ((uid >>> 16) & 0xFF));
+        out.write((int) ((uid >>> 24) & 0xFF));
+        append(AncsNotifications.ATTR_APP_IDENTIFIER,
+                (app + "\0").getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        append(AncsNotifications.ATTR_TITLE, title.getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        return out.toByteArray();
+    }
+
+    private static void append(int attributeId, byte[] value, ByteArrayOutputStream out) {
+        out.write(attributeId);
+        out.write(value.length & 0xFF);
+        out.write((value.length >>> 8) & 0xFF);
+        out.write(value, 0, value.length);
+    }
+
+    /**
+     * One end of the companion link: echoes its {@link Connect} on connect (standard
+     * {@link ServerMessageListener} behaviour) and collects the peer {@link Connect} plus any
+     * {@link SetDataItem} messages it receives.
+     */
+    private static class CompanionEndpoint extends ServerMessageListener {
+        final CountDownLatch connected = new CountDownLatch(1);
+        final CountDownLatch gotPeerConnect = new CountDownLatch(1);
+        final CountDownLatch gotDataItem = new CountDownLatch(1);
+        volatile SetDataItem dataItem;
+        volatile WearableConnection connection;
+
+        CompanionEndpoint(String id, String name) {
+            super(new Connect.Builder()
+                    .id(id)
+                    .name(name)
+                    .peerAndroidId(0x123456789abcdefL)
+                    .peerVersion(1)
+                    .peerMinimumVersion(1)
+                    .build());
+        }
+
+        @Override
+        public void onConnected(WearableConnection connection) {
+            super.onConnected(connection);
+            this.connection = connection;
+            connected.countDown();
+        }
+
+        @Override
+        public void onConnect(Connect connect) {
+            super.onConnect(connect);
+            gotPeerConnect.countDown();
+        }
+
+        @Override
+        public void onSetDataItem(SetDataItem item) {
+            this.dataItem = item;
+            gotDataItem.countDown();
+        }
+
+        @Override
+        public void onSetAsset(org.microg.wearable.proto.SetAsset message) {
+        }
+
+        @Override
+        public void onAckAsset(org.microg.wearable.proto.AckAsset message) {
+        }
+
+        @Override
+        public void onFetchAsset(org.microg.wearable.proto.FetchAsset message) {
+        }
+
+        @Override
+        public void onSyncStart(org.microg.wearable.proto.SyncStart message) {
+        }
+
+        @Override
+        public void onRpcRequest(org.microg.wearable.proto.Request message) {
+        }
+
+        @Override
+        public void onHeartbeat(org.microg.wearable.proto.Heartbeat message) {
+        }
+
+        @Override
+        public void onFilePiece(org.microg.wearable.proto.FilePiece message) {
+        }
+
+        @Override
+        public void onChannelRequest(org.microg.wearable.proto.Request message) {
+        }
+    }
+
+    public void testHandshakeAndNotificationRoundTripOverLoopback() throws Exception {
+        ServerSocket listening = new ServerSocket(0); // ephemeral free port
+        int port = listening.getLocalPort();
+        listening.close();
+        assertTrue("port must be > 0", port > 0);
+
+        CompanionEndpoint phone = new CompanionEndpoint("phone-1", "AndroidPhone");
+        CompanionEndpoint wear = new CompanionEndpoint("wear-1", "AndroidWear");
+
+        SocketConnectionThread server = SocketConnectionThread.serverListen(port, phone);
+        SocketConnectionThread client = SocketConnectionThread.clientConnect(port, wear);
+        server.start();
+        client.start();
+        try {
+            // Both ends exchange Connect handshake messages over the wire.
+            assertTrue("phone did not connect", phone.connected.await(5, TimeUnit.SECONDS));
+            assertTrue("wear did not connect", wear.connected.await(5, TimeUnit.SECONDS));
+            assertTrue("phone did not receive wear Connect", phone.gotPeerConnect.await(5, TimeUnit.SECONDS));
+            assertTrue("wear did not receive phone Connect", wear.gotPeerConnect.await(5, TimeUnit.SECONDS));
+            assertNotNull(phone.getRemoteConnect());
+            assertNotNull(wear.getRemoteConnect());
+            assertEquals("wear-1", phone.getRemoteConnect().id);
+            assertEquals("phone-1", wear.getRemoteConnect().id);
+
+            // Phone pushes a notification into the established link.
+            byte[] rawFrame = ancsFrame(0xBEEF, "org.microg.telegram", "New message");
+            AncsNotifications.Notification notification = AncsNotifications.parse(rawFrame);
+            long seq = WearableCompanionBridge.pushNotification(
+                    phone.connection, "phone-1", 3L, "com.example.app", notification, rawFrame);
+            assertEquals("pushNotification must write", 3L, seq);
+
+            // Wear side receives the SetDataItem carrying the ANCS envelope.
+            assertTrue("wear did not receive data item", wear.gotDataItem.await(5, TimeUnit.SECONDS));
+            SetDataItem item = wear.dataItem;
+            assertNotNull(item);
+            assertEquals("phone-1", item.source);
+            assertEquals("com.example.app", item.packageName);
+            assertEquals(Long.valueOf(3L), item.seqId);
+            assertEquals(Boolean.FALSE, item.deleted);
+            assertTrue(item.uri, item.uri.startsWith(
+                    "wear://phone-1" + WearableCompanionBridge.ANCS_NOTIFICATION_V1_PATH));
+
+            AncsNotifications.Notification echoed =
+                    WearableCompanionBridge.fromEnvelope(item.data.toByteArray());
+            Assert.assertNotNull(echoed);
+            assertEquals(0xBEEFL, echoed.getNotificationUid());
+            assertEquals("org.microg.telegram", echoed.getAppIdentifier());
+            assertEquals("New message", echoed.getTitle());
+        } finally {
+            client.close();
+            server.interrupt(); // unblock serverListen's accept/reject loop cleanly (its close() races the null socket field)
+        }
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/notification/AncsNotificationsTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/notification/AncsNotificationsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.microg.gms.wearable.notification;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+import java.io.ByteArrayOutputStream;
+
+public class AncsNotificationsTest extends TestCase {
+
+    private static void append(int attributeId, byte[] value, ByteArrayOutputStream out) {
+        out.write(attributeId);
+        out.write(value.length & 0xFF);
+        out.write((value.length >>> 8) & 0xFF);
+        out.write(value, 0, value.length);
+    }
+
+    private static byte[] frame(int commandId, long uid, int attributeId, String value) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write((byte) commandId);
+        out.write((int) (uid & 0xFF));
+        out.write((int) ((uid >>> 8) & 0xFF));
+        out.write((int) ((uid >>> 16) & 0xFF));
+        out.write((int) ((uid >>> 24) & 0xFF));
+        append(attributeId, value.getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        return out.toByteArray();
+    }
+
+    public void testParseCompleteFrame() throws Exception {
+        byte[] value = "org.microg.telegram\0".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES);
+        out.write(new byte[]{0x2A, 0x00, 0x00, 0x00}); // uid 42
+        append(AncsNotifications.ATTR_APP_IDENTIFIER, value, out);
+        append(AncsNotifications.ATTR_TITLE, "New message".getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        append(AncsNotifications.ATTR_MESSAGE, "ping".getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+
+        AncsNotifications.Notification notification = AncsNotifications.parse(out.toByteArray());
+
+        assertEquals(42L, notification.getNotificationUid());
+        assertEquals("org.microg.telegram", notification.getAppIdentifier());
+        assertEquals("New message", notification.getTitle());
+        assertEquals("ping", notification.getMessage());
+        Assert.assertNull(notification.getSubtitle());
+    }
+
+    public void testParseMessageSizeIsUInt32() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES);
+        out.write(new byte[]{0x01, 0x00, 0x00, 0x00}); // uid 1
+        append(AncsNotifications.ATTR_TITLE, "t".getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        out.write(AncsNotifications.ATTR_MESSAGE_SIZE);
+        out.write(new byte[]{4, 0});
+        out.write(new byte[]{(byte) 0xE8, 0x03, 0x00, 0x00}); // 1000
+
+        AncsNotifications.Notification notification = AncsNotifications.parse(out.toByteArray());
+
+        assertEquals(1000L, notification.getMessageSize());
+    }
+
+    public void testUnknownAttributeIsSkipped() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES);
+        out.write(new byte[]{0x05, 0x00, 0x00, 0x00});
+        append(0x42, "future".getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+        append(AncsNotifications.ATTR_TITLE, "ok".getBytes(java.nio.charset.StandardCharsets.UTF_8), out);
+
+        AncsNotifications.Notification notification = AncsNotifications.parse(out.toByteArray());
+
+        assertEquals("ok", notification.getTitle());
+    }
+
+    public void testRejectsTruncatedFrame() throws Exception {
+        byte[] frame = frame(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES, 7, AncsNotifications.ATTR_TITLE, "x");
+        try {
+            AncsNotifications.parse(new byte[]{frame[0], frame[1], frame[2]});
+            Assert.fail("expected IllegalArgumentException for truncated frame");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    public void testRejectsEmptyFrame() throws Exception {
+        try {
+            AncsNotifications.parse(new byte[0]);
+            Assert.fail("expected IllegalArgumentException for empty frame");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    public void testRejectsWrongCommandId() throws Exception {
+        byte[] frame = frame(0x01, 7, AncsNotifications.ATTR_TITLE, "x");
+        try {
+            AncsNotifications.parse(frame);
+            Assert.fail("expected IllegalArgumentException for unexpected command id");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    public void testBuildsReadAttributesRequest() throws Exception {
+        byte[] request = AncsNotifications.readAttributesRequest(0x01020304,
+                AncsNotifications.ATTR_APP_IDENTIFIER, AncsNotifications.ATTR_TITLE, AncsNotifications.ATTR_MESSAGE);
+
+        assertEquals(8, request.length);
+        assertEquals(AncsNotifications.COMMAND_GET_NOTIFICATION_ATTRIBUTES, request[0] & 0xFF);
+        assertEquals(0x04, request[1] & 0xFF);
+        assertEquals(0x03, request[2] & 0xFF);
+        assertEquals(0x02, request[3] & 0xFF);
+        assertEquals(0x01, request[4] & 0xFF);
+        assertEquals(AncsNotifications.ATTR_APP_IDENTIFIER, request[5] & 0xFF);
+        assertEquals(AncsNotifications.ATTR_TITLE, request[6] & 0xFF);
+        assertEquals(AncsNotifications.ATTR_MESSAGE, request[7] & 0xFF);
+    }
+}


### PR DESCRIPTION
### What
The first, fully self-contained block toward the notification bridge for [WearOS support (#2843)](https://github.com/microg/GmsCore/issues/2843): a pure-JVM ANCS (Apple Notification Center Service) notification-attributes parser and model.

- `AncsNotifications.parse(byte[])` decodes a *Notification Attributes* Data Source frame into a structured value object (`notificationUid`, `appIdentifier`, `title`, `subtitle`, `message`, `messageSize`, `date`, positive/negative action labels).
- `AncsNotifications.readAttributesRequest(uid, ids…)` builds the matching Control Point request.
- Strict bounds checking: truncated frames and overlength attribute values are rejected instead of yielding partial state; unknown/future attribute IDs are skipped so the parser stays forward compatible.
- The model implements `com.google.android.gms.wearable.AncsNotification`, ready to be routed via `WearableListenerService#onNotificationReceived`.

### Why
The `AncsNotification` API surface is currently an empty interface and `injectAncsNotificationForTesting` is unimplemented — there is no notification path at all on the wear side. This is the parsing/transport-adjacent core that the companion notification flow needs regardless of which Bluetooth transport lands first.

### Verification
- 7 unit tests (`AncsNotificationsTest`) covering full frames, the `MESSAGE_SIZE` uint32 special case, unknown-attribute skipping, and malformed/truncated rejection — all passing (verified standalone with `junit:junit:4.13.2`).

### Next steps (tracked, device-dependent)
- Notification sync engine feeding parsed notifications to `WearableListenerService`.
- Companion pairing/transport wiring so frames arrive from the wear device.