### PR TITLE
WearOS support: Bluetooth transport, notifications, and media controls (#2843)

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -138,6 +138,11 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
@@ -459,6 +464,7 @@
 
         <activity
             android:name="com.google.android.gms.wearable.consent.TermsOfServiceActivity"
+            android:exported="true"
             android:process=":ui"
             android:configChanges="screenSize|orientation|keyboardHidden">
             <intent-filter>

--- a/play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt
+++ b/play-services-core/src/main/kotlin/com/google/android/gms/wearable/consent/TermsOfServiceActivity.kt
@@ -6,13 +6,37 @@
 package com.google.android.gms.wearable.consent
 
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.R
 
+/**
+ * Shown by Wear OS / Galaxy Wearable companion apps during device setup.
+ *
+ * Prior to this implementation the activity immediately returned
+ * [RESULT_CANCELED], which blocked pairing (#2444 / #2843).
+ */
 class TermsOfServiceActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setResult(RESULT_CANCELED)
-        finish()
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.wearable_tos_dialog_title)
+            .setMessage(R.string.wearable_tos_dialog_message)
+            .setPositiveButton(R.string.wearable_tos_accept) { _, _ ->
+                setResult(RESULT_OK)
+                finish()
+            }
+            .setNegativeButton(R.string.wearable_tos_decline) { _, _ ->
+                setResult(RESULT_CANCELED)
+                finish()
+            }
+            .setOnCancelListener {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
+            .setCancelable(true)
+            .show()
     }
 }

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -475,4 +475,11 @@ Please set up a password, PIN, or pattern lock screen."</string>
     <string name="pref_passkey_manager_transport_bluetooth">Bluetooth</string>
     <string name="pref_passkey_manager_transport_hybrid">Hybrid</string>
     <string name="pref_passkey_manager_credential_id_format_internal">ID: %1$s</string>
+
+    <!-- Wearable / Wear OS consent -->
+    <string name="wearable_tos_dialog_title">Wear OS terms</string>
+    <string name="wearable_tos_dialog_message">Companion apps require acceptance of Wear OS terms to finish pairing a watch with this device. microG does not send this choice to Google; accepting only unblocks local setup.</string>
+    <string name="wearable_tos_accept">Accept</string>
+    <string name="wearable_tos_decline">Decline</string>
+    <string name="wearable_notification_listener_label">Wear OS notification bridge</string>
 </resources>

