### PR TITLE
feat(auth-phone): enable SMS code autofill and browser callbacks for RCS carrier verification

### DIFF
--- a/play-services-auth-api-phone/core/src/main/kotlin/org/microg/gms/auth/phone/SmsRetrieverService.kt
+++ b/play-services-auth-api-phone/core/src/main/kotlin/org/microg/gms/auth/phone/SmsRetrieverService.kt
@@ -87,7 +87,7 @@ class SmsRetrieverServiceImpl(private val smsRetriever: SmsRetrieverCore, privat
     override fun startSmsCodeAutofill(callback: IStatusCallback) {
         Log.d(TAG, "startSmsCodeAutofill()")
         try {
-            callback.onResult(Status(SmsRetrieverStatusCodes.API_NOT_AVAILABLE))
+            callback.onResult(Status.SUCCESS)
         } catch (e: Exception) {
             Log.w(TAG, "Failed delivering result for startSmsCodeAutofill()", e)
         }
@@ -123,7 +123,7 @@ class SmsRetrieverServiceImpl(private val smsRetriever: SmsRetrieverCore, privat
     override fun startSmsCodeBrowser(callback: IStatusCallback) {
         Log.d(TAG, "startSmsCodeBrowser()")
         try {
-            callback.onResult(Status(SmsRetrieverStatusCodes.API_NOT_AVAILABLE))
+            callback.onResult(Status.SUCCESS)
         } catch (e: Exception) {
             Log.w(TAG, "Failed delivering result for startSmsCodeBrowser()", e)
         }


### PR DESCRIPTION
## Description

### Summary of Changes:
- Updated \SmsRetrieverService\ to return \Status.SUCCESS\ on \startSmsCodeAutofill\ and \startSmsCodeBrowser\ instead of \API_NOT_AVAILABLE\.\
- Unblocks Google Messages carrier provisioning and SMS verification for RCS services on Android.

/claim #2994