### PR TITLE
Auth: Return recovery PendingIntent for modern clients

### DIFF
--- a/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
+++ b/play-services-core/src/main/java/org/microg/gms/auth/AuthManagerServiceImpl.java
@@ -20,6 +20,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.annotation.SuppressLint;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -77,6 +78,7 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
 
     public static final String KEY_ERROR = "Error";
     public static final String KEY_USER_RECOVERY_INTENT = "userRecoveryIntent";
+    public static final String KEY_USER_RECOVERY_PENDING_INTENT = "userRecoveryPendingIntent";
 
     private final Context context;
 
@@ -171,16 +173,18 @@ public class AuthManagerServiceImpl extends IAuthManagerService.Stub {
                 } catch (Exception e) {
                     Log.w(TAG, "Can't decode consent data: ", e);
                 }
+                PendingIntent pendingIntent = PendingIntentCompat.getActivity(context, 0, i, 0, false);
                 if (notify) {
                     NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
                     nm.notify(packageName.hashCode(), new NotificationCompat.Builder(context)
-                            .setContentIntent(PendingIntentCompat.getActivity(context, 0, i, 0, false))
+                            .setContentIntent(pendingIntent)
                             .setContentTitle(context.getString(R.string.auth_notification_title))
                             .setContentText(context.getString(R.string.auth_notification_content, getPackageLabel(packageName, context.getPackageManager())))
                             .setSmallIcon(android.R.drawable.stat_notify_error)
                             .build());
                 }
                 result.putParcelable(KEY_USER_RECOVERY_INTENT, i);
+                result.putParcelable(KEY_USER_RECOVERY_PENDING_INTENT, pendingIntent);
             }
         } catch (IOException e) {
             Log.w(TAG, e);


### PR DESCRIPTION
## Summary

Return `userRecoveryPendingIntent` alongside the existing `userRecoveryIntent` when token retrieval requires user permission. Reuse the same immutable PendingIntent for the auth notification. Older clients still receive the original Intent.

## Client behavior

Google's `com.google.android.gms:play-services-auth-base:18.3.0` client reads both bundle keys. Its `getTokenWithDetails` error handling logs the following when the advertised GmsCore version is at least `233800000` and the PendingIntent is missing:

```
Recovery PendingIntent is missing on current Gms version: ...
It should always be present on or above Gms version 233800000.
This indicates a bug in Gms implementation.
```

This threshold is observable in the client implementation, not a claim about public API documentation. The client still constructs a legacy recovery exception if only the Intent is present; this patch supplies the modern recovery payload too.

Artifact: https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-auth-base/18.3.0/play-services-auth-base-18.3.0.aar

## Verification

- Cherry-picked the same one-file change onto current upstream master; `git diff --check` passes.
- Built the patch in Morphe MicroG-RE 7.1.0 using JDK 17 and `:play-services-core:assembleDefaultRelease -Pabi=arm64-v8a`.
- Installed that downstream build on a OnePlus 15 running Android 16. Morphe YouTube 21.07.247 loaded the account afterward, and the original missing-PendingIntent/account-list errors were absent from the captured logs.
- The device test included uninstalling/reinstalling MicroG and re-adding the account due to a signing-key change. It is not an isolated A/B test proving the patch alone resolves the account-loading issue. This upstream branch has not separately been built or device-tested.

Originally proposed in https://github.com/MorpheApp/MicroG-RE/pull/249; submitting upstream at the downstream maintainer's request. That PR remains open.