--- a/play-services-wearable/README.md
+++ b/play-services-wearable/README.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: 2026 microG Project Team
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# play-services-wearable
+
+Client library and service implementation for the Wearable Data Layer APIs used by Wear OS
+companion apps and phone↔watch app pairs.
+
+## Support for Wear OS (#2843 / #2444)
+
+This module provides:
+
+1. **Wear OS TOS activity** — `TermsOfServiceActivity` shows an accept/decline dialog so
+   companion apps (Galaxy Wearable, Wear OS) are not blocked by an immediate
+   `RESULT_CANCELED` (see #2444).
+2. **Client API facades** — `NodeApi`, `DataApi`, and `MessageApi` delegate to
+   `WearableServiceImpl` (they previously threw `UnsupportedOperationException`).
+3. **Bluetooth RFCOMM transport** — `BluetoothConnectionThread` speaks the existing
+   length-prefixed protobuf wire format over Bluetooth Classic, using UUIDs documented in
+   [teccheck/wearos-research](https://github.com/teccheck/wearos-research/blob/main/docs/btcomm.md):
+   - `5e8945b0-9525-11e3-a5e2-0800200c9a66` — WearableBt (watch is server; phone connects)
+   - `fafbdd20-83f0-4389-addf-917ac9dae5b2` — Flow (phone is server)
+   - `6a1eafb1-61c0-42a0-8bb0-a336fb1c3f00` — Flow15 (phone is server)
+4. **Notification mirroring** — `WearableNotificationListenerService` forwards posted/removed
+   notifications to connected peers on `/wearable/notification/{posted,removed}`.
+5. **Media controls** — `WearableMediaSessionBridge` pushes playback state on
+   `/wearable/media/state` and handles watch commands under `/wearable/media/control/*`
+   (play, pause, toggle, next, previous, seek, rate).
+
+When a `ConnectionConfiguration` with a Bluetooth MAC (`address`) is enabled, microG starts a
+WearableBt client connection to that device and ensures Flow/Flow15 listeners are running.
+The legacy TCP server on port `5601` (config name `"server"`) is unchanged for emulator use.
+
+Enable the **Wear OS notification bridge** notification listener in system settings so
+notification mirroring and media-session access can work.
+
+## Remaining device-specific work
+
+OEM companion pairing handshakes (Galaxy Wearable / Wear OS by Google setup wizards) still
+benefit from physical-device verification. Stock watch UI may expect additional OEM protocols
+beyond the Data Layer paths above.
+
+## Testing
+
+```bash
+./gradlew :play-services-wearable-core:testDebugUnitTest
+```
+
+Unit tests cover RFCOMM UUIDs (rejecting known-wrong values from earlier PRs), notification
+payload encoding, and media control parsing.

--- a/play-services-wearable/core/build.gradle
+++ b/play-services-wearable/core/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     implementation project(':play-services-wearable')
 
     implementation "org.microg:wearable:$wearableVersion"
+
+    testImplementation 'junit:junit:4.13.2'
 }
 
 android {
@@ -48,6 +50,10 @@ android {
 
     kotlinOptions {
         jvmTarget = 1.8
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
     }
 }
 

--- a/play-services-wearable/core/src/main/AndroidManifest.xml
+++ b/play-services-wearable/core/src/main/AndroidManifest.xml
@@ -6,6 +6,21 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+
     <application>
+        <service
+            android:name="org.microg.gms.wearable.bridge.WearableNotificationListenerService"
+            android:exported="true"
+            android:label="@string/wearable_notification_listener_label"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/BluetoothConnectionThread.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/BluetoothConnectionThread.java
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothServerSocket;
+import android.bluetooth.BluetoothSocket;
+import android.util.Log;
+
+import org.microg.wearable.SocketWearableConnection;
+import org.microg.wearable.WearableConnection;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.UUID;
+
+/**
+ * Bluetooth RFCOMM transport mirroring {@code org.microg.wearable.SocketConnectionThread}.
+ *
+ * <p>UUIDs are taken from Pixel Watch / Wear OS traffic research
+ * (see https://github.com/teccheck/wearos-research/blob/main/docs/btcomm.md):
+ * <ul>
+ *   <li>{@link #WEARABLE_BT_UUID} — primary WearableBt channel; watch is the RFCOMM server</li>
+ *   <li>{@link #FLOW_UUID} — Flow channel; phone is the RFCOMM server</li>
+ *   <li>{@link #FLOW15_UUID} — Flow15 channel; phone is the RFCOMM server</li>
+ * </ul>
+ *
+ * Each {@link BluetoothSocket} is wrapped in a minimal {@link Socket} proxy so the existing
+ * length-prefixed protobuf framing in {@link SocketWearableConnection} can be reused.
+ */
+public abstract class BluetoothConnectionThread extends Thread {
+
+    private static final String TAG = "GmsWearBtThread";
+
+    /**
+     * Primary WearableBt RFCOMM UUID. The wearable advertises this service; the phone connects
+     * as a client.
+     */
+    public static final UUID WEARABLE_BT_UUID =
+            UUID.fromString("5e8945b0-9525-11e3-a5e2-0800200c9a66");
+
+    /** Flow RFCOMM UUID. The phone advertises this service. */
+    public static final UUID FLOW_UUID =
+            UUID.fromString("fafbdd20-83f0-4389-addf-917ac9dae5b2");
+
+    /** Flow15 RFCOMM UUID. The phone advertises this service. */
+    public static final UUID FLOW15_UUID =
+            UUID.fromString("6a1eafb1-61c0-42a0-8bb0-a336fb1c3f00");
+
+    static final String WEARABLE_BT_SERVICE_NAME = "WearableBt";
+    static final String FLOW_SERVICE_NAME = "Flow";
+    static final String FLOW15_SERVICE_NAME = "Flow15";
+
+    private volatile SocketWearableConnection wearableConnection;
+
+    BluetoothConnectionThread() {
+    }
+
+    protected void setWearableConnection(SocketWearableConnection connection) {
+        SocketWearableConnection prev = this.wearableConnection;
+        this.wearableConnection = connection;
+        if (prev != null && prev != connection) {
+            try {
+                prev.close();
+            } catch (IOException e) {
+                Log.w(TAG, "Failed to close previous wearable connection", e);
+            }
+        }
+    }
+
+    public SocketWearableConnection getWearableConnection() {
+        return wearableConnection;
+    }
+
+    public abstract void close();
+
+    private static Socket proxySocket(final BluetoothSocket btSocket) {
+        return new Socket() {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return btSocket.getInputStream();
+            }
+
+            @Override
+            public OutputStream getOutputStream() throws IOException {
+                return btSocket.getOutputStream();
+            }
+
+            @Override
+            public boolean isConnected() {
+                return btSocket.isConnected();
+            }
+
+            @Override
+            public boolean isClosed() {
+                return !btSocket.isConnected();
+            }
+
+            @Override
+            public synchronized void close() throws IOException {
+                btSocket.close();
+            }
+        };
+    }
+
+    /**
+     * Listen for incoming RFCOMM connections on {@code uuid} (phone-as-server roles such as
+     * Flow / Flow15).
+     */
+    @SuppressLint("MissingPermission")
+    public static BluetoothConnectionThread serverListen(
+            BluetoothAdapter adapter, String serviceName, UUID uuid,
+            WearableConnection.Listener listener) {
+        return new BluetoothConnectionThread() {
+            private volatile BluetoothServerSocket serverSocket;
+
+            @Override
+            public void close() {
+                BluetoothServerSocket s = serverSocket;
+                serverSocket = null;
+                if (s != null) {
+                    try {
+                        s.close();
+                    } catch (IOException e) {
+                        Log.w(TAG, "server close: error", e);
+                    }
+                }
+            }
+
+            @Override
+            @SuppressLint("MissingPermission")
+            public void run() {
+                try {
+                    serverSocket = adapter.listenUsingRfcommWithServiceRecord(serviceName, uuid);
+                    Log.d(TAG, "server: listening on " + serviceName + " (" + uuid + ")");
+                    while (!Thread.interrupted()) {
+                        BluetoothSocket btSocket;
+                        try {
+                            btSocket = serverSocket.accept();
+                        } catch (IOException e) {
+                            break;
+                        }
+                        if (btSocket == null || Thread.interrupted()) break;
+                        try {
+                            SocketWearableConnection conn =
+                                    new SocketWearableConnection(proxySocket(btSocket), listener);
+                            setWearableConnection(conn);
+                            try {
+                                conn.run();
+                            } finally {
+                                try {
+                                    btSocket.close();
+                                } catch (IOException e) {
+                                    Log.w(TAG, "server: close error for accepted connection", e);
+                                }
+                            }
+                        } catch (IOException e) {
+                            Log.w(TAG, "server: error on accepted connection", e);
+                        }
+                    }
+                } catch (IOException e) {
+                    if (!Thread.interrupted()) {
+                        Log.w(TAG, "server: socket error on " + serviceName, e);
+                    }
+                } finally {
+                    close();
+                }
+            }
+        };
+    }
+
+    /**
+     * Connect to a remote wearable that advertises {@link #WEARABLE_BT_UUID}.
+     */
+    @SuppressLint("MissingPermission")
+    public static BluetoothConnectionThread clientConnect(
+            BluetoothDevice device, WearableConnection.Listener listener) {
+        return clientConnect(device, WEARABLE_BT_UUID, listener);
+    }
+
+    @SuppressLint("MissingPermission")
+    public static BluetoothConnectionThread clientConnect(
+            BluetoothDevice device, UUID uuid, WearableConnection.Listener listener) {
+        return new BluetoothConnectionThread() {
+            private volatile BluetoothSocket btSocket;
+
+            @Override
+            public void close() {
+                BluetoothSocket s = btSocket;
+                btSocket = null;
+                if (s != null) {
+                    try {
+                        s.close();
+                    } catch (IOException e) {
+                        Log.w(TAG, "client close: error", e);
+                    }
+                }
+            }
+
+            @Override
+            @SuppressLint("MissingPermission")
+            public void run() {
+                BluetoothSocket s = null;
+                try {
+                    s = device.createRfcommSocketToServiceRecord(uuid);
+                    btSocket = s;
+                    Log.d(TAG, "client: connecting to " + device.getAddress() + " via " + uuid);
+                    s.connect();
+                    SocketWearableConnection conn =
+                            new SocketWearableConnection(proxySocket(s), listener);
+                    setWearableConnection(conn);
+                    conn.run();
+                } catch (IOException e) {
+                    if (!Thread.interrupted()) {
+                        Log.w(TAG, "client: connection failed", e);
+                    }
+                } finally {
+                    if (s != null) {
+                        try {
+                            s.close();
+                        } catch (IOException e) {
+                            Log.d(TAG, "client: close error in finally", e);
+                        }
+                    }
+                    btSocket = null;
+                }
+            }
+        };
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/MessageHandler.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/MessageHandler.java
@@ -26,6 +26,8 @@ import com.google.android.gms.wearable.internal.MessageEventParcelable;
 
 import org.microg.gms.profile.Build;
 import org.microg.gms.settings.SettingsContract;
+import org.microg.gms.wearable.bridge.MediaControlCommand;
+import org.microg.gms.wearable.bridge.WearableMediaSessionBridge;
 import org.microg.wearable.ServerMessageListener;
 import org.microg.wearable.proto.AckAsset;
 import org.microg.wearable.proto.Connect;
@@ -143,13 +145,18 @@ public class MessageHandler extends ServerMessageListener {
     public void onRpcRequest(Request rpcRequest) {
         Log.d(TAG, "onRpcRequest: " + rpcRequest);
         if (TextUtils.isEmpty(rpcRequest.targetNodeId) || rpcRequest.targetNodeId.equals(wearable.getLocalNodeId())) {
-            MessageEventParcelable messageEvent = new MessageEventParcelable();
-            messageEvent.data = rpcRequest.rawData != null ? rpcRequest.rawData.toByteArray() : null;
-            messageEvent.path = rpcRequest.path;
-            messageEvent.requestId = rpcRequest.requestId + 31 * (rpcRequest.generation + 527);
-            messageEvent.sourceNodeId = TextUtils.isEmpty(rpcRequest.sourceNodeId) ? peerNodeId : rpcRequest.sourceNodeId;
+            byte[] data = rpcRequest.rawData != null ? rpcRequest.rawData.toByteArray() : null;
+            if (MediaControlCommand.isControlPath(rpcRequest.path)) {
+                WearableMediaSessionBridge.getInstance(wearable.getContext()).handleMessage(rpcRequest.path, data);
+            } else {
+                MessageEventParcelable messageEvent = new MessageEventParcelable();
+                messageEvent.data = data;
+                messageEvent.path = rpcRequest.path;
+                messageEvent.requestId = rpcRequest.requestId + 31 * (rpcRequest.generation + 527);
+                messageEvent.sourceNodeId = TextUtils.isEmpty(rpcRequest.sourceNodeId) ? peerNodeId : rpcRequest.sourceNodeId;
 
-            wearable.sendMessageReceived(rpcRequest.packageName, messageEvent);
+                wearable.sendMessageReceived(rpcRequest.packageName, messageEvent);
+            }
         } else if (rpcRequest.targetNodeId.equals(peerNodeId)) {
             // Drop it
         } else {

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableImpl.java
@@ -16,6 +16,9 @@
 
 package org.microg.gms.wearable;
 
+import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -87,6 +90,9 @@ public class WearableImpl {
     private final Map<String, WearableConnection> activeConnections = new HashMap<String, WearableConnection>();
     private RpcHelper rpcHelper;
     private SocketConnectionThread sct;
+    private BluetoothConnectionThread flowServer;
+    private BluetoothConnectionThread flow15Server;
+    private final Map<String, BluetoothConnectionThread> bluetoothClients = new HashMap<String, BluetoothConnectionThread>();
     private ConnectionConfiguration[] configurations;
     private boolean configurationsUpdated = false;
     private ClockworkNodePreferences clockworkNodePreferences;
@@ -392,6 +398,13 @@ public class WearableImpl {
         return nodes;
     }
 
+    /**
+     * Node IDs with an active wire connection.
+     */
+    public Set<String> getAllConnectedNodes() {
+        return new HashSet<String>(activeConnections.keySet());
+    }
+
     interface ListenerInvoker {
         void invoke(IWearableListener listener) throws RemoteException;
     }
@@ -491,6 +504,9 @@ public class WearableImpl {
         if (!listeners.containsKey(packageName)) {
             listeners.put(packageName, new ArrayList<ListenerInfo>());
         }
+        if (filters == null) {
+            filters = new IntentFilter[0];
+        }
         listeners.get(packageName).add(new ListenerInfo(listener, filters));
     }
 
@@ -508,20 +524,113 @@ public class WearableImpl {
     public void enableConnection(String name) {
         configDatabase.setEnabledState(name, true);
         configurationsUpdated = true;
+        ConnectionConfiguration config = configDatabase.getConfiguration(name);
         if (name.equals("server") && sct == null) {
             Log.d(TAG, "Starting server on :" + WEAR_TCP_PORT);
-            (sct = SocketConnectionThread.serverListen(WEAR_TCP_PORT, new MessageHandler(context, this, configDatabase.getConfiguration(name)))).start();
+            (sct = SocketConnectionThread.serverListen(WEAR_TCP_PORT, new MessageHandler(context, this, config))).start();
         }
+        startBluetoothForConfig(config);
     }
 
     public void disableConnection(String name) {
         configDatabase.setEnabledState(name, false);
         configurationsUpdated = true;
         if (name.equals("server") && sct != null) {
-            activeConnections.remove(sct.getWearableConnection());
+            WearableConnection conn = sct.getWearableConnection();
+            if (conn != null) {
+                activeConnections.values().remove(conn);
+            }
             sct.close();
             sct.interrupt();
             sct = null;
+        }
+        ConnectionConfiguration config = configDatabase.getConfiguration(name);
+        if (config != null && !TextUtils.isEmpty(config.address)) {
+            stopBluetoothClient(config.address);
+        }
+    }
+
+    /**
+     * Starts Flow/Flow15 listeners (phone-as-server) and, when {@code config.address} is a
+     * Bluetooth MAC, a WearableBt client connection to that watch.
+     */
+    @SuppressLint("MissingPermission")
+    private void startBluetoothForConfig(ConnectionConfiguration config) {
+        if (config == null) return;
+        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+        if (adapter == null || !adapter.isEnabled()) {
+            Log.w(TAG, "Bluetooth unavailable or disabled; skipping RFCOMM for " + config.name);
+            return;
+        }
+        ensureBluetoothServers(adapter, config);
+        if (!TextUtils.isEmpty(config.address) && BluetoothAdapter.checkBluetoothAddress(config.address)) {
+            startBluetoothClient(adapter, config);
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private synchronized void ensureBluetoothServers(BluetoothAdapter adapter, ConnectionConfiguration config) {
+        if (flowServer == null) {
+            Log.d(TAG, "Starting Bluetooth Flow server");
+            flowServer = BluetoothConnectionThread.serverListen(
+                    adapter,
+                    BluetoothConnectionThread.FLOW_SERVICE_NAME,
+                    BluetoothConnectionThread.FLOW_UUID,
+                    new MessageHandler(context, this, config));
+            flowServer.start();
+        }
+        if (flow15Server == null) {
+            Log.d(TAG, "Starting Bluetooth Flow15 server");
+            flow15Server = BluetoothConnectionThread.serverListen(
+                    adapter,
+                    BluetoothConnectionThread.FLOW15_SERVICE_NAME,
+                    BluetoothConnectionThread.FLOW15_UUID,
+                    new MessageHandler(context, this, config));
+            flow15Server.start();
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private synchronized void startBluetoothClient(BluetoothAdapter adapter, ConnectionConfiguration config) {
+        String address = config.address;
+        BluetoothConnectionThread existing = bluetoothClients.get(address);
+        if (existing != null && existing.isAlive()) {
+            Log.d(TAG, "Bluetooth client already running for " + address);
+            return;
+        }
+        BluetoothDevice device = adapter.getRemoteDevice(address);
+        Log.d(TAG, "Connecting WearableBt client to " + address);
+        BluetoothConnectionThread client = BluetoothConnectionThread.clientConnect(
+                device, new MessageHandler(context, this, config));
+        bluetoothClients.put(address, client);
+        client.start();
+    }
+
+    private synchronized void stopBluetoothClient(String address) {
+        BluetoothConnectionThread client = bluetoothClients.remove(address);
+        if (client != null) {
+            WearableConnection conn = client.getWearableConnection();
+            if (conn != null) {
+                activeConnections.values().remove(conn);
+            }
+            client.close();
+            client.interrupt();
+        }
+    }
+
+    private synchronized void stopAllBluetooth() {
+        if (flowServer != null) {
+            flowServer.close();
+            flowServer.interrupt();
+            flowServer = null;
+        }
+        if (flow15Server != null) {
+            flow15Server.close();
+            flow15Server.interrupt();
+            flow15Server = null;
+        }
+        for (String address : new ArrayList<String>(bluetoothClients.keySet())) {
+            stopBluetoothClient(address);
         }
     }
 
@@ -581,7 +690,7 @@ public class WearableImpl {
         } catch (IOException e1) {
             Log.w(TAG, e1);
         }
-        if (connection == sct.getWearableConnection()) {
+        if (sct != null && connection == sct.getWearableConnection()) {
             sct.close();
             sct = null;
         }
@@ -622,6 +731,12 @@ public class WearableImpl {
     }
 
     public void stop() {
+        stopAllBluetooth();
+        if (sct != null) {
+            sct.close();
+            sct.interrupt();
+            sct = null;
+        }
         try {
             this.networkHandlerLock.await();
             this.networkHandler.getLooper().quit();

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableService.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/WearableService.java
@@ -27,8 +27,11 @@ import com.google.android.gms.common.internal.IGmsCallbacks;
 import org.microg.gms.BaseService;
 import org.microg.gms.common.GmsService;
 import org.microg.gms.common.PackageUtils;
+import org.microg.gms.wearable.bridge.WearableMediaSessionBridge;
 
 public class WearableService extends BaseService {
+
+    private static WearableService instance;
 
     public static final Feature[] FEATURES = new Feature[]{
             new Feature("app_client", 4L),
@@ -72,17 +75,34 @@ public class WearableService extends BaseService {
         super("GmsWearSvc", GmsService.WEAR);
     }
 
+    /**
+     * @return the running service instance, or {@code null} if the service is not started.
+     */
+    public static WearableService getInstance() {
+        return instance;
+    }
+
+    public WearableImpl getWearableImpl() {
+        return wearable;
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
+        instance = this;
         ConfigurationDatabaseHelper configurationDatabaseHelper = new ConfigurationDatabaseHelper(getApplicationContext());
         NodeDatabaseHelper nodeDatabaseHelper = new NodeDatabaseHelper(getApplicationContext());
         wearable = new WearableImpl(getApplicationContext(), nodeDatabaseHelper, configurationDatabaseHelper);
+        WearableMediaSessionBridge.getInstance(getApplicationContext()).start();
     }
 
     @Override
     public void onDestroy() {
+        WearableMediaSessionBridge.getInstance(getApplicationContext()).stop();
         super.onDestroy();
+        if (instance == this) {
+            instance = null;
+        }
         wearable.stop();
     }
 

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/MediaControlCommand.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/MediaControlCommand.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.bridge;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Locale;
+
+/**
+ * Parses watch→phone media control messages sent on paths under
+ * {@link #PATH_PREFIX}.
+ */
+public final class MediaControlCommand {
+
+    public static final String PATH_PREFIX = "/wearable/media/control/";
+    public static final String STATE_PATH = "/wearable/media/state";
+
+    public enum Action {
+        PLAY,
+        PAUSE,
+        TOGGLE,
+        NEXT,
+        PREVIOUS,
+        SEEK,
+        RATE
+    }
+
+    public final Action action;
+    public final long seekPositionMs;
+    public final float playbackRate;
+
+    public MediaControlCommand(Action action, long seekPositionMs, float playbackRate) {
+        this.action = action;
+        this.seekPositionMs = seekPositionMs;
+        this.playbackRate = playbackRate;
+    }
+
+    public static boolean isControlPath(String path) {
+        return path != null && path.startsWith(PATH_PREFIX);
+    }
+
+    public static MediaControlCommand parse(String path, byte[] data) {
+        if (!isControlPath(path)) {
+            return null;
+        }
+        String name = path.substring(PATH_PREFIX.length()).toLowerCase(Locale.US);
+        switch (name) {
+            case "play":
+                return new MediaControlCommand(Action.PLAY, 0L, 1f);
+            case "pause":
+                return new MediaControlCommand(Action.PAUSE, 0L, 1f);
+            case "toggle":
+                return new MediaControlCommand(Action.TOGGLE, 0L, 1f);
+            case "next":
+                return new MediaControlCommand(Action.NEXT, 0L, 1f);
+            case "previous":
+                return new MediaControlCommand(Action.PREVIOUS, 0L, 1f);
+            case "seek":
+                return new MediaControlCommand(Action.SEEK, readLong(data), 1f);
+            case "rate":
+                return new MediaControlCommand(Action.RATE, 0L, readFloat(data));
+            default:
+                return null;
+        }
+    }
+
+    private static long readLong(byte[] data) {
+        if (data == null || data.length < 8) {
+            return 0L;
+        }
+        return ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).getLong();
+    }
+
+    private static float readFloat(byte[] data) {
+        if (data == null || data.length < 4) {
+            return 1f;
+        }
+        return ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).getFloat();
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/NotificationPayload.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/NotificationPayload.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.bridge;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wire payload for phone→watch notification mirroring over the Wearable Data Layer.
+ *
+ * <p>Encoding is a simple {@code key=value} line protocol (UTF-8) so it can be unit-tested on
+ * the JVM without Android's {@code org.json} package.
+ */
+public final class NotificationPayload {
+
+    public static final String PATH_POSTED = "/wearable/notification/posted";
+    public static final String PATH_REMOVED = "/wearable/notification/removed";
+
+    public final String key;
+    public final String packageName;
+    public final int id;
+    public final String title;
+    public final String text;
+    public final String category;
+    public final int priority;
+    public final boolean ongoing;
+    public final List<String> actions;
+
+    public NotificationPayload(
+            String key,
+            String packageName,
+            int id,
+            String title,
+            String text,
+            String category,
+            int priority,
+            boolean ongoing,
+            List<String> actions) {
+        this.key = key != null ? key : "";
+        this.packageName = packageName != null ? packageName : "";
+        this.id = id;
+        this.title = title != null ? title : "";
+        this.text = text != null ? text : "";
+        this.category = category != null ? category : "";
+        this.priority = priority;
+        this.ongoing = ongoing;
+        this.actions = actions != null
+                ? Collections.unmodifiableList(new ArrayList<String>(actions))
+                : Collections.<String>emptyList();
+    }
+
+    public byte[] toBytes() {
+        Map<String, String> fields = new LinkedHashMap<String, String>();
+        fields.put("key", key);
+        fields.put("packageName", packageName);
+        fields.put("id", Integer.toString(id));
+        fields.put("title", title);
+        fields.put("text", text);
+        fields.put("category", category);
+        fields.put("priority", Integer.toString(priority));
+        fields.put("ongoing", Boolean.toString(ongoing));
+        fields.put("actions", joinActions(actions));
+        return encode(fields);
+    }
+
+    public static NotificationPayload fromBytes(byte[] data) {
+        if (data == null || data.length == 0) {
+            throw new IllegalArgumentException("empty payload");
+        }
+        Map<String, String> fields = decode(data);
+        List<String> actions = splitActions(fields.get("actions"));
+        return new NotificationPayload(
+                fields.get("key"),
+                fields.get("packageName"),
+                parseInt(fields.get("id"), 0),
+                fields.get("title"),
+                fields.get("text"),
+                fields.get("category"),
+                parseInt(fields.get("priority"), 0),
+                Boolean.parseBoolean(fields.get("ongoing")),
+                actions);
+    }
+
+    public static byte[] removedBytes(String key, String packageName, int id) {
+        Map<String, String> fields = new LinkedHashMap<String, String>();
+        fields.put("key", key != null ? key : "");
+        fields.put("packageName", packageName != null ? packageName : "");
+        fields.put("id", Integer.toString(id));
+        return encode(fields);
+    }
+
+    static byte[] encode(Map<String, String> fields) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : fields.entrySet()) {
+            sb.append(entry.getKey())
+                    .append('=')
+                    .append(escape(entry.getValue()))
+                    .append('\n');
+        }
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    static Map<String, String> decode(byte[] data) {
+        Map<String, String> fields = new LinkedHashMap<String, String>();
+        String raw = new String(data, StandardCharsets.UTF_8);
+        String[] lines = raw.split("\n", -1);
+        for (String line : lines) {
+            if (line.isEmpty()) {
+                continue;
+            }
+            int eq = line.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            fields.put(line.substring(0, eq), unescape(line.substring(eq + 1)));
+        }
+        return fields;
+    }
+
+    private static String joinActions(List<String> actions) {
+        if (actions == null || actions.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < actions.size(); i++) {
+            if (i > 0) {
+                sb.append('\u001f');
+            }
+            sb.append(actions.get(i));
+        }
+        return sb.toString();
+    }
+
+    private static List<String> splitActions(String value) {
+        List<String> actions = new ArrayList<String>();
+        if (value == null || value.isEmpty()) {
+            return actions;
+        }
+        String[] parts = value.split("\u001f", -1);
+        Collections.addAll(actions, parts);
+        return actions;
+    }
+
+    private static int parseInt(String value, int fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("\\", "\\\\")
+                .replace("\n", "\\n")
+                .replace("=", "\\=");
+    }
+
+    private static String unescape(String value) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\\' && i + 1 < value.length()) {
+                char next = value.charAt(++i);
+                if (next == 'n') {
+                    sb.append('\n');
+                } else {
+                    sb.append(next);
+                }
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/WearableMediaSessionBridge.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/WearableMediaSessionBridge.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.bridge;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.media.MediaMetadata;
+import android.media.session.MediaController;
+import android.media.session.MediaSessionManager;
+import android.media.session.PlaybackState;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import org.microg.gms.wearable.WearableImpl;
+import org.microg.gms.wearable.WearableService;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Bridges phone {@link MediaController} sessions to Wear OS peers: pushes metadata/state and
+ * applies control commands arriving on {@link MediaControlCommand#PATH_PREFIX}.
+ */
+public final class WearableMediaSessionBridge {
+
+    private static final String TAG = "GmsWearMediaBridge";
+
+    private static WearableMediaSessionBridge instance;
+
+    private final Context context;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private MediaSessionManager sessionManager;
+    private MediaController activeController;
+    private final MediaController.Callback controllerCallback = new MediaController.Callback() {
+        @Override
+        public void onPlaybackStateChanged(PlaybackState state) {
+            publishState();
+        }
+
+        @Override
+        public void onMetadataChanged(MediaMetadata metadata) {
+            publishState();
+        }
+    };
+    private final MediaSessionManager.OnActiveSessionsChangedListener sessionsListener =
+            controllers -> updateActiveController(controllers);
+
+    private WearableMediaSessionBridge(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    public static synchronized WearableMediaSessionBridge getInstance(Context context) {
+        if (instance == null) {
+            instance = new WearableMediaSessionBridge(context);
+        }
+        return instance;
+    }
+
+    public void start() {
+        handler.post(() -> {
+            try {
+                sessionManager = (MediaSessionManager) context.getSystemService(Context.MEDIA_SESSION_SERVICE);
+                if (sessionManager == null) {
+                    Log.w(TAG, "MediaSessionManager unavailable");
+                    return;
+                }
+                ComponentName listener = new ComponentName(context, WearableNotificationListenerService.class);
+                sessionManager.addOnActiveSessionsChangedListener(sessionsListener, listener);
+                updateActiveController(sessionManager.getActiveSessions(listener));
+            } catch (SecurityException e) {
+                Log.w(TAG, "Notification listener permission required for media sessions", e);
+            }
+        });
+    }
+
+    public void stop() {
+        handler.post(() -> {
+            if (sessionManager != null) {
+                try {
+                    sessionManager.removeOnActiveSessionsChangedListener(sessionsListener);
+                } catch (Exception e) {
+                    Log.d(TAG, "removeOnActiveSessionsChangedListener", e);
+                }
+            }
+            detachController();
+            sessionManager = null;
+        });
+    }
+
+    /**
+     * @return {@code true} if the message was a media control command (handled or unrecognized).
+     */
+    public boolean handleMessage(String path, byte[] data) {
+        MediaControlCommand command = MediaControlCommand.parse(path, data);
+        if (command == null) {
+            return MediaControlCommand.isControlPath(path);
+        }
+        handler.post(() -> apply(command));
+        return true;
+    }
+
+    private void apply(MediaControlCommand command) {
+        MediaController controller = activeController;
+        if (controller == null) {
+            Log.d(TAG, "No active media session for " + command.action);
+            return;
+        }
+        MediaController.TransportControls controls = controller.getTransportControls();
+        switch (command.action) {
+            case PLAY:
+                controls.play();
+                break;
+            case PAUSE:
+                controls.pause();
+                break;
+            case TOGGLE:
+                PlaybackState state = controller.getPlaybackState();
+                if (state != null && state.getState() == PlaybackState.STATE_PLAYING) {
+                    controls.pause();
+                } else {
+                    controls.play();
+                }
+                break;
+            case NEXT:
+                controls.skipToNext();
+                break;
+            case PREVIOUS:
+                controls.skipToPrevious();
+                break;
+            case SEEK:
+                controls.seekTo(command.seekPositionMs);
+                break;
+            case RATE:
+                controls.setPlaybackSpeed(command.playbackRate);
+                break;
+        }
+    }
+
+    private void updateActiveController(List<MediaController> controllers) {
+        detachController();
+        if (controllers == null || controllers.isEmpty()) {
+            return;
+        }
+        activeController = controllers.get(0);
+        activeController.registerCallback(controllerCallback, handler);
+        publishState();
+    }
+
+    private void detachController() {
+        if (activeController != null) {
+            try {
+                activeController.unregisterCallback(controllerCallback);
+            } catch (Exception e) {
+                Log.d(TAG, "unregisterCallback", e);
+            }
+            activeController = null;
+        }
+    }
+
+    private void publishState() {
+        WearableService service = WearableService.getInstance();
+        if (service == null) {
+            return;
+        }
+        WearableImpl wearable = service.getWearableImpl();
+        if (wearable == null) {
+            return;
+        }
+        Set<String> nodes = wearable.getAllConnectedNodes();
+        if (nodes.isEmpty() || activeController == null) {
+            return;
+        }
+        byte[] payload = encodeState(activeController);
+        String packageName = context.getPackageName();
+        for (String nodeId : nodes) {
+            wearable.sendMessage(packageName, nodeId, MediaControlCommand.STATE_PATH, payload);
+        }
+    }
+
+    static byte[] encodeState(MediaController controller) {
+        Map<String, String> fields = new LinkedHashMap<String, String>();
+        MediaMetadata metadata = controller.getMetadata();
+        PlaybackState state = controller.getPlaybackState();
+        if (metadata != null) {
+            fields.put("title", nullToEmpty(metadata.getString(MediaMetadata.METADATA_KEY_TITLE)));
+            fields.put("artist", nullToEmpty(metadata.getString(MediaMetadata.METADATA_KEY_ARTIST)));
+            fields.put("album", nullToEmpty(metadata.getString(MediaMetadata.METADATA_KEY_ALBUM)));
+            fields.put("duration", Long.toString(metadata.getLong(MediaMetadata.METADATA_KEY_DURATION)));
+        }
+        if (state != null) {
+            fields.put("isPlaying", Boolean.toString(state.getState() == PlaybackState.STATE_PLAYING));
+            fields.put("position", Long.toString(state.getPosition()));
+            fields.put("playbackSpeed", Float.toString(state.getPlaybackSpeed()));
+        } else {
+            fields.put("isPlaying", "false");
+            fields.put("position", "0");
+            fields.put("playbackSpeed", "1.0");
+        }
+        String pkg = controller.getPackageName();
+        fields.put("packageName", pkg != null ? pkg : "");
+        return NotificationPayload.encode(fields);
+    }
+
+    private static String nullToEmpty(String value) {
+        return value != null ? value : "";
+    }
+}

--- a/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/WearableNotificationListenerService.java
+++ b/play-services-wearable/core/src/main/java/org/microg/gms/wearable/bridge/WearableNotificationListenerService.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.bridge;
+
+import android.app.Notification;
+import android.os.Bundle;
+import android.service.notification.NotificationListenerService;
+import android.service.notification.StatusBarNotification;
+import android.util.Log;
+
+import org.microg.gms.wearable.WearableImpl;
+import org.microg.gms.wearable.WearableService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Mirrors phone notifications to connected Wear OS peers over the Wearable message transport.
+ *
+ * <p>Requires the user to enable microG as a notification listener. Ongoing / local-only
+ * notifications are skipped.
+ */
+public class WearableNotificationListenerService extends NotificationListenerService {
+
+    private static final String TAG = "GmsWearNotifBridge";
+
+    @Override
+    public void onNotificationPosted(StatusBarNotification sbn) {
+        if (sbn == null || shouldSkip(sbn)) {
+            return;
+        }
+        WearableImpl wearable = wearable();
+        if (wearable == null) {
+            return;
+        }
+        Notification notification = sbn.getNotification();
+        Bundle extras = notification.extras;
+        String title = extras != null ? extras.getString(Notification.EXTRA_TITLE, "") : "";
+        CharSequence textCs = extras != null ? extras.getCharSequence(Notification.EXTRA_TEXT) : null;
+        String text = textCs != null ? textCs.toString() : "";
+        List<String> actions = new ArrayList<String>();
+        if (notification.actions != null) {
+            for (Notification.Action action : notification.actions) {
+                if (action.title != null) {
+                    actions.add(action.title.toString());
+                }
+            }
+        }
+        NotificationPayload payload = new NotificationPayload(
+                sbn.getKey(),
+                sbn.getPackageName(),
+                sbn.getId(),
+                title,
+                text,
+                notification.category,
+                notification.priority,
+                (notification.flags & Notification.FLAG_ONGOING_EVENT) != 0,
+                actions);
+        broadcast(wearable, NotificationPayload.PATH_POSTED, payload.toBytes());
+    }
+
+    @Override
+    public void onNotificationRemoved(StatusBarNotification sbn) {
+        if (sbn == null) {
+            return;
+        }
+        WearableImpl wearable = wearable();
+        if (wearable == null) {
+            return;
+        }
+        broadcast(
+                wearable,
+                NotificationPayload.PATH_REMOVED,
+                NotificationPayload.removedBytes(sbn.getKey(), sbn.getPackageName(), sbn.getId()));
+    }
+
+    private static boolean shouldSkip(StatusBarNotification sbn) {
+        if (sbn.isOngoing()) {
+            return true;
+        }
+        Notification notification = sbn.getNotification();
+        if (notification == null) {
+            return true;
+        }
+        if ((notification.flags & Notification.FLAG_LOCAL_ONLY) != 0) {
+            return true;
+        }
+        // Do not echo microG's own wearable bridge traffic.
+        String pkg = sbn.getPackageName();
+        return pkg != null && pkg.contains("android.gms") && sbn.getTag() != null
+                && sbn.getTag().startsWith("wearable");
+    }
+
+    private WearableImpl wearable() {
+        WearableService service = WearableService.getInstance();
+        return service != null ? service.getWearableImpl() : null;
+    }
+
+    private void broadcast(WearableImpl wearable, String path, byte[] data) {
+        Set<String> nodes = wearable.getAllConnectedNodes();
+        if (nodes.isEmpty()) {
+            return;
+        }
+        String packageName = getPackageName();
+        for (String nodeId : nodes) {
+            int requestId = wearable.sendMessage(packageName, nodeId, path, data);
+            if (requestId < 0) {
+                Log.d(TAG, "Failed to send " + path + " to " + nodeId);
+            }
+        }
+    }
+}

--- a/play-services-wearable/core/src/main/res/values/strings.xml
+++ b/play-services-wearable/core/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2026 microG Project Team
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<resources>
+    <string name="wearable_notification_listener_label">Wear OS notification bridge</string>
+</resources>

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/BluetoothConnectionThreadTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/BluetoothConnectionThreadTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+/**
+ * Verifies Wear OS Bluetooth RFCOMM UUIDs against documented research values
+ * (teccheck/wearos-research). Several bounty PRs used incorrect UUIDs.
+ */
+public class BluetoothConnectionThreadTest {
+
+    @Test
+    public void wearableBtUuidMatchesResearch() {
+        assertEquals(
+                UUID.fromString("5e8945b0-9525-11e3-a5e2-0800200c9a66"),
+                BluetoothConnectionThread.WEARABLE_BT_UUID);
+    }
+
+    @Test
+    public void flowUuidMatchesResearch() {
+        assertEquals(
+                UUID.fromString("fafbdd20-83f0-4389-addf-917ac9dae5b2"),
+                BluetoothConnectionThread.FLOW_UUID);
+    }
+
+    @Test
+    public void flow15UuidMatchesResearch() {
+        assertEquals(
+                UUID.fromString("6a1eafb1-61c0-42a0-8bb0-a336fb1c3f00"),
+                BluetoothConnectionThread.FLOW15_UUID);
+    }
+
+    @Test
+    public void uuidsAreDistinctAndNonNil() {
+        UUID nil = UUID.fromString("00000000-0000-0000-0000-000000000000");
+        assertNotNull(BluetoothConnectionThread.WEARABLE_BT_UUID);
+        assertNotEquals(nil, BluetoothConnectionThread.WEARABLE_BT_UUID);
+        assertNotEquals(BluetoothConnectionThread.WEARABLE_BT_UUID, BluetoothConnectionThread.FLOW_UUID);
+        assertNotEquals(BluetoothConnectionThread.FLOW_UUID, BluetoothConnectionThread.FLOW15_UUID);
+        // Common incorrect values seen in prior PRs
+        assertNotEquals(
+                UUID.fromString("00000003-0000-1000-8000-00805f9b34fb"),
+                BluetoothConnectionThread.WEARABLE_BT_UUID);
+        assertNotEquals(
+                UUID.fromString("a3c87500-8ed3-4bdf-8a39-a01bebede295"),
+                BluetoothConnectionThread.WEARABLE_BT_UUID);
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/bridge/MediaControlCommandTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/bridge/MediaControlCommandTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.bridge;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class MediaControlCommandTest {
+
+    @Test
+    public void parsesNamedActions() {
+        assertEquals(MediaControlCommand.Action.PLAY,
+                MediaControlCommand.parse("/wearable/media/control/play", null).action);
+        assertEquals(MediaControlCommand.Action.PAUSE,
+                MediaControlCommand.parse("/wearable/media/control/pause", null).action);
+        assertEquals(MediaControlCommand.Action.TOGGLE,
+                MediaControlCommand.parse("/wearable/media/control/toggle", null).action);
+        assertEquals(MediaControlCommand.Action.NEXT,
+                MediaControlCommand.parse("/wearable/media/control/next", null).action);
+        assertEquals(MediaControlCommand.Action.PREVIOUS,
+                MediaControlCommand.parse("/wearable/media/control/previous", null).action);
+    }
+
+    @Test
+    public void parsesSeekAndRatePayloads() {
+        byte[] seek = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(12345L).array();
+        MediaControlCommand seekCmd = MediaControlCommand.parse("/wearable/media/control/seek", seek);
+        assertNotNull(seekCmd);
+        assertEquals(MediaControlCommand.Action.SEEK, seekCmd.action);
+        assertEquals(12345L, seekCmd.seekPositionMs);
+
+        byte[] rate = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putFloat(1.5f).array();
+        MediaControlCommand rateCmd = MediaControlCommand.parse("/wearable/media/control/rate", rate);
+        assertNotNull(rateCmd);
+        assertEquals(MediaControlCommand.Action.RATE, rateCmd.action);
+        assertEquals(1.5f, rateCmd.playbackRate, 0.001f);
+    }
+
+    @Test
+    public void rejectsUnknownPaths() {
+        assertFalse(MediaControlCommand.isControlPath("/other"));
+        assertNull(MediaControlCommand.parse("/wearable/media/control/unknown", null));
+        assertNull(MediaControlCommand.parse("/wearable/notification/posted", null));
+    }
+
+    @Test
+    public void controlPathPrefixRecognized() {
+        assertTrue(MediaControlCommand.isControlPath("/wearable/media/control/play"));
+        assertEquals("/wearable/media/state", MediaControlCommand.STATE_PATH);
+    }
+}

--- a/play-services-wearable/core/src/test/java/org/microg/gms/wearable/bridge/NotificationPayloadTest.java
+++ b/play-services-wearable/core/src/test/java/org/microg/gms/wearable/bridge/NotificationPayloadTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable.bridge;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+public class NotificationPayloadTest {
+
+    @Test
+    public void roundTripPreservesFields() {
+        NotificationPayload original = new NotificationPayload(
+                "pkg|0|42",
+                "com.example.mail",
+                42,
+                "Subject\nline2",
+                "Hello=body",
+                "email",
+                1,
+                false,
+                Arrays.asList("Reply", "Archive"));
+
+        NotificationPayload decoded = NotificationPayload.fromBytes(original.toBytes());
+
+        assertEquals(original.key, decoded.key);
+        assertEquals(original.packageName, decoded.packageName);
+        assertEquals(original.id, decoded.id);
+        assertEquals(original.title, decoded.title);
+        assertEquals(original.text, decoded.text);
+        assertEquals(original.category, decoded.category);
+        assertEquals(original.priority, decoded.priority);
+        assertEquals(original.ongoing, decoded.ongoing);
+        assertEquals(original.actions, decoded.actions);
+    }
+
+    @Test
+    public void removedPayloadContainsIdentity() {
+        byte[] bytes = NotificationPayload.removedBytes("key-1", "com.example", 7);
+        Map<String, String> fields = NotificationPayload.decode(bytes);
+        assertEquals("key-1", fields.get("key"));
+        assertEquals("com.example", fields.get("packageName"));
+        assertEquals("7", fields.get("id"));
+    }
+
+    @Test
+    public void emptyActionsRoundTrip() {
+        NotificationPayload payload = new NotificationPayload(
+                "k", "p", 1, "t", "x", "c", 0, false, Collections.<String>emptyList());
+        NotificationPayload decoded = NotificationPayload.fromBytes(payload.toBytes());
+        assertEquals(0, decoded.actions.size());
+        assertFalse(decoded.ongoing);
+    }
+}

--- a/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/DeleteDataItemsResponse.java
+++ b/play-services-wearable/src/main/java/com/google/android/gms/wearable/internal/DeleteDataItemsResponse.java
@@ -24,9 +24,9 @@ public class DeleteDataItemsResponse extends AutoSafeParcelable {
     @SafeParceled(1)
     private int versionCode = 1;
     @SafeParceled(2)
-    private int status;
+    public int status;
     @SafeParceled(3)
-    private int count;
+    public int count;
 
     private DeleteDataItemsResponse() {
     }

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/BaseWearableListener.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/BaseWearableListener.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.microg.gms.wearable;
+
+import android.os.RemoteException;
+
+import com.google.android.gms.common.data.DataHolder;
+import com.google.android.gms.wearable.internal.AmsEntityUpdateParcelable;
+import com.google.android.gms.wearable.internal.AncsNotificationParcelable;
+import com.google.android.gms.wearable.internal.CapabilityInfoParcelable;
+import com.google.android.gms.wearable.internal.ChannelEventParcelable;
+import com.google.android.gms.wearable.internal.IWearableListener;
+import com.google.android.gms.wearable.internal.MessageEventParcelable;
+import com.google.android.gms.wearable.internal.NodeParcelable;
+
+import java.util.List;
+
+/**
+ * No-op {@link IWearableListener} stub for client API wrappers that only care about a subset
+ * of wearable events.
+ */
+public class BaseWearableListener extends IWearableListener.Stub {
+    @Override
+    public void onDataChanged(DataHolder data) throws RemoteException {
+    }
+
+    @Override
+    public void onMessageReceived(MessageEventParcelable messageEvent) throws RemoteException {
+    }
+
+    @Override
+    public void onPeerConnected(NodeParcelable node) throws RemoteException {
+    }
+
+    @Override
+    public void onPeerDisconnected(NodeParcelable node) throws RemoteException {
+    }
+
+    @Override
+    public void onConnectedNodes(List<NodeParcelable> nodes) throws RemoteException {
+    }
+
+    @Override
+    public void onNotificationReceived(AncsNotificationParcelable notification) throws RemoteException {
+    }
+
+    @Override
+    public void onChannelEvent(ChannelEventParcelable channelEvent) throws RemoteException {
+    }
+
+    @Override
+    public void onConnectedCapabilityChanged(CapabilityInfoParcelable capabilityInfo) throws RemoteException {
+    }
+
+    @Override
+    public void onEntityUpdate(AmsEntityUpdateParcelable update) throws RemoteException {
+    }
+}

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/DataApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/DataApiImpl.java
@@ -16,60 +16,270 @@
 
 package org.microg.gms.wearable;
 
+import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
+import com.google.android.gms.common.data.DataHolder;
 import com.google.android.gms.wearable.Asset;
 import com.google.android.gms.wearable.DataApi;
+import com.google.android.gms.wearable.DataEventBuffer;
+import com.google.android.gms.wearable.DataItem;
 import com.google.android.gms.wearable.DataItemAsset;
 import com.google.android.gms.wearable.DataItemBuffer;
+import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.AddListenerRequest;
+import com.google.android.gms.wearable.internal.DeleteDataItemsResponse;
+import com.google.android.gms.wearable.internal.GetDataItemResponse;
+import com.google.android.gms.wearable.internal.GetFdForAssetResponse;
+import com.google.android.gms.wearable.internal.IWearableListener;
 import com.google.android.gms.wearable.internal.PutDataRequest;
+import com.google.android.gms.wearable.internal.PutDataResponse;
+import com.google.android.gms.wearable.internal.RemoveListenerRequest;
+
+import org.microg.gms.common.GmsConnector;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class DataApiImpl implements DataApi {
+    private final Map<DataListener, IWearableListener> listenerWrappers = new ConcurrentHashMap<DataListener, IWearableListener>();
+
     @Override
-    public PendingResult<Status> addListener(GoogleApiClient client, DataListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> addListener(GoogleApiClient client, final DataListener listener) {
+        final IWearableListener wrapper = new DataListenerWrapper(listener);
+        listenerWrappers.put(listener, wrapper);
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().addListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new AddListenerRequest(wrapper, new IntentFilter[0], null));
+            }
+        });
     }
 
     @Override
-    public PendingResult<DeleteDataItemsResult> deleteDataItems(GoogleApiClient client, Uri uri) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DeleteDataItemsResult> deleteDataItems(GoogleApiClient client, final Uri uri) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DeleteDataItemsResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DeleteDataItemsResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().deleteDataItems(new BaseWearableCallbacks() {
+                    @Override
+                    public void onDeleteDataItemsResponse(DeleteDataItemsResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new DeleteDataItemsResultImpl(response));
+                    }
+                }, uri);
+            }
+        });
     }
 
     @Override
-    public PendingResult<DataItemResult> getDataItem(GoogleApiClient client, Uri uri) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DataItemResult> getDataItem(GoogleApiClient client, final Uri uri) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getDataItem(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetDataItemResponse(GetDataItemResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemResultImpl(response));
+                    }
+                }, uri);
+            }
+        });
     }
 
     @Override
     public PendingResult<DataItemBuffer> getDataItems(GoogleApiClient client) {
-        throw new UnsupportedOperationException();
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemBuffer>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemBuffer> resultProvider) throws RemoteException {
+                client.getServiceInterface().getDataItems(new BaseWearableCallbacks() {
+                    @Override
+                    public void onDataItemChanged(DataHolder dataHolder) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemBuffer(dataHolder));
+                    }
+                });
+            }
+        });
     }
 
     @Override
-    public PendingResult<DataItemBuffer> getDataItems(GoogleApiClient client, Uri uri) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DataItemBuffer> getDataItems(GoogleApiClient client, final Uri uri) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemBuffer>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemBuffer> resultProvider) throws RemoteException {
+                client.getServiceInterface().getDataItemsByUri(new BaseWearableCallbacks() {
+                    @Override
+                    public void onDataItemChanged(DataHolder dataHolder) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemBuffer(dataHolder));
+                    }
+                }, uri);
+            }
+        });
     }
 
     @Override
-    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, DataItemAsset asset) {
-        throw new UnsupportedOperationException();
+    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, final DataItemAsset asset) {
+        final Asset assetObj = Asset.createFromRef(asset.getId());
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetFdForAssetResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetFdForAssetResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getFdForAsset(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetFdForAssetResponse(GetFdForAssetResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetFdForAssetResultImpl(response));
+                    }
+                }, assetObj);
+            }
+        });
     }
 
     @Override
-    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, Asset asset) {
-        throw new UnsupportedOperationException();
+    public PendingResult<GetFdForAssetResult> getFdForAsset(GoogleApiClient client, final Asset asset) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetFdForAssetResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetFdForAssetResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getFdForAsset(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetFdForAssetResponse(GetFdForAssetResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetFdForAssetResultImpl(response));
+                    }
+                }, asset);
+            }
+        });
     }
 
     @Override
-    public PendingResult<DataItemResult> putDataItem(GoogleApiClient client, PutDataRequest request) {
-        throw new UnsupportedOperationException();
+    public PendingResult<DataItemResult> putDataItem(GoogleApiClient client, final PutDataRequest request) {
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, DataItemResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<DataItemResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().putData(new BaseWearableCallbacks() {
+                    @Override
+                    public void onPutDataResponse(PutDataResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new DataItemResultImpl(response));
+                    }
+                }, request);
+            }
+        });
     }
 
     @Override
-    public PendingResult<Status> removeListener(GoogleApiClient client, DataListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> removeListener(GoogleApiClient client, final DataListener listener) {
+        final IWearableListener wrapper = listenerWrappers.remove(listener);
+        if (wrapper == null) {
+            return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+                @Override
+                public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                    resultProvider.onResultAvailable(Status.SUCCESS);
+                }
+            });
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().removeListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new RemoveListenerRequest(wrapper));
+            }
+        });
+    }
+
+    public static class DataItemResultImpl implements DataItemResult {
+        private final Status status;
+        private final DataItem dataItem;
+
+        public DataItemResultImpl(GetDataItemResponse response) {
+            this.status = new Status(response.statusCode);
+            this.dataItem = response.dataItem;
+        }
+
+        public DataItemResultImpl(PutDataResponse response) {
+            this.status = new Status(response.statusCode);
+            this.dataItem = response.dataItem;
+        }
+
+        @Override
+        public DataItem getDataItem() {
+            return dataItem;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    public static class DeleteDataItemsResultImpl implements DeleteDataItemsResult {
+        private final Status status;
+        private final int numDeleted;
+
+        public DeleteDataItemsResultImpl(DeleteDataItemsResponse response) {
+            this.status = new Status(response.status);
+            this.numDeleted = response.count;
+        }
+
+        @Override
+        public int getNumDeleted() {
+            return numDeleted;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    public static class GetFdForAssetResultImpl implements GetFdForAssetResult {
+        private final Status status;
+        private final ParcelFileDescriptor pfd;
+
+        public GetFdForAssetResultImpl(GetFdForAssetResponse response) {
+            this.status = new Status(response.statusCode);
+            this.pfd = response.pfd;
+        }
+
+        @Override
+        public ParcelFileDescriptor getFd() {
+            return pfd;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            if (pfd != null) {
+                return new ParcelFileDescriptor.AutoCloseInputStream(pfd);
+            }
+            return null;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    private static class DataListenerWrapper extends BaseWearableListener {
+        private final DataListener listener;
+
+        DataListenerWrapper(DataListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onDataChanged(DataHolder dataHolder) throws RemoteException {
+            listener.onDataChanged(new DataEventBuffer(dataHolder));
+        }
     }
 }

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/MessageApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/MessageApiImpl.java
@@ -16,6 +16,7 @@
 
 package org.microg.gms.wearable;
 
+import android.content.IntentFilter;
 import android.os.RemoteException;
 
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -23,19 +24,59 @@ import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.wearable.MessageApi;
 import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.AddListenerRequest;
+import com.google.android.gms.wearable.internal.IWearableListener;
+import com.google.android.gms.wearable.internal.MessageEventParcelable;
+import com.google.android.gms.wearable.internal.RemoveListenerRequest;
 import com.google.android.gms.wearable.internal.SendMessageResponse;
 
 import org.microg.gms.common.GmsConnector;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class MessageApiImpl implements MessageApi {
+    private final Map<MessageListener, IWearableListener> listenerWrappers = new ConcurrentHashMap<MessageListener, IWearableListener>();
+
     @Override
-    public PendingResult<Status> addListener(GoogleApiClient client, MessageListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> addListener(GoogleApiClient client, final MessageListener listener) {
+        final IWearableListener wrapper = new MessageListenerWrapper(listener);
+        listenerWrappers.put(listener, wrapper);
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().addListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new AddListenerRequest(wrapper, new IntentFilter[0], null));
+            }
+        });
     }
 
     @Override
-    public PendingResult<Status> removeListener(GoogleApiClient client, MessageListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> removeListener(GoogleApiClient client, final MessageListener listener) {
+        final IWearableListener wrapper = listenerWrappers.remove(listener);
+        if (wrapper == null) {
+            return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+                @Override
+                public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                    resultProvider.onResultAvailable(Status.SUCCESS);
+                }
+            });
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().removeListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new RemoveListenerRequest(wrapper));
+            }
+        });
     }
 
     @Override
@@ -68,6 +109,19 @@ public class MessageApiImpl implements MessageApi {
         @Override
         public Status getStatus() {
             return new Status(response.statusCode);
+        }
+    }
+
+    private static class MessageListenerWrapper extends BaseWearableListener {
+        private final MessageListener listener;
+
+        MessageListenerWrapper(MessageListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onMessageReceived(MessageEventParcelable messageEvent) throws RemoteException {
+            listener.onMessageReceived(messageEvent);
         }
     }
 }

--- a/play-services-wearable/src/main/java/org/microg/gms/wearable/NodeApiImpl.java
+++ b/play-services-wearable/src/main/java/org/microg/gms/wearable/NodeApiImpl.java
@@ -16,29 +16,163 @@
 
 package org.microg.gms.wearable;
 
+import android.content.IntentFilter;
+import android.os.RemoteException;
+
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.Status;
+import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.NodeApi;
+import com.google.android.gms.wearable.Wearable;
+import com.google.android.gms.wearable.internal.AddListenerRequest;
+import com.google.android.gms.wearable.internal.GetConnectedNodesResponse;
+import com.google.android.gms.wearable.internal.GetLocalNodeResponse;
+import com.google.android.gms.wearable.internal.IWearableListener;
+import com.google.android.gms.wearable.internal.NodeParcelable;
+import com.google.android.gms.wearable.internal.RemoveListenerRequest;
+
+import org.microg.gms.common.GmsConnector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NodeApiImpl implements NodeApi {
+    private final Map<NodeListener, IWearableListener> listenerWrappers = new ConcurrentHashMap<NodeListener, IWearableListener>();
+
     @Override
-    public PendingResult<Status> addListener(GoogleApiClient client, NodeListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> addListener(GoogleApiClient client, final NodeListener listener) {
+        final IWearableListener wrapper = new NodeListenerWrapper(listener);
+        listenerWrappers.put(listener, wrapper);
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().addListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new AddListenerRequest(wrapper, new IntentFilter[0], null));
+            }
+        });
     }
 
     @Override
     public PendingResult<GetConnectedNodesResult> getConnectedNodes(GoogleApiClient client) {
-        throw new UnsupportedOperationException();
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetConnectedNodesResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetConnectedNodesResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getConnectedNodes(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetConnectedNodesResponse(GetConnectedNodesResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetConnectedNodesResultImpl(response));
+                    }
+                });
+            }
+        });
     }
 
     @Override
     public PendingResult<GetLocalNodeResult> getLocalNode(GoogleApiClient client) {
-        throw new UnsupportedOperationException();
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, GetLocalNodeResult>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<GetLocalNodeResult> resultProvider) throws RemoteException {
+                client.getServiceInterface().getLocalNode(new BaseWearableCallbacks() {
+                    @Override
+                    public void onGetLocalNodeResponse(GetLocalNodeResponse response) throws RemoteException {
+                        resultProvider.onResultAvailable(new GetLocalNodeResultImpl(response));
+                    }
+                });
+            }
+        });
     }
 
     @Override
-    public PendingResult<Status> removeListener(GoogleApiClient client, NodeListener listener) {
-        throw new UnsupportedOperationException();
+    public PendingResult<Status> removeListener(GoogleApiClient client, final NodeListener listener) {
+        final IWearableListener wrapper = listenerWrappers.remove(listener);
+        if (wrapper == null) {
+            return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+                @Override
+                public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                    resultProvider.onResultAvailable(Status.SUCCESS);
+                }
+            });
+        }
+        return GmsConnector.call(client, Wearable.API, new GmsConnector.Callback<WearableClientImpl, Status>() {
+            @Override
+            public void onClientAvailable(WearableClientImpl client, final ResultProvider<Status> resultProvider) throws RemoteException {
+                client.getServiceInterface().removeListener(new BaseWearableCallbacks() {
+                    @Override
+                    public void onStatus(Status status) throws RemoteException {
+                        resultProvider.onResultAvailable(status);
+                    }
+                }, new RemoveListenerRequest(wrapper));
+            }
+        });
+    }
+
+    public static class GetConnectedNodesResultImpl implements GetConnectedNodesResult {
+        private final Status status;
+        private final List<Node> nodes;
+
+        public GetConnectedNodesResultImpl(GetConnectedNodesResponse response) {
+            this.status = new Status(response.statusCode);
+            this.nodes = new ArrayList<Node>();
+            if (response.nodes != null) {
+                for (NodeParcelable node : response.nodes) {
+                    this.nodes.add(node);
+                }
+            }
+        }
+
+        @Override
+        public List<Node> getNodes() {
+            return nodes;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    public static class GetLocalNodeResultImpl implements GetLocalNodeResult {
+        private final Status status;
+        private final Node node;
+
+        public GetLocalNodeResultImpl(GetLocalNodeResponse response) {
+            this.status = new Status(response.statusCode);
+            this.node = response.node;
+        }
+
+        @Override
+        public Node getNode() {
+            return node;
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    private static class NodeListenerWrapper extends BaseWearableListener {
+        private final NodeListener listener;
+
+        NodeListenerWrapper(NodeListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void onPeerConnected(NodeParcelable node) throws RemoteException {
+            listener.onPeerConnected(node);
+        }
+
+        @Override
+        public void onPeerDisconnected(NodeParcelable node) throws RemoteException {
+            listener.onPeerDisconnected(node);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2843

## Summary

This adds foundational Wear OS phone-side support in microG so modern companion apps can pair and use basic watch functionality: notifications, media controls, and Data Layer messaging over Bluetooth.

Closes the long-standing gap discussed in #4 and #2444 by implementing client APIs, a Bluetooth RFCOMM transport, and bridge services instead of returning `UnsupportedOperationException` or immediate `RESULT_CANCELED` from the Wear OS terms flow.

## What changed

### Wear OS terms / pairing unblock
- Updated `TermsOfServiceActivity` to show an accept/decline dialog so companion apps (Galaxy Wearable, Wear OS) are not blocked by an immediate cancel result (#2444).

### Client API implementation
- Implemented `NodeApi`, `DataApi`, and `MessageApi` facades so they delegate to `WearableServiceImpl` instead of throwing.

### Bluetooth RFCOMM transport
- Added `BluetoothConnectionThread` using the length-prefixed protobuf wire format and UUIDs documented in [teccheck/wearos-research](https://github.com/teccheck/wearos-research/blob/main/docs/btcomm.md):
  - `5e8945b0-9525-11e3-a5e2-0800200c9a66` — WearableBt (watch server; phone connects)
  - `fafbdd20-83f0-4389-addf-917ac9dae5b2` — Flow (phone server)
  - `6a1eafb1-61c0-42a0-8bb0-a336fb1c3f00` — Flow15 (phone server)

When a `ConnectionConfiguration` with a Bluetooth MAC is enabled, microG starts a WearableBt client connection and ensures Flow/Flow15 listeners are running. The legacy TCP server on port `5601` remains for emulator use.

### Notification mirroring
- Added `WearableNotificationListenerService` to forward posted/removed notifications to connected peers on `/wearable/notification/{posted,removed}`.

### Media controls
- Added `WearableMediaSessionBridge` for playback state on `/wearable/media/state` and watch commands under `/wearable/media/control/*` (play, pause, toggle, next, previous, seek, rate).

## Testing

```bash
./gradlew :play-services-wearable-core:testDebugUnitTest
```

Unit tests cover:
- RFCOMM UUID selection (rejecting known-wrong values)
- Notification payload encoding
- Media control parsing
- Bluetooth connection thread behavior

## Manual verification notes

- Enable the **Wear OS notification bridge** notification listener in system settings for notification mirroring and media-session access.
- OEM companion pairing wizards (Galaxy Wearable / Wear OS by Google) may still need physical-device verification; stock watch UI can expect additional OEM-specific protocols beyond these Data Layer paths.

## Bounty context

- **Issue:** https://github.com/microg/GmsCore/issues/2843
- **Tracked bounty:** https://www.bountyhub.dev/en/bounty/view/27a47575-ef9f-49d3-9685-c056d6825f9d

## Checklist

- [x] Unit tests added/updated for new wearable bridge code
- [ ] Verified on physical Wear OS device + companion app
- [ ] CI green
